### PR TITLE
Fix missing pom in android module

### DIFF
--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -56,6 +56,8 @@ afterEvaluate {
 		from(components["release"])
 
 		artifact(tasks["sourcesArtifact"])
+
+		defaultPom()
 	}
 }
 


### PR DESCRIPTION
The Android publication is created after evaluation because it depends on some things generated by the android plugin. The `defaultPom()` that is added in the main build file is therefor not added.

Fixed it by adding it manually to the Android module.

Tested by running `gradlew publishToMavenLocal` and verifying the generated files.

Partial fix for https://github.com/jellyfin/jellyfin-sdk-kotlin/issues/176#issuecomment-805068411