### PR TITLE
Automatically release on Sonatype

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -24,7 +24,7 @@ jobs:
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
       - name: Run publish task
         if: github.repository == 'jellyfin/jellyfin-sdk-kotlin'
-        run: ./gradlew --no-daemon --info publish
+        run: ./gradlew --no-daemon --info publish closeAndReleaseSonatypeStagingRepository
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
This PR adds the `closeAndReleaseSonatypeStagingRepository` task to the publishing script. This wil automatically close&release the staging repository so releases will be 100% automatic. I didn't add it previously so I could verify the staging repository for the validation process.

I'm not sure what happens if we call the task from snapshot builds as the documentation is not clear about it. I'll assume it just works and otherwise make another PR.

Closes #176 