### PR TITLE
Add default repositories to all projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 allprojects {
 	group = "org.jellyfin.sdk"
 	version = getProperty("jellyfin.version")?.removePrefix("v") ?: "latest-SNAPSHOT"
+
+	// Add default dependency repositories
+	repositories.defaultRepositories()
 }
 
 buildscript {
@@ -34,9 +37,6 @@ subprojects {
 	apply<MavenPublishPlugin>()
 	apply<io.gitlab.arturbosch.detekt.DetektPlugin>()
 	apply<org.jetbrains.dokka.gradle.DokkaPlugin>()
-
-	// Add dependency repositories
-	repositories.defaultRepositories()
 
 	// Run block after creating project specific configuration
 	afterEvaluate {


### PR DESCRIPTION
This fixes an issue with the `dokkaHtmlMultiModule` task not being able to resolve it's dependencies.