### PR TITLE
Publish javadoc using Dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 	id("io.gitlab.arturbosch.detekt").version(Dependencies.detektVersion)
+	id("org.jetbrains.dokka") version "1.4.30"
 }
 
 // Versioning
@@ -32,6 +33,7 @@ subprojects {
 	apply<SigningPlugin>()
 	apply<MavenPublishPlugin>()
 	apply<io.gitlab.arturbosch.detekt.DetektPlugin>()
+	apply<org.jetbrains.dokka.gradle.DokkaPlugin>()
 
 	// Add dependency repositories
 	repositories.defaultRepositories()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-	id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
+	id("io.github.gradle-nexus.publish-plugin").version(Dependencies.nexusPublishPluginVersion)
 	id("io.gitlab.arturbosch.detekt").version(Dependencies.detektVersion)
-	id("org.jetbrains.dokka") version "1.4.30"
+	id("org.jetbrains.dokka").version(Dependencies.dokkaVersion)
 }
 
 // Versioning

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -73,7 +73,11 @@ object Dependencies {
 	const val kotlinPoet = "com.squareup:kotlinpoet:1.7.2"
 	const val kasechange = "net.pearx.kasechange:kasechange:1.3.0"
 	const val clikt = "com.github.ajalt.clikt:clikt:3.0.1"
+
+	// Gradle plugins
 	const val detektVersion = "1.14.2"
+	const val nexusPublishPluginVersion = "1.0.0"
+	const val dokkaVersion = "1.4.30"
 }
 
 /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 kotlin.incremental=true
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -30,8 +30,15 @@ val sourcesJar by tasks.creating(Jar::class) {
 	from(sourceSets.getByName("main").allSource)
 }
 
+val javadocJar by tasks.creating(Jar::class) {
+	dependsOn(tasks.getByName("dokkaJavadoc"))
+	archiveClassifier.set("javadoc")
+	from("$buildDir/dokka/javadoc")
+}
+
 publishing.publications.create<MavenPublication>("default") {
 	from(components["kotlin"])
 
 	artifact(sourcesJar)
+	artifact(javadocJar)
 }

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
 	id("kotlin")
 }
 
-kotlin {
-	explicitApi()
-}
-
 dependencies {
 	apiProject(":jellyfin-api")
 	apiProject(":jellyfin-model")
@@ -23,14 +19,25 @@ dependencies {
 	testImplementation(Dependencies.Kotlin.Test.junit)
 }
 
+kotlin {
+	explicitApi()
+}
+
 val sourcesJar by tasks.creating(Jar::class) {
 	archiveClassifier.set("sources")
 
 	from(sourceSets.getByName("main").allSource)
 }
 
+val javadocJar by tasks.creating(Jar::class) {
+	dependsOn(tasks.getByName("dokkaJavadoc"))
+	archiveClassifier.set("javadoc")
+	from("$buildDir/dokka/javadoc")
+}
+
 publishing.publications.create<MavenPublication>("default") {
 	from(components["kotlin"])
 
 	artifact(sourcesJar)
+	artifact(javadocJar)
 }

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -23,8 +23,15 @@ val sourcesJar by tasks.creating(Jar::class) {
 	from(sourceSets.getByName("main").allSource)
 }
 
+val javadocJar by tasks.creating(Jar::class) {
+	dependsOn(tasks.getByName("dokkaJavadoc"))
+	archiveClassifier.set("javadoc")
+	from("$buildDir/dokka/javadoc")
+}
+
 publishing.publications.create<MavenPublication>("default") {
 	from(components["kotlin"])
 
 	artifact(sourcesJar)
+	artifact(javadocJar)
 }

--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -49,6 +49,12 @@ tasks.create<Jar>("sourcesArtifact") {
 	from(android.sourceSets["main"].java.srcDirs)
 }
 
+val javadocJar by tasks.creating(Jar::class) {
+	dependsOn(tasks.getByName("dokkaJavadoc"))
+	archiveClassifier.set("javadoc")
+	from("$buildDir/dokka/javadoc")
+}
+
 // Because of limitations in the android plugin
 // the publishing definition should be inside the "afterEvaluate" block
 afterEvaluate {
@@ -56,6 +62,7 @@ afterEvaluate {
 		from(components["release"])
 
 		artifact(tasks["sourcesArtifact"])
+		artifact(tasks["javadocJar"])
 
 		defaultPom()
 	}


### PR DESCRIPTION
The Dokka plugin will generate javadoc files and those are added to the publications. Unfortunately Dokka loves memory so I had to increase it in the gradle.properties.

Partial fix for https://github.com/jellyfin/jellyfin-sdk-kotlin/issues/176#issuecomment-805068411