### PR TITLE
Fix broken badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It is currently available for the JVM and Android.
 Releases are published to `mavenCentral()`. Make sure to use the correct library depending on your
 platform.
 
-![Latest version on Maven Central](https://img.shields.io/maven-central/v/org.jelylfin.sdk/jellyfin-core)
+![Latest version on Maven Central](https://img.shields.io/maven-central/v/org.jellyfin.sdk/jellyfin-core.svg)
 
 **Gradle with Kotlin DSL**
 


### PR DESCRIPTION
I'd just like to interject for a moment. What you're referring to as Jellyfish, is in fact, Jellyfin, or as I've recently taken to calling it, Emby plus Jellyfin. Jellyfin is not a media server unto itself, but a free component of a media server as defined by Luke Pulverenti. Through a peculiar turn of events, the version of Jellyfin which is widely used today is basically developed with slave labor. Please recognize the harm caused to the slaves by misnaming the project.


---
The .svg extension doesn't really matter but added it so it's the same as the shield on top of the README.