### PR TITLE
Rename apiclient to SDK (after repository rename)

### DIFF
--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-20.04
-    if: github.repository == 'jellyfin/jellyfin-apiclient-java'
+    if: github.repository == 'jellyfin/jellyfin-sdk-kotlin'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-20.04
-    if: github.repository == 'jellyfin/jellyfin-apiclient-java'
+    if: github.repository == 'jellyfin/jellyfin-sdk-kotlin'
     steps:
       - uses: mschilde/auto-label-merge-conflicts@v2.0
         with:

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -1,4 +1,4 @@
-name: Apiclient Publish
+name: SDK Publish
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     environment: release
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.repository == 'jellyfin/jellyfin-apiclient-java' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.repository == 'jellyfin/jellyfin-sdk-kotlin' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
       - name: Run publish task
-        if: github.repository == 'jellyfin/jellyfin-apiclient-java'
+        if: github.repository == 'jellyfin/jellyfin-sdk-kotlin'
         run: ./gradlew --no-daemon --info publish
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -1,4 +1,4 @@
-name: Apiclient Test
+name: SDK Test
 
 on:
   push:

--- a/buildSrc/src/main/kotlin/Pom.kt
+++ b/buildSrc/src/main/kotlin/Pom.kt
@@ -2,13 +2,13 @@ import org.gradle.api.publish.maven.MavenPublication
 
 fun MavenPublication.defaultPom() = pom {
 	name.set("${groupId}:${artifactId}")
-	description.set("Kotlin API Client for Jellyfin")
-	url.set("https://github.com/jellyfin/jellyfin-apiclient-java")
+	description.set("Jellyfin Kotlin SDK")
+	url.set("https://github.com/jellyfin/jellyfin-sdk-kotlin")
 
 	scm {
-		connection.set("scm:git:git://github.com/jellyfin/jellyfin-apiclient-java.git")
-		developerConnection.set("scm:git:ssh://github.com:jellyfin/jellyfin-apiclient-java.git")
-		url.set("https://github.com/jellyfin/jellyfin-apiclient-java/tree/master")
+		connection.set("scm:git:git://github.com/jellyfin/jellyfin-sdk-kotlin.git")
+		developerConnection.set("scm:git:ssh://github.com:jellyfin/jellyfin-sdk-kotlin.git")
+		url.set("https://github.com/jellyfin/jellyfin-sdk-kotlin/tree/master")
 	}
 
 	licenses {


### PR DESCRIPTION
Depends on #196 and #193. This renames the GitHub workflows and pom configuration.
Merge **after** renaming the repository.