### PR TITLE
Add binary compatibility validation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ openapi.json filter=lfs diff=lfs merge=lfs -text linguist-vendored
 
 # Generated sources
 kotlin-generated/* linguist-generated
+api/*.api linguist-generated

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -33,3 +33,24 @@ jobs:
             ${{ runner.os }}-java-
       - name: Run test task
         run: ./gradlew --build-cache --no-daemon --info test
+
+  validate-binary-compatibility:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Setup Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run apiCheck task
+        run: ./gradlew --build-cache --no-daemon --info apiCheck

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
 	id("io.github.gradle-nexus.publish-plugin").version(Dependencies.nexusPublishPluginVersion)
 	id("io.gitlab.arturbosch.detekt").version(Dependencies.detektVersion)
 	id("org.jetbrains.dokka").version(Dependencies.dokkaVersion)
+	id("org.jetbrains.kotlinx.binary-compatibility-validator").version(Dependencies.KotlinX.binaryCompatibilityValidatorVersion)
 }
 
 // Versioning
@@ -26,6 +27,11 @@ nexusPublishing.repositories.sonatype {
 
 	username.set(getProperty("ossrh.username"))
 	password.set(getProperty("ossrh.password"))
+}
+
+apiValidation {
+	// Ignore generator / samples / other non jellyfin-x modules
+	ignoredProjects.addAll(subprojects.map { it.name }.filter { !it.startsWith("jellyfin-") })
 }
 
 subprojects {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -28,6 +28,7 @@ object Dependencies {
 
 		val coroutinesCore = item("coroutines-core", "1.4.2")
 		val serializationJson = item("serialization-json", "1.0.1")
+		const val binaryCompatibilityValidatorVersion = "0.5.0"
 	}
 
 	object Android {

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1,0 +1,985 @@
+public abstract interface class org/jellyfin/sdk/api/client/ApiClient {
+	public abstract fun createAuthorizationHeader ()Ljava/lang/String;
+	public abstract fun createPath (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
+	public abstract fun createUrl (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Z)Ljava/lang/String;
+	public abstract fun getAccessToken ()Ljava/lang/String;
+	public abstract fun getBaseUrl ()Ljava/lang/String;
+	public abstract fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
+	public abstract fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public abstract fun setAccessToken (Ljava/lang/String;)V
+	public abstract fun setBaseUrl (Ljava/lang/String;)V
+	public abstract fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
+	public abstract fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+}
+
+public final class org/jellyfin/sdk/api/client/ApiClient$DefaultImpls {
+	public static synthetic fun createPath$default (Lorg/jellyfin/sdk/api/client/ApiClient;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun createUrl$default (Lorg/jellyfin/sdk/api/client/ApiClient;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ZILjava/lang/Object;)Ljava/lang/String;
+}
+
+public class org/jellyfin/sdk/api/client/KtorClient : org/jellyfin/sdk/api/client/ApiClient {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun createAuthorizationHeader ()Ljava/lang/String;
+	public fun createPath (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
+	public fun createUrl (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Z)Ljava/lang/String;
+	public fun getAccessToken ()Ljava/lang/String;
+	public fun getBaseUrl ()Ljava/lang/String;
+	public final fun getClient ()Lio/ktor/client/HttpClient;
+	public fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
+	public fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public fun setAccessToken (Ljava/lang/String;)V
+	public fun setBaseUrl (Ljava/lang/String;)V
+	public fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
+	public fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+}
+
+public final class org/jellyfin/sdk/api/client/MissingPathVariableError : java/lang/Error {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/api/client/Response {
+	public fun <init> (Ljava/lang/Object;ILjava/util/Map;)V
+	public final fun getContent ()Ljava/lang/Object;
+	public final fun getHeader (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getHeaders (Ljava/lang/String;)Ljava/util/List;
+	public final fun getStatus ()I
+	public final synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+}
+
+public abstract class org/jellyfin/sdk/api/client/compatibility/JavaCallback : kotlin/coroutines/Continuation {
+	public fun <init> ()V
+	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun onResponse (Lorg/jellyfin/sdk/api/client/Response;)V
+	public fun resumeWith (Ljava/lang/Object;)V
+}
+
+public abstract class org/jellyfin/sdk/api/client/compatibility/JavaDataCallback : kotlin/coroutines/Continuation {
+	public fun <init> ()V
+	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun onData (Ljava/lang/Object;)V
+	public fun resumeWith (Ljava/lang/Object;)V
+}
+
+public final class org/jellyfin/sdk/api/client/extensions/UserApiExtensionsKt {
+	public static final fun authenticateUserByName (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/info/ApiConstants {
+	public static final field INSTANCE Lorg/jellyfin/sdk/api/info/ApiConstants;
+	public static final field apiVersion Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/api/operations/ActivityLogApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getLogEntries (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLogEntries$default (Lorg/jellyfin/sdk/api/operations/ActivityLogApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ApiKeyApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun createKey (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getKeys (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun revokeKey (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ArtistsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getAlbumArtists (Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAlbumArtists$default (Lorg/jellyfin/sdk/api/operations/ArtistsApi;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getArtistByName (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getArtistByName$default (Lorg/jellyfin/sdk/api/operations/ArtistsApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getArtists (Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getArtists$default (Lorg/jellyfin/sdk/api/operations/ArtistsApi;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/AudioApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getAudioStream (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAudioStream$default (Lorg/jellyfin/sdk/api/operations/AudioApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getAudioStreamByContainer (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAudioStreamByContainer$default (Lorg/jellyfin/sdk/api/operations/AudioApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getAudioStreamByContainerUrl (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getAudioStreamByContainerUrl$default (Lorg/jellyfin/sdk/api/operations/AudioApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun getAudioStreamUrl (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getAudioStreamUrl$default (Lorg/jellyfin/sdk/api/operations/AudioApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/api/operations/BrandingApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getBrandingCss (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getBrandingCss2 (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getBrandingOptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ChannelsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getAllChannelFeatures (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getChannelFeatures (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getChannelItems (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getChannelItems$default (Lorg/jellyfin/sdk/api/operations/ChannelsApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getChannels (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getChannels$default (Lorg/jellyfin/sdk/api/operations/ChannelsApi;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLatestChannelItems (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLatestChannelItems$default (Lorg/jellyfin/sdk/api/operations/ChannelsApi;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/CollectionApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun addToCollection (Ljava/util/UUID;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addToCollection$default (Lorg/jellyfin/sdk/api/operations/CollectionApi;Ljava/util/UUID;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createCollection (Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createCollection$default (Lorg/jellyfin/sdk/api/operations/CollectionApi;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun removeFromCollection (Ljava/util/UUID;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun removeFromCollection$default (Lorg/jellyfin/sdk/api/operations/CollectionApi;Ljava/util/UUID;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ConfigurationApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getConfiguration (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDefaultMetadataOptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getNamedConfiguration (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getNamedConfigurationUrl (Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getNamedConfigurationUrl$default (Lorg/jellyfin/sdk/api/operations/ConfigurationApi;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun updateConfiguration (Lorg/jellyfin/sdk/model/api/ServerConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateMediaEncoderPath (Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateNamedConfiguration (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/DashboardApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getConfigurationPages (Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getConfigurationPages$default (Lorg/jellyfin/sdk/api/operations/DashboardApi;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getDashboardConfigurationPage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getDashboardConfigurationPage$default (Lorg/jellyfin/sdk/api/operations/DashboardApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/DevicesApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun deleteDevice (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDeviceInfo (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDeviceOptions (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDevices (Ljava/lang/Boolean;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getDevices$default (Lorg/jellyfin/sdk/api/operations/DevicesApi;Ljava/lang/Boolean;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateDeviceOptions (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/DisplayPreferencesApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getDisplayPreferences (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateDisplayPreferences (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/DlnaApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun createProfile (Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createProfile$default (Lorg/jellyfin/sdk/api/operations/DlnaApi;Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteProfile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDefaultProfile (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getProfile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getProfileInfos (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateProfile (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateProfile$default (Lorg/jellyfin/sdk/api/operations/DlnaApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/DlnaServerApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getConnectionManager (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getConnectionManager2 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getConnectionManager3 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getContentDirectory (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getContentDirectory2 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getContentDirectory3 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDescriptionXml (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDescriptionXml2 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getIcon (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getIconId (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getIconIdUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getIconIdUrl$default (Lorg/jellyfin/sdk/api/operations/DlnaServerApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getIconUrl (Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getIconUrl$default (Lorg/jellyfin/sdk/api/operations/DlnaServerApi;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getMediaReceiverRegistrar (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMediaReceiverRegistrar2 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMediaReceiverRegistrar3 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun processConnectionManagerControlRequest (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun processContentDirectoryControlRequest (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun processMediaReceiverRegistrarControlRequest (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/DynamicHlsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getHlsAudioSegment (Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getHlsAudioSegment$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getHlsAudioSegmentUrl (Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getHlsAudioSegmentUrl$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun getHlsVideoSegment (Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getHlsVideoSegment$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getHlsVideoSegmentUrl (Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getHlsVideoSegmentUrl$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun getMasterHlsAudioPlaylist (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMasterHlsAudioPlaylist$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZLkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMasterHlsAudioPlaylistUrl (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZZ)Ljava/lang/String;
+	public static synthetic fun getMasterHlsAudioPlaylistUrl$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun getMasterHlsVideoPlaylist (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMasterHlsVideoPlaylist$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZLkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMasterHlsVideoPlaylistUrl (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZZ)Ljava/lang/String;
+	public static synthetic fun getMasterHlsVideoPlaylistUrl$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun getVariantHlsAudioPlaylist (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getVariantHlsAudioPlaylist$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getVariantHlsAudioPlaylistUrl (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getVariantHlsAudioPlaylistUrl$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun getVariantHlsVideoPlaylist (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getVariantHlsVideoPlaylist$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getVariantHlsVideoPlaylistUrl (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getVariantHlsVideoPlaylistUrl$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/api/operations/EnvironmentApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getDefaultDirectoryBrowser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDirectoryContents (Ljava/lang/String;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getDirectoryContents$default (Lorg/jellyfin/sdk/api/operations/EnvironmentApi;Ljava/lang/String;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getDrives (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getNetworkShares (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getParentPath (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun validatePath (Lorg/jellyfin/sdk/model/api/ValidatePathDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/FilterApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getQueryFilters (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getQueryFilters$default (Lorg/jellyfin/sdk/api/operations/FilterApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getQueryFiltersLegacy (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getQueryFiltersLegacy$default (Lorg/jellyfin/sdk/api/operations/FilterApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/GenresApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getGenre (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGenre$default (Lorg/jellyfin/sdk/api/operations/GenresApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGenres (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGenres$default (Lorg/jellyfin/sdk/api/operations/GenresApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/HlsSegmentApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getHlsAudioSegmentLegacyAac (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getHlsAudioSegmentLegacyAacUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getHlsAudioSegmentLegacyAacUrl$default (Lorg/jellyfin/sdk/api/operations/HlsSegmentApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getHlsAudioSegmentLegacyMp3 (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getHlsAudioSegmentLegacyMp3Url (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getHlsAudioSegmentLegacyMp3Url$default (Lorg/jellyfin/sdk/api/operations/HlsSegmentApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getHlsPlaylistLegacy (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getHlsPlaylistLegacyUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getHlsPlaylistLegacyUrl$default (Lorg/jellyfin/sdk/api/operations/HlsSegmentApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getHlsVideoSegmentLegacy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getHlsVideoSegmentLegacyUrl (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getHlsVideoSegmentLegacyUrl$default (Lorg/jellyfin/sdk/api/operations/HlsSegmentApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun stopEncodingProcess (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ImageApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun deleteItemImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteItemImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteItemImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteUserImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteUserImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteUserImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getArtistImage (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getArtistImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getArtistImageUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getArtistImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getGenreImage (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGenreImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGenreImageByIndex (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGenreImageByIndex$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGenreImageByIndexUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getGenreImageByIndexUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getGenreImageUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)Ljava/lang/String;
+	public static synthetic fun getGenreImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getItemImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getItemImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getItemImage2 (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;IILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;DIILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getItemImage2$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;IILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;DIILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getItemImage2Url (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;IILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;DIILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getItemImage2Url$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;IILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;DIILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getItemImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getItemImageByIndex$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getItemImageByIndexUrl (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getItemImageByIndexUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getItemImageInfos (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getItemImageUrl (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)Ljava/lang/String;
+	public static synthetic fun getItemImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getMusicGenreImage (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMusicGenreImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMusicGenreImageByIndex (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMusicGenreImageByIndex$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMusicGenreImageByIndexUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getMusicGenreImageByIndexUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getMusicGenreImageUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)Ljava/lang/String;
+	public static synthetic fun getMusicGenreImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getPersonImage (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPersonImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPersonImageByIndex (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPersonImageByIndex$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPersonImageByIndexUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getPersonImageByIndexUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getPersonImageUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)Ljava/lang/String;
+	public static synthetic fun getPersonImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getStudioImage (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStudioImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStudioImageByIndex (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStudioImageByIndex$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStudioImageByIndexUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getStudioImageByIndexUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getStudioImageUrl (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)Ljava/lang/String;
+	public static synthetic fun getStudioImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getUserImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUserImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getUserImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUserImageByIndex$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getUserImageByIndexUrl (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getUserImageByIndexUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILjava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getUserImageUrl (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Z)Ljava/lang/String;
+	public static synthetic fun getUserImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun postUserImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postUserImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun postUserImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setItemImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setItemImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateItemImageIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ImageByNameApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getGeneralImage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGeneralImageUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getGeneralImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageByNameApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getGeneralImages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMediaInfoImage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMediaInfoImageUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getMediaInfoImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageByNameApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getMediaInfoImages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRatingImage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRatingImageUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getRatingImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageByNameApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getRatingImages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/InstantMixApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getInstantMixFromAlbum (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromAlbum$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromArtists (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromArtists$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromArtists2 (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromArtists2$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromItem (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromItem$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromMusicGenreById (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromMusicGenreById$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromMusicGenreById2 (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromMusicGenreById2$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromMusicGenreByName (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromMusicGenreByName$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromPlaylist (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromPlaylist$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInstantMixFromSong (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInstantMixFromSong$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ItemLookupApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun applySearchCriteria (Ljava/util/UUID;ZLorg/jellyfin/sdk/model/api/RemoteSearchResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun applySearchCriteria$default (Lorg/jellyfin/sdk/api/operations/ItemLookupApi;Ljava/util/UUID;ZLorg/jellyfin/sdk/model/api/RemoteSearchResult;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getBookRemoteSearchResults (Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getBoxSetRemoteSearchResults (Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getExternalIdInfos (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMovieRemoteSearchResults (Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMusicAlbumRemoteSearchResults (Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMusicArtistRemoteSearchResults (Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMusicVideoRemoteSearchResults (Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPersonRemoteSearchResults (Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRemoteSearchImage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRemoteSearchImageUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getRemoteSearchImageUrl$default (Lorg/jellyfin/sdk/api/operations/ItemLookupApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getSeriesRemoteSearchResults (Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getTrailerRemoteSearchResults (Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ItemRefreshApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun post (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun post$default (Lorg/jellyfin/sdk/api/operations/ItemRefreshApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ItemUpdateApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getMetadataEditorInfo (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateItem (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateItemContentType (Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateItemContentType$default (Lorg/jellyfin/sdk/api/operations/ItemUpdateApi;Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ItemsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getItems (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getItems$default (Lorg/jellyfin/sdk/api/operations/ItemsApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;IIILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getItemsByUserId (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getItemsByUserId$default (Lorg/jellyfin/sdk/api/operations/ItemsApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;IIILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getResumeItems (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getResumeItems$default (Lorg/jellyfin/sdk/api/operations/ItemsApi;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/LibraryApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun deleteItem (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteItems (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteItems$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getAncestors (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAncestors$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getCriticReviews (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDownload (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDownloadUrl (Ljava/util/UUID;Z)Ljava/lang/String;
+	public static synthetic fun getDownloadUrl$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getFile (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFileUrl (Ljava/util/UUID;Z)Ljava/lang/String;
+	public static synthetic fun getFileUrl$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getItemCounts (Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getItemCounts$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLibraryOptionsInfo (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLibraryOptionsInfo$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMediaFolders (Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMediaFolders$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPhysicalPaths (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSimilarAlbums (Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSimilarAlbums$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSimilarArtists (Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSimilarArtists$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSimilarItems (Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSimilarItems$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSimilarMovies (Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSimilarMovies$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSimilarShows (Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSimilarShows$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSimilarTrailers (Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSimilarTrailers$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getThemeMedia (Ljava/util/UUID;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getThemeMedia$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getThemeSongs (Ljava/util/UUID;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getThemeSongs$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getThemeVideos (Ljava/util/UUID;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getThemeVideos$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/UUID;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun postAddedMovies (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postAddedMovies$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun postAddedSeries (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postAddedSeries$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun postUpdatedMedia (Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun postUpdatedMovies (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postUpdatedMovies$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun postUpdatedSeries (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postUpdatedSeries$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun refreshLibrary (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/LibraryStructureApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun addMediaPath (ZLorg/jellyfin/sdk/model/api/MediaPathDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addMediaPath$default (Lorg/jellyfin/sdk/api/operations/LibraryStructureApi;ZLorg/jellyfin/sdk/model/api/MediaPathDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun addVirtualFolder (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/AddVirtualFolderDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addVirtualFolder$default (Lorg/jellyfin/sdk/api/operations/LibraryStructureApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/AddVirtualFolderDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getVirtualFolders (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun removeMediaPath (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun removeMediaPath$default (Lorg/jellyfin/sdk/api/operations/LibraryStructureApi;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun removeVirtualFolder (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun removeVirtualFolder$default (Lorg/jellyfin/sdk/api/operations/LibraryStructureApi;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun renameVirtualFolder (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun renameVirtualFolder$default (Lorg/jellyfin/sdk/api/operations/LibraryStructureApi;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateLibraryOptions (Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateLibraryOptions$default (Lorg/jellyfin/sdk/api/operations/LibraryStructureApi;Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateMediaPath (Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/LiveTvApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun addListingProvider (Ljava/lang/String;ZZLorg/jellyfin/sdk/model/api/ListingsProviderInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addListingProvider$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;ZZLorg/jellyfin/sdk/model/api/ListingsProviderInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun addTunerHost (Lorg/jellyfin/sdk/model/api/TunerHostInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addTunerHost$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Lorg/jellyfin/sdk/model/api/TunerHostInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun cancelSeriesTimer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun cancelTimer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createSeriesTimer (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createSeriesTimer$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createTimer (Lorg/jellyfin/sdk/model/api/TimerInfoDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createTimer$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Lorg/jellyfin/sdk/model/api/TimerInfoDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteListingProvider (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteListingProvider$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteRecording (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteTunerHost (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteTunerHost$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun discoverTuners (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun discoverTuners$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun discvoverTuners (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun discvoverTuners$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getChannel (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getChannel$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getChannelMappingOptions (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getChannelMappingOptions$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getDefaultListingProvider (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDefaultTimer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getDefaultTimer$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuideInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLineups (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLineups$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLiveRecordingFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLiveRecordingFileUrl (Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getLiveRecordingFileUrl$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getLiveStreamFile (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLiveStreamFileUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getLiveStreamFileUrl$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getLiveTvChannels (Lorg/jellyfin/sdk/model/api/ChannelType;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/jellyfin/sdk/model/api/SortOrder;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLiveTvChannels$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Lorg/jellyfin/sdk/model/api/ChannelType;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/jellyfin/sdk/model/api/SortOrder;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLiveTvInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLiveTvPrograms (Ljava/util/List;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLiveTvPrograms$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/util/List;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getProgram (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getProgram$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPrograms (Lorg/jellyfin/sdk/model/api/GetProgramsDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPrograms$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Lorg/jellyfin/sdk/model/api/GetProgramsDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecommendedPrograms (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedPrograms$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecording (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecording$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecordingFolders (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecordingFolders$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecordingGroup (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecordingGroups (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecordingGroups$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecordings (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecordings$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecordingsSeries (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecordingsSeries$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSchedulesDirectCountries (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSchedulesDirectCountriesUrl (Z)Ljava/lang/String;
+	public static synthetic fun getSchedulesDirectCountriesUrl$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getSeriesTimer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSeriesTimers (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SortOrder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSeriesTimers$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SortOrder;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getTimer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getTimers (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getTimers$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getTunerHostTypes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resetTuner (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setChannelMapping (Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateSeriesTimer (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateSeriesTimer$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateTimer (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TimerInfoDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateTimer$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TimerInfoDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/LocalizationApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getCountries (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getCultures (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLocalizationOptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getParentalRatings (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/MediaInfoApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun closeLiveStream (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getBitrateTestBytes (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getBitrateTestBytes$default (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getBitrateTestBytesUrl (IZ)Ljava/lang/String;
+	public static synthetic fun getBitrateTestBytesUrl$default (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;IZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getPlaybackInfo (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPostedPlaybackInfo (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPostedPlaybackInfo$default (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPostedPlaybackInfoDeprecated (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPostedPlaybackInfoDeprecated$default (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun openLiveStream (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun openLiveStream$default (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/MoviesApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getMovieRecommendations (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMovieRecommendations$default (Lorg/jellyfin/sdk/api/operations/MoviesApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/MusicGenresApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getMusicGenre (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMusicGenre$default (Lorg/jellyfin/sdk/api/operations/MusicGenresApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMusicGenres (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMusicGenres$default (Lorg/jellyfin/sdk/api/operations/MusicGenresApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/NotificationsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun createAdminNotification (Lorg/jellyfin/sdk/model/api/AdminNotificationDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getNotificationServices (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getNotificationTypes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getNotifications (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getNotificationsSummary (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setRead (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setUnread (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/PackageApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun cancelPackageInstallation (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPackageInfo (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPackageInfo$default (Lorg/jellyfin/sdk/api/operations/PackageApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPackages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRepositories (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun installPackage (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun installPackage$default (Lorg/jellyfin/sdk/api/operations/PackageApi;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setRepositories (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/PersonsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getPerson (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPerson$default (Lorg/jellyfin/sdk/api/operations/PersonsApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPersons (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPersons$default (Lorg/jellyfin/sdk/api/operations/PersonsApi;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/PlayStateApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun markPlayedItem (Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun markPlayedItem$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun markUnplayedItem (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun onPlaybackProgress (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onPlaybackProgress$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun onPlaybackStart (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onPlaybackStart$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun onPlaybackStopped (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onPlaybackStopped$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun pingPlaybackSession (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reportPlaybackProgress (Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun reportPlaybackProgress$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun reportPlaybackStart (Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun reportPlaybackStart$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun reportPlaybackStopped (Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun reportPlaybackStopped$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/PlaylistsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun addToPlaylist (Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addToPlaylist$default (Lorg/jellyfin/sdk/api/operations/PlaylistsApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createPlaylist (Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createPlaylist$default (Lorg/jellyfin/sdk/api/operations/PlaylistsApi;Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createPlaylistDeprecated (Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createPlaylistDeprecated$default (Lorg/jellyfin/sdk/api/operations/PlaylistsApi;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPlaylistItems (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPlaylistItems$default (Lorg/jellyfin/sdk/api/operations/PlaylistsApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun moveItem (Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun removeFromPlaylist (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun removeFromPlaylist$default (Lorg/jellyfin/sdk/api/operations/PlaylistsApi;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/PluginsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun disablePlugin (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun enablePlugin (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPluginConfiguration (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPluginImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPluginImageUrl (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Z)Ljava/lang/String;
+	public static synthetic fun getPluginImageUrl$default (Lorg/jellyfin/sdk/api/operations/PluginsApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getPluginManifest (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPlugins (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun uninstallPlugin (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun uninstallPluginByVersion (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updatePluginConfiguration (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updatePluginSecurityInfo (Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/QuickConnectApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun activate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun authorize (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun available (Lorg/jellyfin/sdk/model/api/QuickConnectState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun connect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deauthorize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getStatus (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun initiate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/RemoteImageApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun downloadRemoteImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun downloadRemoteImage$default (Lorg/jellyfin/sdk/api/operations/RemoteImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRemoteImage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRemoteImageProviders (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRemoteImageUrl (Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getRemoteImageUrl$default (Lorg/jellyfin/sdk/api/operations/RemoteImageApi;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getRemoteImages (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRemoteImages$default (Lorg/jellyfin/sdk/api/operations/RemoteImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/ScheduledTasksApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getTask (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getTasks (Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getTasks$default (Lorg/jellyfin/sdk/api/operations/ScheduledTasksApi;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun startTask (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun stopTask (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateTask (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/SearchApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun get (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ZZZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun get$default (Lorg/jellyfin/sdk/api/operations/SearchApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ZZZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/SessionApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun addUserToSession (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun displayContent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAuthProviders (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPasswordResetProviders (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSessions (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSessions$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun play (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayCommand;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun play$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayCommand;Ljava/util/List;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun postCapabilities (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postCapabilities$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun postFullCapabilities (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postFullCapabilities$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun removeUserFromSession (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reportSessionEnded (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reportViewing (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun reportViewing$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun sendFullGeneralCommand (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GeneralCommand;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun sendGeneralCommand (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GeneralCommandType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun sendMessageCommand (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun sendMessageCommand$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun sendPlaystateCommand (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlaystateCommand;Ljava/lang/Long;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun sendPlaystateCommand$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlaystateCommand;Ljava/lang/Long;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun sendSystemCommand (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GeneralCommandType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/StartupApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun completeWizard (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFirstUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFirstUser2 (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getStartupConfiguration (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setRemoteAccess (Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateInitialConfiguration (Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateStartupUser (Lorg/jellyfin/sdk/model/api/StartupUserDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateStartupUser$default (Lorg/jellyfin/sdk/api/operations/StartupApi;Lorg/jellyfin/sdk/model/api/StartupUserDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/StudiosApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getStudio (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStudio$default (Lorg/jellyfin/sdk/api/operations/StudiosApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStudios (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStudios$default (Lorg/jellyfin/sdk/api/operations/StudiosApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/SubtitleApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun deleteSubtitle (Ljava/util/UUID;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun downloadRemoteSubtitles (Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFallbackFont (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFallbackFontList (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFallbackFontUrl (Ljava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun getFallbackFontUrl$default (Lorg/jellyfin/sdk/api/operations/SubtitleApi;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getRemoteSubtitles (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSubtitle (Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Long;ZZJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSubtitle$default (Lorg/jellyfin/sdk/api/operations/SubtitleApi;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Long;ZZJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSubtitlePlaylist (Ljava/util/UUID;ILjava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSubtitlePlaylistUrl (Ljava/util/UUID;ILjava/lang/String;IZ)Ljava/lang/String;
+	public static synthetic fun getSubtitlePlaylistUrl$default (Lorg/jellyfin/sdk/api/operations/SubtitleApi;Ljava/util/UUID;ILjava/lang/String;IZILjava/lang/Object;)Ljava/lang/String;
+	public final fun getSubtitleWithTicks (Ljava/util/UUID;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/Long;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSubtitleWithTicks$default (Lorg/jellyfin/sdk/api/operations/SubtitleApi;Ljava/util/UUID;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/Long;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchRemoteSubtitles (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchRemoteSubtitles$default (Lorg/jellyfin/sdk/api/operations/SubtitleApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun uploadSubtitle (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/SuggestionsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getSuggestions (Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSuggestions$default (Lorg/jellyfin/sdk/api/operations/SuggestionsApi;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/SyncPlayApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun syncPlayBuffering (Lorg/jellyfin/sdk/model/api/BufferRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayCreateGroup (Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayGetGroups (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayJoinGroup (Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayLeaveGroup (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayMovePlaylistItem (Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayNextItem (Lorg/jellyfin/sdk/model/api/NextItemRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayPause (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayPing (Lorg/jellyfin/sdk/model/api/PingRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayPreviousItem (Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayQueue (Lorg/jellyfin/sdk/model/api/QueueRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayReady (Lorg/jellyfin/sdk/model/api/ReadyRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayRemoveFromPlaylist (Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlaySeek (Lorg/jellyfin/sdk/model/api/SeekRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlaySetIgnoreWait (Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlaySetNewQueue (Lorg/jellyfin/sdk/model/api/PlayRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlaySetPlaylistItem (Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlaySetRepeatMode (Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlaySetShuffleMode (Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayStop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncPlayUnpause (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/SystemApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getEndpointInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLogFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPingSystem (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPublicSystemInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getServerLogs (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSystemInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getWakeOnLanInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun postPingSystem (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun restartApplication (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun shutdownApplication (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/TimeSyncApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getUtcTime (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/TrailersApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getTrailers (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getTrailers$default (Lorg/jellyfin/sdk/api/operations/TrailersApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;IIILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/TvShowsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getEpisodes (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getEpisodes$default (Lorg/jellyfin/sdk/api/operations/TvShowsApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getNextUp (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getNextUp$default (Lorg/jellyfin/sdk/api/operations/TvShowsApi;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSeasons (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSeasons$default (Lorg/jellyfin/sdk/api/operations/TvShowsApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getUpcomingEpisodes (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUpcomingEpisodes$default (Lorg/jellyfin/sdk/api/operations/TvShowsApi;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/UniversalAudioApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getUniversalAudioStream (Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUniversalAudioStream$default (Lorg/jellyfin/sdk/api/operations/UniversalAudioApi;Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getUniversalAudioStreamUrl (Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ZZZ)Ljava/lang/String;
+	public static synthetic fun getUniversalAudioStreamUrl$default (Lorg/jellyfin/sdk/api/operations/UniversalAudioApi;Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ZZZILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/api/operations/UserApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun authenticateUser (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun authenticateUser$default (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun authenticateUserByName (Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun authenticateWithQuickConnect (Lorg/jellyfin/sdk/model/api/QuickConnectDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createUserByName (Lorg/jellyfin/sdk/model/api/CreateUserByName;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteUser (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun forgotPassword (Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun forgotPasswordPin (Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getCurrentUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPublicUsers (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUserById (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUsers (Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUsers$default (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateUser (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UserDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateUserConfiguration (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UserConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateUserEasyPassword (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateUserPassword (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UpdateUserPassword;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateUserPolicy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UserPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/UserLibraryApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun deleteUserItemRating (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getIntros (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getItem (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLatestMedia (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;IZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLatestMedia$default (Lorg/jellyfin/sdk/api/operations/UserLibraryApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;IZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLocalTrailers (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRootFolder (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSpecialFeatures (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun markFavoriteItem (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unmarkFavoriteItem (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateUserItemRating (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateUserItemRating$default (Lorg/jellyfin/sdk/api/operations/UserLibraryApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/UserViewsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getGroupingOptions (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUserViews (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUserViews$default (Lorg/jellyfin/sdk/api/operations/UserViewsApi;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/VideoAttachmentsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getAttachment (Ljava/util/UUID;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAttachmentUrl (Ljava/util/UUID;Ljava/lang/String;IZ)Ljava/lang/String;
+	public static synthetic fun getAttachmentUrl$default (Lorg/jellyfin/sdk/api/operations/VideoAttachmentsApi;Ljava/util/UUID;Ljava/lang/String;IZILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/api/operations/VideoHlsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getLiveHlsStream (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLiveHlsStream$default (Lorg/jellyfin/sdk/api/operations/VideoHlsApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLiveHlsStreamUrl (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Z)Ljava/lang/String;
+	public static synthetic fun getLiveHlsStreamUrl$default (Lorg/jellyfin/sdk/api/operations/VideoHlsApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ZIILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/api/operations/VideosApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun deleteAlternateSources (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAdditionalPart (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAdditionalPart$default (Lorg/jellyfin/sdk/api/operations/VideosApi;Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getVideoStream (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getVideoStream$default (Lorg/jellyfin/sdk/api/operations/VideosApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getVideoStreamByContainer (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getVideoStreamByContainer$default (Lorg/jellyfin/sdk/api/operations/VideosApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getVideoStreamByContainerUrl (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getVideoStreamByContainerUrl$default (Lorg/jellyfin/sdk/api/operations/VideosApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun getVideoStreamUrl (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun getVideoStreamUrl$default (Lorg/jellyfin/sdk/api/operations/VideosApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;ZIILjava/lang/Object;)Ljava/lang/String;
+	public final fun mergeVersions (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun mergeVersions$default (Lorg/jellyfin/sdk/api/operations/VideosApi;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/operations/YearsApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public final fun getYear (ILjava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getYear$default (Lorg/jellyfin/sdk/api/operations/YearsApi;ILjava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getYears (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getYears$default (Lorg/jellyfin/sdk/api/operations/YearsApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/List;Ljava/util/UUID;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/sockets/SocketSubscription {
+	public fun <init> (Lorg/jellyfin/sdk/api/sockets/WebSocketApi;Lkotlin/jvm/functions/Function1;)V
+	public final fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/sockets/WebSocketApi {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
+	public final fun cancelSubscription (Lorg/jellyfin/sdk/api/sockets/SocketSubscription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun publish (Lorg/jellyfin/sdk/model/socket/OutgoingSocketMessage;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun subscribe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun subscribe (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/jellyfin-core/api/jellyfin-core.api
+++ b/jellyfin-core/api/jellyfin-core.api
@@ -1,0 +1,135 @@
+public final class org/jellyfin/sdk/Jellyfin {
+	public static final field Companion Lorg/jellyfin/sdk/Jellyfin$Companion;
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Lorg/jellyfin/sdk/JellyfinOptions;)V
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)Lorg/jellyfin/sdk/api/client/KtorClient;
+	public static synthetic fun createApi$default (Lorg/jellyfin/sdk/Jellyfin;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/api/client/KtorClient;
+	public final fun getDiscovery ()Lorg/jellyfin/sdk/discovery/DiscoveryService;
+}
+
+public final class org/jellyfin/sdk/Jellyfin$Companion {
+	public final fun getApiVersion ()Lorg/jellyfin/sdk/model/discovery/ServerVersion;
+	public final fun getRecommendedVersion ()Lorg/jellyfin/sdk/model/discovery/ServerVersion;
+}
+
+public final class org/jellyfin/sdk/JellyfinOptions {
+	public static final field Companion Lorg/jellyfin/sdk/JellyfinOptions$Companion;
+	public fun <init> (Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/ClientInfo;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun copy (Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
+	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun getDiscoverBroadcastAddressesProvider ()Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/JellyfinOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lorg/jellyfin/sdk/JellyfinOptions;
+	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
+	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun getDiscoveryBroadcastAddressesProvider ()Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;
+	public final fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
+	public final fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public final fun setDiscoveryBroadcastAddressesProvider (Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;)V
+}
+
+public final class org/jellyfin/sdk/JellyfinOptions$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/JellyfinOptions;
+}
+
+public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
+	public static final field Companion Lorg/jellyfin/sdk/discovery/AddressCandidateHelper$Companion;
+	public static final field JF_BASE_URL Ljava/lang/String;
+	public static final field JF_HTTPS_PORT I
+	public static final field JF_HTTP_PORT I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun addBaseUrlCandidates ()V
+	public final fun addCommonCandidates ()V
+	public final fun addPortCandidates ()V
+	public final fun addProtocolCandidates ()V
+	public final fun getCandidates ()Ljava/util/List;
+	public final fun prioritize ()V
+}
+
+public final class org/jellyfin/sdk/discovery/AddressCandidateHelper$Companion {
+}
+
+public abstract interface class org/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider {
+	public abstract fun getBroadcastAddresses (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/discovery/DiscoveryService {
+	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;)V
+	public final fun discoverLocalServers (II)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun discoverLocalServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;IIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/List;
+	public final fun getRecommendedServer (Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServer$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/lang/String;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/util/List;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/lang/String;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/List;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/discovery/JavaNetBroadcastAddressesProvider : org/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider {
+	public fun <init> ()V
+	public fun getBroadcastAddresses (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/discovery/LocalServerDiscovery {
+	public static final field Companion Lorg/jellyfin/sdk/discovery/LocalServerDiscovery$Companion;
+	public static final field DISCOVERY_MAX_SERVERS I
+	public static final field DISCOVERY_MESSAGE Ljava/lang/String;
+	public static final field DISCOVERY_PORT I
+	public static final field DISCOVERY_RECEIVE_BUFFER I
+	public static final field DISCOVERY_TIMEOUT I
+	public fun <init> ()V
+	public fun <init> (Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun discover (II)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun discover$default (Lorg/jellyfin/sdk/discovery/LocalServerDiscovery;IIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class org/jellyfin/sdk/discovery/LocalServerDiscovery$Companion {
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerDiscovery {
+	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
+	public final fun discover (Ljava/util/List;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discover (Lkotlinx/coroutines/flow/Flow;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerInfo {
+	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+	public final fun component4 ()Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Ljava/lang/String;
+	public final fun getParent ()Ljava/lang/String;
+	public final fun getResponseTime ()J
+	public final fun getScore ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+	public final fun getSystemInfo ()Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
+	public fun hashCode ()I
+	public final fun isAppended ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerInfoScore : java/lang/Enum {
+	public static final field BAD Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+	public static final field GOOD Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+	public static final field OK Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+	public static fun values ()[Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+}
+

--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -1,0 +1,11915 @@
+public final class org/jellyfin/sdk/model/ClientInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/ClientInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/ClientInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/ClientInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/model/DeviceInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/DeviceInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/DeviceInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/DeviceInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/model/api/AccessSchedule {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AccessSchedule$Companion;
+	public synthetic fun <init> (IILjava/util/UUID;Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;DDLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;DD)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public final fun component4 ()D
+	public final fun component5 ()D
+	public final fun copy (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;DD)Lorg/jellyfin/sdk/model/api/AccessSchedule;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AccessSchedule;ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;DDILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AccessSchedule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDayOfWeek ()Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public final fun getEndHour ()D
+	public final fun getId ()I
+	public final fun getStartHour ()D
+	public final fun getUserId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AccessSchedule;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AccessSchedule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AccessSchedule$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AccessSchedule;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AccessSchedule;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AccessSchedule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ActivityLogEntry {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ActivityLogEntry$Companion;
+	public synthetic fun <init> (IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LogLevel;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LogLevel;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Lorg/jellyfin/sdk/model/api/LogLevel;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/time/LocalDateTime;
+	public final fun component8 ()Ljava/util/UUID;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LogLevel;)Lorg/jellyfin/sdk/model/api/ActivityLogEntry;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ActivityLogEntry;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LogLevel;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ActivityLogEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Ljava/time/LocalDateTime;
+	public final fun getId ()J
+	public final fun getItemId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getSeverity ()Lorg/jellyfin/sdk/model/api/LogLevel;
+	public final fun getShortOverview ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/util/UUID;
+	public final fun getUserPrimaryImageTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ActivityLogEntry;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ActivityLogEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ActivityLogEntry$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ActivityLogEntry;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ActivityLogEntry;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ActivityLogEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ActivityLogEntryQueryResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;II)V
+	public synthetic fun <init> (Ljava/util/List;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;II)Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;Ljava/util/List;IIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getStartIndex ()I
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ActivityLogEntryQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ActivityLogEntryQueryResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AddVirtualFolderDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/LibraryOptions;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/LibraryOptions;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/LibraryOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/LibraryOptions;)Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;Lorg/jellyfin/sdk/model/api/LibraryOptions;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLibraryOptions ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AddVirtualFolderDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AddVirtualFolderDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AdminNotificationDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AdminNotificationDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/AdminNotificationDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AdminNotificationDto;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AdminNotificationDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNotificationLevel ()Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AdminNotificationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AdminNotificationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AdminNotificationDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AdminNotificationDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AdminNotificationDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AdminNotificationDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AlbumInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AlbumInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/util/Map;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/util/Map;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/util/Map;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/util/Map;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/AlbumInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AlbumInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AlbumInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlbumArtists ()Ljava/util/List;
+	public final fun getArtistProviderIds ()Ljava/util/Map;
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getSongInfos ()Ljava/util/List;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AlbumInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AlbumInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AlbumInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AlbumInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AlbumInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AlbumInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/AlbumInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/AlbumInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/AlbumInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/AlbumInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/AlbumInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/AlbumInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/AlbumInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AllThemeMediaResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AllThemeMediaResult$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;)Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSoundtrackSongsResult ()Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public final fun getThemeSongsResult ()Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public final fun getThemeVideosResult ()Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AllThemeMediaResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AllThemeMediaResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AllThemeMediaResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/Architecture : java/lang/Enum {
+	public static final field ARM Lorg/jellyfin/sdk/model/api/Architecture;
+	public static final field ARM_64 Lorg/jellyfin/sdk/model/api/Architecture;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/Architecture$Companion;
+	public static final field WASM Lorg/jellyfin/sdk/model/api/Architecture;
+	public static final field X64 Lorg/jellyfin/sdk/model/api/Architecture;
+	public static final field X86 Lorg/jellyfin/sdk/model/api/Architecture;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Architecture;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/Architecture;
+}
+
+public final class org/jellyfin/sdk/model/api/Architecture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/Architecture$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/Architecture;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/Architecture;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/Architecture$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ArtistInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ArtistInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;)Lorg/jellyfin/sdk/model/api/ArtistInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ArtistInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ArtistInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getSongInfos ()Ljava/util/List;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ArtistInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ArtistInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ArtistInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ArtistInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ArtistInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ArtistInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/ArtistInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/ArtistInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/ArtistInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/ArtistInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/ArtistInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/ArtistInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/ArtistInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticateUserByName {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AuthenticateUserByName$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPassword ()Ljava/lang/String;
+	public final fun getPw ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticateUserByName$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticateUserByName$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticateUserByName$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AuthenticationInfo$Companion;
+	public synthetic fun <init> (IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZLjava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZLjava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZLjava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/time/LocalDateTime;
+	public final fun component11 ()Ljava/time/LocalDateTime;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/UUID;
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZLjava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/AuthenticationInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AuthenticationInfo;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZLjava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AuthenticationInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessToken ()Ljava/lang/String;
+	public final fun getAppName ()Ljava/lang/String;
+	public final fun getAppVersion ()Ljava/lang/String;
+	public final fun getDateCreated ()Ljava/time/LocalDateTime;
+	public final fun getDateLastActivity ()Ljava/time/LocalDateTime;
+	public final fun getDateRevoked ()Ljava/time/LocalDateTime;
+	public final fun getDeviceId ()Ljava/lang/String;
+	public final fun getDeviceName ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getUserId ()Ljava/util/UUID;
+	public final fun getUserName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isActive ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticationInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticationInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticationInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AuthenticationInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationInfoQueryResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;II)V
+	public synthetic fun <init> (Ljava/util/List;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;II)Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;Ljava/util/List;IIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getStartIndex ()I
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationInfoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationInfoQueryResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/AuthenticationResult$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/UserDto;Lorg/jellyfin/sdk/model/api/SessionInfo;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/UserDto;Lorg/jellyfin/sdk/model/api/SessionInfo;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/UserDto;Lorg/jellyfin/sdk/model/api/SessionInfo;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/UserDto;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/SessionInfo;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/UserDto;Lorg/jellyfin/sdk/model/api/SessionInfo;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/AuthenticationResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/AuthenticationResult;Lorg/jellyfin/sdk/model/api/UserDto;Lorg/jellyfin/sdk/model/api/SessionInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/AuthenticationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessToken ()Ljava/lang/String;
+	public final fun getServerId ()Ljava/lang/String;
+	public final fun getSessionInfo ()Lorg/jellyfin/sdk/model/api/SessionInfo;
+	public final fun getUser ()Lorg/jellyfin/sdk/model/api/UserDto;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticationResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticationResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticationResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/AuthenticationResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/AuthenticationResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItem {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BaseItem$Companion;
+	public synthetic fun <init> (ILjava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;ZZLjava/lang/String;IILjava/util/List;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;ZZLjava/lang/String;IILjava/util/List;Z)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;ZZLjava/lang/String;IILjava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/time/LocalDateTime;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;ZZLjava/lang/String;IILjava/util/List;Z)Lorg/jellyfin/sdk/model/api/BaseItem;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BaseItem;Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;ZZLjava/lang/String;IILjava/util/List;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BaseItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getDateLastSaved ()Ljava/time/LocalDateTime;
+	public final fun getExtraIds ()Ljava/util/List;
+	public final fun getHeight ()I
+	public final fun getRemoteTrailers ()Ljava/util/List;
+	public final fun getShortcutPath ()Ljava/lang/String;
+	public final fun getSize ()Ljava/lang/Long;
+	public final fun getSupportsExternalTransfer ()Z
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public final fun isHd ()Z
+	public final fun isShortcut ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItem;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItem$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItem;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BaseItem;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BaseItemDto$Companion;
+	public synthetic fun <init> (IIIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayAccess;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/UserItemDataDto;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Double;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/VideoType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/LocationType;Lorg/jellyfin/sdk/model/api/IsoType;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Lorg/jellyfin/sdk/model/api/ImageOrientation;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Double;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ChannelType;Lorg/jellyfin/sdk/model/api/ProgramAudio;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayAccess;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/UserItemDataDto;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Double;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/VideoType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/LocationType;Lorg/jellyfin/sdk/model/api/IsoType;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Lorg/jellyfin/sdk/model/api/ImageOrientation;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Double;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ChannelType;Lorg/jellyfin/sdk/model/api/ProgramAudio;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayAccess;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/UserItemDataDto;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Double;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/VideoType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/LocationType;Lorg/jellyfin/sdk/model/api/IsoType;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Lorg/jellyfin/sdk/model/api/ImageOrientation;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Double;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ChannelType;Lorg/jellyfin/sdk/model/api/ProgramAudio;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component100 ()Ljava/lang/String;
+	public final fun component101 ()Ljava/lang/String;
+	public final fun component102 ()Ljava/lang/String;
+	public final fun component103 ()Ljava/lang/String;
+	public final fun component104 ()Ljava/util/List;
+	public final fun component105 ()Lorg/jellyfin/sdk/model/api/LocationType;
+	public final fun component106 ()Lorg/jellyfin/sdk/model/api/IsoType;
+	public final fun component107 ()Ljava/lang/String;
+	public final fun component108 ()Ljava/time/LocalDateTime;
+	public final fun component109 ()Ljava/util/List;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component110 ()Ljava/lang/Integer;
+	public final fun component111 ()Ljava/lang/Integer;
+	public final fun component112 ()Ljava/lang/Integer;
+	public final fun component113 ()Ljava/lang/Integer;
+	public final fun component114 ()Ljava/lang/Integer;
+	public final fun component115 ()Ljava/lang/Integer;
+	public final fun component116 ()Ljava/lang/Integer;
+	public final fun component117 ()Ljava/lang/Integer;
+	public final fun component118 ()Ljava/lang/Integer;
+	public final fun component119 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component120 ()Ljava/lang/Integer;
+	public final fun component121 ()Ljava/lang/Integer;
+	public final fun component122 ()Ljava/lang/String;
+	public final fun component123 ()Ljava/lang/String;
+	public final fun component124 ()Ljava/lang/String;
+	public final fun component125 ()Ljava/lang/Double;
+	public final fun component126 ()Ljava/lang/Double;
+	public final fun component127 ()Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public final fun component128 ()Ljava/lang/Double;
+	public final fun component129 ()Ljava/lang/Double;
+	public final fun component13 ()Ljava/lang/Integer;
+	public final fun component130 ()Ljava/lang/Double;
+	public final fun component131 ()Ljava/lang/Double;
+	public final fun component132 ()Ljava/lang/Double;
+	public final fun component133 ()Ljava/lang/Integer;
+	public final fun component134 ()Ljava/lang/String;
+	public final fun component135 ()Ljava/lang/String;
+	public final fun component136 ()Ljava/lang/String;
+	public final fun component137 ()Ljava/time/LocalDateTime;
+	public final fun component138 ()Ljava/lang/Double;
+	public final fun component139 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component140 ()Ljava/lang/String;
+	public final fun component141 ()Lorg/jellyfin/sdk/model/api/ChannelType;
+	public final fun component142 ()Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public final fun component143 ()Ljava/lang/Boolean;
+	public final fun component144 ()Ljava/lang/Boolean;
+	public final fun component145 ()Ljava/lang/Boolean;
+	public final fun component146 ()Ljava/lang/Boolean;
+	public final fun component147 ()Ljava/lang/Boolean;
+	public final fun component148 ()Ljava/lang/Boolean;
+	public final fun component149 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component150 ()Ljava/lang/String;
+	public final fun component151 ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun component16 ()Ljava/lang/Boolean;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public final fun component24 ()Ljava/time/LocalDateTime;
+	public final fun component25 ()Ljava/util/List;
+	public final fun component26 ()Ljava/util/List;
+	public final fun component27 ()Ljava/lang/Float;
+	public final fun component28 ()Ljava/util/List;
+	public final fun component29 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component30 ()Ljava/lang/Boolean;
+	public final fun component31 ()Ljava/lang/String;
+	public final fun component32 ()Ljava/lang/String;
+	public final fun component33 ()Ljava/util/UUID;
+	public final fun component34 ()Ljava/lang/String;
+	public final fun component35 ()Ljava/lang/String;
+	public final fun component36 ()Ljava/util/List;
+	public final fun component37 ()Ljava/util/List;
+	public final fun component38 ()Ljava/lang/Float;
+	public final fun component39 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/util/UUID;
+	public final fun component40 ()Ljava/lang/Long;
+	public final fun component41 ()Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public final fun component42 ()Ljava/lang/String;
+	public final fun component43 ()Ljava/lang/Integer;
+	public final fun component44 ()Ljava/lang/Boolean;
+	public final fun component45 ()Ljava/lang/String;
+	public final fun component46 ()Ljava/lang/String;
+	public final fun component47 ()Ljava/lang/Integer;
+	public final fun component48 ()Ljava/lang/Integer;
+	public final fun component49 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component50 ()Ljava/util/List;
+	public final fun component51 ()Ljava/util/Map;
+	public final fun component52 ()Ljava/lang/Boolean;
+	public final fun component53 ()Ljava/lang/Boolean;
+	public final fun component54 ()Ljava/util/UUID;
+	public final fun component55 ()Ljava/lang/String;
+	public final fun component56 ()Ljava/util/List;
+	public final fun component57 ()Ljava/util/List;
+	public final fun component58 ()Ljava/util/List;
+	public final fun component59 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component60 ()Ljava/lang/String;
+	public final fun component61 ()Ljava/util/List;
+	public final fun component62 ()Ljava/lang/Integer;
+	public final fun component63 ()Lorg/jellyfin/sdk/model/api/UserItemDataDto;
+	public final fun component64 ()Ljava/lang/Integer;
+	public final fun component65 ()Ljava/lang/Integer;
+	public final fun component66 ()Ljava/lang/String;
+	public final fun component67 ()Ljava/util/UUID;
+	public final fun component68 ()Ljava/util/UUID;
+	public final fun component69 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component70 ()Ljava/lang/String;
+	public final fun component71 ()Ljava/lang/String;
+	public final fun component72 ()Ljava/lang/String;
+	public final fun component73 ()Ljava/util/List;
+	public final fun component74 ()Ljava/util/List;
+	public final fun component75 ()Ljava/lang/Double;
+	public final fun component76 ()Ljava/util/List;
+	public final fun component77 ()Ljava/util/List;
+	public final fun component78 ()Ljava/lang/String;
+	public final fun component79 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/time/LocalDateTime;
+	public final fun component80 ()Ljava/lang/String;
+	public final fun component81 ()Ljava/util/UUID;
+	public final fun component82 ()Ljava/lang/String;
+	public final fun component83 ()Ljava/lang/String;
+	public final fun component84 ()Ljava/lang/String;
+	public final fun component85 ()Ljava/util/List;
+	public final fun component86 ()Ljava/lang/String;
+	public final fun component87 ()Ljava/util/List;
+	public final fun component88 ()Lorg/jellyfin/sdk/model/api/VideoType;
+	public final fun component89 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun component90 ()Ljava/lang/Integer;
+	public final fun component91 ()Ljava/util/Map;
+	public final fun component92 ()Ljava/util/List;
+	public final fun component93 ()Ljava/util/List;
+	public final fun component94 ()Ljava/lang/String;
+	public final fun component95 ()Ljava/lang/String;
+	public final fun component96 ()Ljava/lang/String;
+	public final fun component97 ()Ljava/lang/String;
+	public final fun component98 ()Ljava/util/Map;
+	public final fun component99 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayAccess;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/UserItemDataDto;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Double;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/VideoType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/LocationType;Lorg/jellyfin/sdk/model/api/IsoType;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Lorg/jellyfin/sdk/model/api/ImageOrientation;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Double;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ChannelType;Lorg/jellyfin/sdk/model/api/ProgramAudio;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;)Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Float;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayAccess;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/UserItemDataDto;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Double;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/VideoType;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/LocationType;Lorg/jellyfin/sdk/model/api/IsoType;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Lorg/jellyfin/sdk/model/api/ImageOrientation;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Double;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ChannelType;Lorg/jellyfin/sdk/model/api/ProgramAudio;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;IIIIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAirDays ()Ljava/util/List;
+	public final fun getAirTime ()Ljava/lang/String;
+	public final fun getAirsAfterSeasonNumber ()Ljava/lang/Integer;
+	public final fun getAirsBeforeEpisodeNumber ()Ljava/lang/Integer;
+	public final fun getAirsBeforeSeasonNumber ()Ljava/lang/Integer;
+	public final fun getAlbum ()Ljava/lang/String;
+	public final fun getAlbumArtist ()Ljava/lang/String;
+	public final fun getAlbumArtists ()Ljava/util/List;
+	public final fun getAlbumCount ()Ljava/lang/Integer;
+	public final fun getAlbumId ()Ljava/util/UUID;
+	public final fun getAlbumPrimaryImageTag ()Ljava/lang/String;
+	public final fun getAltitude ()Ljava/lang/Double;
+	public final fun getAperture ()Ljava/lang/Double;
+	public final fun getArtistCount ()Ljava/lang/Integer;
+	public final fun getArtistItems ()Ljava/util/List;
+	public final fun getArtists ()Ljava/util/List;
+	public final fun getAspectRatio ()Ljava/lang/String;
+	public final fun getAudio ()Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public final fun getBackdropImageTags ()Ljava/util/List;
+	public final fun getCameraMake ()Ljava/lang/String;
+	public final fun getCameraModel ()Ljava/lang/String;
+	public final fun getCanDelete ()Ljava/lang/Boolean;
+	public final fun getCanDownload ()Ljava/lang/Boolean;
+	public final fun getChannelId ()Ljava/util/UUID;
+	public final fun getChannelName ()Ljava/lang/String;
+	public final fun getChannelNumber ()Ljava/lang/String;
+	public final fun getChannelPrimaryImageTag ()Ljava/lang/String;
+	public final fun getChannelType ()Lorg/jellyfin/sdk/model/api/ChannelType;
+	public final fun getChapters ()Ljava/util/List;
+	public final fun getChildCount ()Ljava/lang/Integer;
+	public final fun getCollectionType ()Ljava/lang/String;
+	public final fun getCommunityRating ()Ljava/lang/Float;
+	public final fun getCompletionPercentage ()Ljava/lang/Double;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getCriticRating ()Ljava/lang/Float;
+	public final fun getCumulativeRunTimeTicks ()Ljava/lang/Long;
+	public final fun getCurrentProgram ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun getCustomRating ()Ljava/lang/String;
+	public final fun getDateCreated ()Ljava/time/LocalDateTime;
+	public final fun getDateLastMediaAdded ()Ljava/time/LocalDateTime;
+	public final fun getDisplayOrder ()Ljava/lang/String;
+	public final fun getDisplayPreferencesId ()Ljava/lang/String;
+	public final fun getEnableMediaSourceDisplay ()Ljava/lang/Boolean;
+	public final fun getEndDate ()Ljava/time/LocalDateTime;
+	public final fun getEpisodeCount ()Ljava/lang/Integer;
+	public final fun getEpisodeTitle ()Ljava/lang/String;
+	public final fun getEtag ()Ljava/lang/String;
+	public final fun getExposureTime ()Ljava/lang/Double;
+	public final fun getExternalUrls ()Ljava/util/List;
+	public final fun getExtraType ()Ljava/lang/String;
+	public final fun getFocalLength ()Ljava/lang/Double;
+	public final fun getForcedSortName ()Ljava/lang/String;
+	public final fun getGenreItems ()Ljava/util/List;
+	public final fun getGenres ()Ljava/util/List;
+	public final fun getHasSubtitles ()Ljava/lang/Boolean;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getImageBlurHashes ()Ljava/util/Map;
+	public final fun getImageOrientation ()Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public final fun getImageTags ()Ljava/util/Map;
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getIndexNumberEnd ()Ljava/lang/Integer;
+	public final fun getIsoSpeedRating ()Ljava/lang/Integer;
+	public final fun getIsoType ()Lorg/jellyfin/sdk/model/api/IsoType;
+	public final fun getLatitude ()Ljava/lang/Double;
+	public final fun getLocalTrailerCount ()Ljava/lang/Integer;
+	public final fun getLocationType ()Lorg/jellyfin/sdk/model/api/LocationType;
+	public final fun getLockData ()Ljava/lang/Boolean;
+	public final fun getLockedFields ()Ljava/util/List;
+	public final fun getLongitude ()Ljava/lang/Double;
+	public final fun getMediaSourceCount ()Ljava/lang/Integer;
+	public final fun getMediaSources ()Ljava/util/List;
+	public final fun getMediaStreams ()Ljava/util/List;
+	public final fun getMediaType ()Ljava/lang/String;
+	public final fun getMovieCount ()Ljava/lang/Integer;
+	public final fun getMusicVideoCount ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/String;
+	public final fun getOfficialRating ()Ljava/lang/String;
+	public final fun getOriginalTitle ()Ljava/lang/String;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getParentArtImageTag ()Ljava/lang/String;
+	public final fun getParentArtItemId ()Ljava/lang/String;
+	public final fun getParentBackdropImageTags ()Ljava/util/List;
+	public final fun getParentBackdropItemId ()Ljava/lang/String;
+	public final fun getParentId ()Ljava/util/UUID;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getParentLogoImageTag ()Ljava/lang/String;
+	public final fun getParentLogoItemId ()Ljava/lang/String;
+	public final fun getParentPrimaryImageItemId ()Ljava/lang/String;
+	public final fun getParentPrimaryImageTag ()Ljava/lang/String;
+	public final fun getParentThumbImageTag ()Ljava/lang/String;
+	public final fun getParentThumbItemId ()Ljava/lang/String;
+	public final fun getPartCount ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPeople ()Ljava/util/List;
+	public final fun getPlayAccess ()Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public final fun getPlaylistItemId ()Ljava/lang/String;
+	public final fun getPreferredMetadataCountryCode ()Ljava/lang/String;
+	public final fun getPreferredMetadataLanguage ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getPrimaryImageAspectRatio ()Ljava/lang/Double;
+	public final fun getProductionLocations ()Ljava/util/List;
+	public final fun getProductionYear ()Ljava/lang/Integer;
+	public final fun getProgramCount ()Ljava/lang/Integer;
+	public final fun getProgramId ()Ljava/lang/String;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getRecursiveItemCount ()Ljava/lang/Integer;
+	public final fun getRemoteTrailers ()Ljava/util/List;
+	public final fun getRunTimeTicks ()Ljava/lang/Long;
+	public final fun getScreenshotImageTags ()Ljava/util/List;
+	public final fun getSeasonId ()Ljava/util/UUID;
+	public final fun getSeasonName ()Ljava/lang/String;
+	public final fun getSeriesCount ()Ljava/lang/Integer;
+	public final fun getSeriesId ()Ljava/util/UUID;
+	public final fun getSeriesName ()Ljava/lang/String;
+	public final fun getSeriesPrimaryImageTag ()Ljava/lang/String;
+	public final fun getSeriesStudio ()Ljava/lang/String;
+	public final fun getSeriesThumbImageTag ()Ljava/lang/String;
+	public final fun getSeriesTimerId ()Ljava/lang/String;
+	public final fun getServerId ()Ljava/lang/String;
+	public final fun getShutterSpeed ()Ljava/lang/Double;
+	public final fun getSoftware ()Ljava/lang/String;
+	public final fun getSongCount ()Ljava/lang/Integer;
+	public final fun getSortName ()Ljava/lang/String;
+	public final fun getSourceType ()Ljava/lang/String;
+	public final fun getSpecialFeatureCount ()Ljava/lang/Integer;
+	public final fun getStartDate ()Ljava/time/LocalDateTime;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getStudios ()Ljava/util/List;
+	public final fun getSupportsSync ()Ljava/lang/Boolean;
+	public final fun getTaglines ()Ljava/util/List;
+	public final fun getTags ()Ljava/util/List;
+	public final fun getTimerId ()Ljava/lang/String;
+	public final fun getTrailerCount ()Ljava/lang/Integer;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUserData ()Lorg/jellyfin/sdk/model/api/UserItemDataDto;
+	public final fun getVideo3dFormat ()Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public final fun getVideoType ()Lorg/jellyfin/sdk/model/api/VideoType;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isFolder ()Ljava/lang/Boolean;
+	public final fun isHd ()Ljava/lang/Boolean;
+	public final fun isKids ()Ljava/lang/Boolean;
+	public final fun isLive ()Ljava/lang/Boolean;
+	public final fun isMovie ()Ljava/lang/Boolean;
+	public final fun isNews ()Ljava/lang/Boolean;
+	public final fun isPlaceHolder ()Ljava/lang/Boolean;
+	public final fun isPremiere ()Ljava/lang/Boolean;
+	public final fun isRepeat ()Ljava/lang/Boolean;
+	public final fun isSeries ()Ljava/lang/Boolean;
+	public final fun isSports ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItemDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItemDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BaseItemDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemDtoQueryResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;II)V
+	public synthetic fun <init> (Ljava/util/List;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;II)Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;Ljava/util/List;IIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getStartIndex ()I
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemDtoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemDtoQueryResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemPerson {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BaseItemPerson$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lorg/jellyfin/sdk/model/api/BaseItemPerson;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BaseItemPerson;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BaseItemPerson;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImageBlurHashes ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPrimaryImageTag ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItemPerson;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemPerson$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItemPerson$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItemPerson;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BaseItemPerson;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BaseItemPerson$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BasePluginConfiguration {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BasePluginConfiguration$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BasePluginConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BasePluginConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BasePluginConfiguration$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BasePluginConfiguration;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BasePluginConfiguration;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BasePluginConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BookInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BookInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/lang/String;)Lorg/jellyfin/sdk/model/api/BookInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BookInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BookInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getSeriesName ()Ljava/lang/String;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BookInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BookInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BookInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BookInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BookInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BookInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/BookInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/BookInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/BookInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/BookInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/BookInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/BookInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/BookInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BoxSetInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BoxSetInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)Lorg/jellyfin/sdk/model/api/BoxSetInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BoxSetInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BoxSetInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BoxSetInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BoxSetInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BoxSetInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BoxSetInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BoxSetInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BoxSetInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/BoxSetInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/BoxSetInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/BoxSetInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/BoxSetInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/BoxSetInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/BoxSetInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/BoxSetInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BrandingOptions {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BrandingOptions$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/BrandingOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BrandingOptions;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BrandingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomCss ()Ljava/lang/String;
+	public final fun getLoginDisclaimer ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BrandingOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BrandingOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BrandingOptions$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BrandingOptions;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BrandingOptions;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BrandingOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BufferRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/BufferRequestDto$Companion;
+	public synthetic fun <init> (ILjava/time/LocalDateTime;JZLjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/time/LocalDateTime;JZLjava/util/UUID;)V
+	public final fun component1 ()Ljava/time/LocalDateTime;
+	public final fun component2 ()J
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/UUID;
+	public final fun copy (Ljava/time/LocalDateTime;JZLjava/util/UUID;)Lorg/jellyfin/sdk/model/api/BufferRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/BufferRequestDto;Ljava/time/LocalDateTime;JZLjava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/BufferRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlaylistItemId ()Ljava/util/UUID;
+	public final fun getPositionTicks ()J
+	public final fun getWhen ()Ljava/time/LocalDateTime;
+	public fun hashCode ()I
+	public final fun isPlaying ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BufferRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/BufferRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BufferRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BufferRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/BufferRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/BufferRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelFeatures {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelFeatures$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ZZZZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ZZZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ZZZZ)Lorg/jellyfin/sdk/model/api/ChannelFeatures;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ChannelFeatures;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ZZZZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ChannelFeatures;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutoRefreshLevels ()Ljava/lang/Integer;
+	public final fun getCanFilter ()Z
+	public final fun getCanSearch ()Z
+	public final fun getContentTypes ()Ljava/util/List;
+	public final fun getDefaultSortFields ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxPageSize ()Ljava/lang/Integer;
+	public final fun getMediaTypes ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSupportsContentDownloading ()Z
+	public final fun getSupportsLatestMedia ()Z
+	public final fun getSupportsSortOrderToggle ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ChannelFeatures;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelFeatures$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelFeatures$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelFeatures;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ChannelFeatures;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelFeatures$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelItemSortField : java/lang/Enum {
+	public static final field COMMUNITY_PLAY_COUNT Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static final field COMMUNITY_RATING Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelItemSortField$Companion;
+	public static final field DATE_CREATED Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static final field NAME Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static final field PLAY_COUNT Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static final field PREMIERE_DATE Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static final field RUNTIME Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelItemSortField$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelItemSortField$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ChannelItemSortField;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelItemSortField$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMappingOptionsDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMappings ()Ljava/util/List;
+	public final fun getProviderChannels ()Ljava/util/List;
+	public final fun getProviderName ()Ljava/lang/String;
+	public final fun getTunerChannels ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMappingOptionsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMappingOptionsDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMediaContentType : java/lang/Enum {
+	public static final field CLIP Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelMediaContentType$Companion;
+	public static final field EPISODE Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static final field MOVIE Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static final field MOVIE_EXTRA Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static final field PODCAST Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static final field SONG Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static final field TRAILER Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static final field TV_EXTRA Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMediaContentType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelMediaContentType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMediaContentType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMediaType : java/lang/Enum {
+	public static final field AUDIO Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelMediaType$Companion;
+	public static final field PHOTO Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+	public static final field VIDEO Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMediaType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelMediaType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ChannelMediaType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelMediaType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelType$Companion;
+	public static final field RADIO Lorg/jellyfin/sdk/model/api/ChannelType;
+	public static final field TV Lorg/jellyfin/sdk/model/api/ChannelType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelType;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ChannelType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChannelType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChapterInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ChapterInfo$Companion;
+	public synthetic fun <init> (IJLjava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/time/LocalDateTime;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChapterInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ChapterInfo;JLjava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ChapterInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImageDateModified ()Ljava/time/LocalDateTime;
+	public final fun getImagePath ()Ljava/lang/String;
+	public final fun getImageTag ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStartPositionTicks ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ChapterInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ChapterInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChapterInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChapterInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ChapterInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ChapterInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ClientCapabilities {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ClientCapabilities$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ClientCapabilities;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ClientCapabilities;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppStoreUrl ()Ljava/lang/String;
+	public final fun getDeviceProfile ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun getIconUrl ()Ljava/lang/String;
+	public final fun getMessageCallbackUrl ()Ljava/lang/String;
+	public final fun getPlayableMediaTypes ()Ljava/util/List;
+	public final fun getSupportedCommands ()Ljava/util/List;
+	public final fun getSupportsContentUploading ()Z
+	public final fun getSupportsMediaControl ()Z
+	public final fun getSupportsPersistentIdentifier ()Z
+	public final fun getSupportsSync ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ClientCapabilities;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ClientCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ClientCapabilities$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ClientCapabilities;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ClientCapabilities;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ClientCapabilities$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ClientCapabilitiesDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;Ljava/util/List;Ljava/util/List;ZZLjava/lang/String;ZZLorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppStoreUrl ()Ljava/lang/String;
+	public final fun getDeviceProfile ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun getIconUrl ()Ljava/lang/String;
+	public final fun getMessageCallbackUrl ()Ljava/lang/String;
+	public final fun getPlayableMediaTypes ()Ljava/util/List;
+	public final fun getSupportedCommands ()Ljava/util/List;
+	public final fun getSupportsContentUploading ()Z
+	public final fun getSupportsMediaControl ()Z
+	public final fun getSupportsPersistentIdentifier ()Z
+	public final fun getSupportsSync ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ClientCapabilitiesDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ClientCapabilitiesDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CodecProfile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CodecProfile$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/CodecType;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/CodecType;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/CodecType;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/CodecType;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/CodecType;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CodecProfile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/CodecProfile;Lorg/jellyfin/sdk/model/api/CodecType;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/CodecProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplyConditions ()Ljava/util/List;
+	public final fun getCodec ()Ljava/lang/String;
+	public final fun getConditions ()Ljava/util/List;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/CodecType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CodecProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/CodecProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CodecProfile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CodecProfile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CodecProfile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CodecProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CodecType : java/lang/Enum {
+	public static final field AUDIO Lorg/jellyfin/sdk/model/api/CodecType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CodecType$Companion;
+	public static final field VIDEO Lorg/jellyfin/sdk/model/api/CodecType;
+	public static final field VIDEO_AUDIO Lorg/jellyfin/sdk/model/api/CodecType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CodecType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/CodecType;
+}
+
+public final class org/jellyfin/sdk/model/api/CodecType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CodecType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CodecType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CodecType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CodecType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CollectionCreationResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CollectionCreationResult$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/CollectionCreationResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/CollectionCreationResult;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/CollectionCreationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CollectionCreationResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/CollectionCreationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CollectionCreationResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CollectionCreationResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CollectionCreationResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CollectionCreationResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CollectionTypeOptions : java/lang/Enum {
+	public static final field BOOKS Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static final field BOX_SETS Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CollectionTypeOptions$Companion;
+	public static final field HOME_VIDEOS Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static final field MIXED Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static final field MOVIES Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static final field MUSIC Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static final field MUSIC_VIDEOS Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static final field TV_SHOWS Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+}
+
+public final class org/jellyfin/sdk/model/api/CollectionTypeOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CollectionTypeOptions$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CollectionTypeOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ConfigurationPageInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Ljava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Ljava/util/UUID;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Ljava/util/UUID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+	public final fun component7 ()Ljava/util/UUID;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfigurationPageType ()Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getEnableInMainMenu ()Z
+	public final fun getMenuIcon ()Ljava/lang/String;
+	public final fun getMenuSection ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPluginId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ConfigurationPageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ConfigurationPageInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ConfigurationPageType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ConfigurationPageType$Companion;
+	public static final field NONE Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+	public static final field PLUGIN_CONFIGURATION Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+}
+
+public final class org/jellyfin/sdk/model/api/ConfigurationPageType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ConfigurationPageType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ConfigurationPageType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ContainerProfile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ContainerProfile$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/util/List;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ContainerProfile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ContainerProfile;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ContainerProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConditions ()Ljava/util/List;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ContainerProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ContainerProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ContainerProfile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ContainerProfile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ContainerProfile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ContainerProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ControlResponse {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ControlResponse$Companion;
+	public synthetic fun <init> (ILjava/util/Map;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/util/Map;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/ControlResponse;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ControlResponse;Ljava/util/Map;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ControlResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getXml ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isSuccessful ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ControlResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ControlResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ControlResponse$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ControlResponse;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ControlResponse;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ControlResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CountryInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CountryInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CountryInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/CountryInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/CountryInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getThreeLetterIsoRegionName ()Ljava/lang/String;
+	public final fun getTwoLetterIsoRegionName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CountryInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/CountryInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CountryInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CountryInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CountryInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CountryInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CreatePlaylistDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CreatePlaylistDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/UUID;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Ljava/lang/String;Ljava/util/List;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIds ()Ljava/util/List;
+	public final fun getMediaType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/CreatePlaylistDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CreatePlaylistDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CreatePlaylistDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CreateUserByName {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CreateUserByName$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CreateUserByName;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/CreateUserByName;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/CreateUserByName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPassword ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CreateUserByName;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/CreateUserByName$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CreateUserByName$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CreateUserByName;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CreateUserByName;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CreateUserByName$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CultureDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/CultureDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/CultureDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/CultureDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/CultureDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getThreeLetterIsoLanguageName ()Ljava/lang/String;
+	public final fun getThreeLetterIsoLanguageNames ()Ljava/util/List;
+	public final fun getTwoLetterIsoLanguageName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CultureDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/CultureDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CultureDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CultureDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/CultureDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/CultureDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DayOfWeek : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DayOfWeek$Companion;
+	public static final field FRIDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static final field MONDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static final field SATURDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static final field SUNDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static final field THURSDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static final field TUESDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static final field WEDNESDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/DayOfWeek;
+}
+
+public final class org/jellyfin/sdk/model/api/DayOfWeek$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DayOfWeek$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DayOfWeek;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DayOfWeek$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DayPattern : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DayPattern$Companion;
+	public static final field DAILY Lorg/jellyfin/sdk/model/api/DayPattern;
+	public static final field WEEKDAYS Lorg/jellyfin/sdk/model/api/DayPattern;
+	public static final field WEEKENDS Lorg/jellyfin/sdk/model/api/DayPattern;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayPattern;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/DayPattern;
+}
+
+public final class org/jellyfin/sdk/model/api/DayPattern$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DayPattern$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DayPattern;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DayPattern;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DayPattern$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceIdentification {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceIdentification$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/DeviceIdentification;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DeviceIdentification;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DeviceIdentification;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFriendlyName ()Ljava/lang/String;
+	public final fun getHeaders ()Ljava/util/List;
+	public final fun getManufacturer ()Ljava/lang/String;
+	public final fun getManufacturerUrl ()Ljava/lang/String;
+	public final fun getModelDescription ()Ljava/lang/String;
+	public final fun getModelName ()Ljava/lang/String;
+	public final fun getModelNumber ()Ljava/lang/String;
+	public final fun getModelUrl ()Ljava/lang/String;
+	public final fun getSerialNumber ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceIdentification;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceIdentification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceIdentification$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceIdentification;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DeviceIdentification;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceIdentification$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/UUID;
+	public final fun component7 ()Ljava/time/LocalDateTime;
+	public final fun component8 ()Lorg/jellyfin/sdk/model/api/ClientCapabilities;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DeviceInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DeviceInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DeviceInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppName ()Ljava/lang/String;
+	public final fun getAppVersion ()Ljava/lang/String;
+	public final fun getCapabilities ()Lorg/jellyfin/sdk/model/api/ClientCapabilities;
+	public final fun getDateLastActivity ()Ljava/time/LocalDateTime;
+	public final fun getIconUrl ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLastUserId ()Ljava/util/UUID;
+	public final fun getLastUserName ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DeviceInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceInfoQueryResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;II)V
+	public synthetic fun <init> (Ljava/util/List;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;II)Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;Ljava/util/List;IIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getStartIndex ()I
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceInfoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceInfoQueryResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceOptions {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceOptions$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DeviceOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DeviceOptions;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DeviceOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceOptions$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceOptions;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DeviceOptions;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceProfile$Companion;
+	public synthetic fun <init> (IILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceIdentification;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;IZZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceIdentification;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;IZZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceIdentification;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;IZZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Z
+	public final fun component13 ()Z
+	public final fun component14 ()Z
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()I
+	public final fun component19 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/Integer;
+	public final fun component21 ()Ljava/lang/Integer;
+	public final fun component22 ()Ljava/lang/Integer;
+	public final fun component23 ()Ljava/lang/Integer;
+	public final fun component24 ()Ljava/lang/Integer;
+	public final fun component25 ()Ljava/lang/Integer;
+	public final fun component26 ()Ljava/lang/String;
+	public final fun component27 ()Ljava/lang/String;
+	public final fun component28 ()I
+	public final fun component29 ()Z
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/DeviceIdentification;
+	public final fun component30 ()Z
+	public final fun component31 ()Z
+	public final fun component32 ()Z
+	public final fun component33 ()Ljava/util/List;
+	public final fun component34 ()Ljava/util/List;
+	public final fun component35 ()Ljava/util/List;
+	public final fun component36 ()Ljava/util/List;
+	public final fun component37 ()Ljava/util/List;
+	public final fun component38 ()Ljava/util/List;
+	public final fun component39 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceIdentification;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;IZZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceIdentification;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;IZZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlbumArtPn ()Ljava/lang/String;
+	public final fun getCodecProfiles ()Ljava/util/List;
+	public final fun getContainerProfiles ()Ljava/util/List;
+	public final fun getDirectPlayProfiles ()Ljava/util/List;
+	public final fun getEnableAlbumArtInDidl ()Z
+	public final fun getEnableMsMediaReceiverRegistrar ()Z
+	public final fun getEnableSingleAlbumArtLimit ()Z
+	public final fun getEnableSingleSubtitleLimit ()Z
+	public final fun getFriendlyName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIdentification ()Lorg/jellyfin/sdk/model/api/DeviceIdentification;
+	public final fun getIgnoreTranscodeByteRangeRequests ()Z
+	public final fun getManufacturer ()Ljava/lang/String;
+	public final fun getManufacturerUrl ()Ljava/lang/String;
+	public final fun getMaxAlbumArtHeight ()I
+	public final fun getMaxAlbumArtWidth ()I
+	public final fun getMaxIconHeight ()Ljava/lang/Integer;
+	public final fun getMaxIconWidth ()Ljava/lang/Integer;
+	public final fun getMaxStaticBitrate ()Ljava/lang/Integer;
+	public final fun getMaxStaticMusicBitrate ()Ljava/lang/Integer;
+	public final fun getMaxStreamingBitrate ()Ljava/lang/Integer;
+	public final fun getModelDescription ()Ljava/lang/String;
+	public final fun getModelName ()Ljava/lang/String;
+	public final fun getModelNumber ()Ljava/lang/String;
+	public final fun getModelUrl ()Ljava/lang/String;
+	public final fun getMusicStreamingTranscodingBitrate ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getProtocolInfo ()Ljava/lang/String;
+	public final fun getRequiresPlainFolders ()Z
+	public final fun getRequiresPlainVideoItems ()Z
+	public final fun getResponseProfiles ()Ljava/util/List;
+	public final fun getSerialNumber ()Ljava/lang/String;
+	public final fun getSonyAggregationFlags ()Ljava/lang/String;
+	public final fun getSubtitleProfiles ()Ljava/util/List;
+	public final fun getSupportedMediaTypes ()Ljava/lang/String;
+	public final fun getTimelineOffsetSeconds ()I
+	public final fun getTranscodingProfiles ()Ljava/util/List;
+	public final fun getUserId ()Ljava/lang/String;
+	public final fun getXmlRootAttributes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceProfile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DeviceProfile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfileInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceProfileInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfileType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfileType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfileType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfileType;)Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfileType;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfileInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceProfileInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfileInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfileType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceProfileType$Companion;
+	public static final field SYSTEM Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public static final field USER Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfileType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceProfileType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DeviceProfileType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DeviceProfileType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DirectPlayProfile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DirectPlayProfile$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;)Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DirectPlayProfile;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioCodec ()Ljava/lang/String;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun getVideoCodec ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DirectPlayProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DirectPlayProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DirectPlayProfile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DirectPlayProfile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DirectPlayProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DisplayPreferencesDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZIILjava/util/Map;Lorg/jellyfin/sdk/model/api/ScrollDirection;ZZLorg/jellyfin/sdk/model/api/SortOrder;ZLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZIILjava/util/Map;Lorg/jellyfin/sdk/model/api/ScrollDirection;ZZLorg/jellyfin/sdk/model/api/SortOrder;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZIILjava/util/Map;Lorg/jellyfin/sdk/model/api/ScrollDirection;ZZLorg/jellyfin/sdk/model/api/SortOrder;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Lorg/jellyfin/sdk/model/api/SortOrder;
+	public final fun component13 ()Z
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZIILjava/util/Map;Lorg/jellyfin/sdk/model/api/ScrollDirection;ZZLorg/jellyfin/sdk/model/api/SortOrder;ZLjava/lang/String;)Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZIILjava/util/Map;Lorg/jellyfin/sdk/model/api/ScrollDirection;ZZLorg/jellyfin/sdk/model/api/SortOrder;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClient ()Ljava/lang/String;
+	public final fun getCustomPrefs ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIndexBy ()Ljava/lang/String;
+	public final fun getPrimaryImageHeight ()I
+	public final fun getPrimaryImageWidth ()I
+	public final fun getRememberIndexing ()Z
+	public final fun getRememberSorting ()Z
+	public final fun getScrollDirection ()Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public final fun getShowBackdrop ()Z
+	public final fun getShowSidebar ()Z
+	public final fun getSortBy ()Ljava/lang/String;
+	public final fun getSortOrder ()Lorg/jellyfin/sdk/model/api/SortOrder;
+	public final fun getViewType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/DisplayPreferencesDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DisplayPreferencesDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DlnaProfileType : java/lang/Enum {
+	public static final field AUDIO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DlnaProfileType$Companion;
+	public static final field PHOTO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public static final field VIDEO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+}
+
+public final class org/jellyfin/sdk/model/api/DlnaProfileType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DlnaProfileType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DlnaProfileType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DlnaProfileType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek$Companion;
+	public static final field EVERYDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field FRIDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field MONDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field SATURDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field SUNDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field THURSDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field TUESDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field WEDNESDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field WEEKDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static final field WEEKEND Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+}
+
+public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/EncodingContext : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/EncodingContext$Companion;
+	public static final field STATIC Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public static final field STREAMING Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/EncodingContext;
+}
+
+public final class org/jellyfin/sdk/model/api/EncodingContext$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/EncodingContext$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/EncodingContext;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/EncodingContext$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/EndPointInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/EndPointInfo$Companion;
+	public synthetic fun <init> (IZZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZZ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Lorg/jellyfin/sdk/model/api/EndPointInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/EndPointInfo;ZZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/EndPointInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isInNetwork ()Z
+	public final fun isLocal ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/EndPointInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/EndPointInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/EndPointInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/EndPointInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/EndPointInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/EndPointInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalIdInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ExternalIdInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ExternalIdInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ExternalIdInfo;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ExternalIdInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public final fun getUrlFormatString ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ExternalIdInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalIdInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ExternalIdInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ExternalIdInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ExternalIdInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalIdInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalIdMediaType : java/lang/Enum {
+	public static final field ALBUM Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field ALBUM_ARTIST Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field ARTIST Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field BOX_SET Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ExternalIdMediaType$Companion;
+	public static final field EPISODE Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field MOVIE Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field OTHER_ARTIST Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field PERSON Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field RELEASE_GROUP Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field SEASON Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field SERIES Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field TRACK Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalIdMediaType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ExternalIdMediaType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalIdMediaType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalUrl {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ExternalUrl$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ExternalUrl;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ExternalUrl;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ExternalUrl;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ExternalUrl;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalUrl$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ExternalUrl$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ExternalUrl;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ExternalUrl;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ExternalUrl$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FFmpegLocation : java/lang/Enum {
+	public static final field CUSTOM Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/FFmpegLocation$Companion;
+	public static final field NOT_FOUND Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public static final field SET_BY_ARGUMENT Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public static final field SYSTEM Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+}
+
+public final class org/jellyfin/sdk/model/api/FFmpegLocation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FFmpegLocation$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/FFmpegLocation;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FFmpegLocation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FileSystemEntryInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/FileSystemEntryType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/FileSystemEntryType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/FileSystemEntryType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/FileSystemEntryType;)Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/FileSystemEntryType;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/FileSystemEntryInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FileSystemEntryInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FileSystemEntryType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/FileSystemEntryType$Companion;
+	public static final field DIRECTORY Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public static final field FILE Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public static final field NETWORK_COMPUTER Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public static final field NETWORK_SHARE Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+}
+
+public final class org/jellyfin/sdk/model/api/FileSystemEntryType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FileSystemEntryType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/FileSystemEntryType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FileSystemEntryType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FontFile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/FontFile$Companion;
+	public synthetic fun <init> (ILjava/lang/String;JLjava/time/LocalDateTime;Ljava/time/LocalDateTime;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;JLjava/time/LocalDateTime;Ljava/time/LocalDateTime;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/time/LocalDateTime;Ljava/time/LocalDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/time/LocalDateTime;
+	public final fun component4 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;JLjava/time/LocalDateTime;Ljava/time/LocalDateTime;)Lorg/jellyfin/sdk/model/api/FontFile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/FontFile;Ljava/lang/String;JLjava/time/LocalDateTime;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/FontFile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDateCreated ()Ljava/time/LocalDateTime;
+	public final fun getDateModified ()Ljava/time/LocalDateTime;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSize ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/FontFile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/FontFile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FontFile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FontFile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/FontFile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/FontFile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordAction : java/lang/Enum {
+	public static final field CONTACT_ADMIN Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ForgotPasswordAction$Companion;
+	public static final field IN_NETWORK_REQUIRED Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public static final field PIN_CODE Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordAction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordAction$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordAction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ForgotPasswordDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnteredUsername ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordPinDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPin ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordPinDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordPinDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ForgotPasswordResult$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/ForgotPasswordAction;Ljava/lang/String;Ljava/time/LocalDateTime;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;Ljava/lang/String;Ljava/time/LocalDateTime;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;Ljava/lang/String;Ljava/time/LocalDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/time/LocalDateTime;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;Ljava/lang/String;Ljava/time/LocalDateTime;)Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;Ljava/lang/String;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public final fun getPinExpirationDate ()Ljava/time/LocalDateTime;
+	public final fun getPinFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ForgotPasswordResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GeneralCommand {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GeneralCommand$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;)Lorg/jellyfin/sdk/model/api/GeneralCommand;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/GeneralCommand;Lorg/jellyfin/sdk/model/api/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/GeneralCommand;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Ljava/util/Map;
+	public final fun getControllingUserId ()Ljava/util/UUID;
+	public final fun getName ()Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GeneralCommand;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/GeneralCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GeneralCommand$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GeneralCommand;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GeneralCommand;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GeneralCommand$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GeneralCommandType : java/lang/Enum {
+	public static final field BACK Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field CHANNEL_DOWN Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field CHANNEL_UP Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GeneralCommandType$Companion;
+	public static final field DISPLAY_CONTENT Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field DISPLAY_MESSAGE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field GO_HOME Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field GO_TO_SEARCH Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field GO_TO_SETTINGS Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field GUIDE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field MOVE_DOWN Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field MOVE_LEFT Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field MOVE_RIGHT Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field MOVE_UP Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field MUTE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field NEXT_LETTER Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PAGE_DOWN Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PAGE_UP Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PLAY Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PLAY_MEDIA_SOURCE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PLAY_NEXT Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PLAY_STATE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PLAY_TRAILERS Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field PREVIOUS_LETTER Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SELECT Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SEND_KEY Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SEND_STRING Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SET_AUDIO_STREAM_INDEX Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SET_REPEAT_MODE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SET_SHUFFLE_QUEUE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SET_SUBTITLE_STREAM_INDEX Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SET_VOLUME Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field TAKE_SCREENSHOT Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field TOGGLE_CONTEXT_MENU Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field TOGGLE_FULLSCREEN Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field TOGGLE_MUTE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field TOGGLE_OSD Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field TOGGLE_OSD_MENU Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field TOGGLE_STATS Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field UNMUTE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field VOLUME_DOWN Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field VOLUME_UP Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+}
+
+public final class org/jellyfin/sdk/model/api/GeneralCommandType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GeneralCommandType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GeneralCommandType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GeneralCommandType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GetProgramsDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GetProgramsDto$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLjava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLjava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLjava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/lang/Integer;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component20 ()Ljava/lang/Boolean;
+	public final fun component21 ()Z
+	public final fun component22 ()Ljava/lang/Integer;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Ljava/lang/Boolean;
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Ljava/util/UUID;
+	public final fun component27 ()Ljava/util/List;
+	public final fun component3 ()Ljava/time/LocalDateTime;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/time/LocalDateTime;
+	public final fun component7 ()Ljava/time/LocalDateTime;
+	public final fun component8 ()Ljava/time/LocalDateTime;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLjava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/GetProgramsDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/GetProgramsDto;Ljava/util/List;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ZLjava/lang/Integer;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/GetProgramsDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelIds ()Ljava/util/List;
+	public final fun getEnableImageTypes ()Ljava/util/List;
+	public final fun getEnableImages ()Ljava/lang/Boolean;
+	public final fun getEnableTotalRecordCount ()Z
+	public final fun getEnableUserData ()Ljava/lang/Boolean;
+	public final fun getFields ()Ljava/util/List;
+	public final fun getGenreIds ()Ljava/util/List;
+	public final fun getGenres ()Ljava/util/List;
+	public final fun getHasAired ()Ljava/lang/Boolean;
+	public final fun getImageTypeLimit ()Ljava/lang/Integer;
+	public final fun getLibrarySeriesId ()Ljava/util/UUID;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getMaxEndDate ()Ljava/time/LocalDateTime;
+	public final fun getMaxStartDate ()Ljava/time/LocalDateTime;
+	public final fun getMinEndDate ()Ljava/time/LocalDateTime;
+	public final fun getMinStartDate ()Ljava/time/LocalDateTime;
+	public final fun getSeriesTimerId ()Ljava/lang/String;
+	public final fun getSortBy ()Ljava/util/List;
+	public final fun getSortOrder ()Ljava/util/List;
+	public final fun getStartIndex ()Ljava/lang/Integer;
+	public final fun getUserId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public final fun isAiring ()Ljava/lang/Boolean;
+	public final fun isKids ()Ljava/lang/Boolean;
+	public final fun isMovie ()Ljava/lang/Boolean;
+	public final fun isNews ()Ljava/lang/Boolean;
+	public final fun isSeries ()Ljava/lang/Boolean;
+	public final fun isSports ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GetProgramsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/GetProgramsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GetProgramsDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GetProgramsDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GetProgramsDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GetProgramsDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupInfoDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupInfoDto$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GroupStateType;Ljava/util/List;Ljava/time/LocalDateTime;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GroupStateType;Ljava/util/List;Ljava/time/LocalDateTime;)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GroupStateType;Ljava/util/List;Ljava/time/LocalDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GroupStateType;Ljava/util/List;Ljava/time/LocalDateTime;)Lorg/jellyfin/sdk/model/api/GroupInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/GroupInfoDto;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/GroupStateType;Ljava/util/List;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/GroupInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Ljava/util/UUID;
+	public final fun getGroupName ()Ljava/lang/String;
+	public final fun getLastUpdatedAt ()Ljava/time/LocalDateTime;
+	public final fun getParticipants ()Ljava/util/List;
+	public final fun getState ()Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GroupInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/GroupInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupInfoDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupInfoDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GroupInfoDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupQueueMode : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupQueueMode$Companion;
+	public static final field QUEUE Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public static final field QUEUE_NEXT Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupQueueMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupQueueMode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GroupQueueMode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupQueueMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupRepeatMode : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupRepeatMode$Companion;
+	public static final field REPEAT_ALL Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public static final field REPEAT_NONE Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public static final field REPEAT_ONE Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupRepeatMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupRepeatMode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GroupRepeatMode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupRepeatMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupShuffleMode : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupShuffleMode$Companion;
+	public static final field SHUFFLE Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public static final field SORTED Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupShuffleMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupShuffleMode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GroupShuffleMode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupShuffleMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupStateType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupStateType$Companion;
+	public static final field IDLE Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public static final field PAUSED Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public static final field PLAYING Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public static final field WAITING Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupStateType;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupStateType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupStateType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GroupStateType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupStateType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupUpdateType : java/lang/Enum {
+	public static final field CREATE_GROUP_DENIED Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupUpdateType$Companion;
+	public static final field GROUP_DOES_NOT_EXIST Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field GROUP_JOINED Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field GROUP_LEFT Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field JOIN_GROUP_DENIED Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field LIBRARY_ACCESS_DENIED Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field NOT_IN_GROUP Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field PLAY_QUEUE Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field STATE_UPDATE Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field USER_JOINED Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static final field USER_LEFT Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupUpdateType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupUpdateType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GroupUpdateType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GroupUpdateType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GuideInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/GuideInfo$Companion;
+	public synthetic fun <init> (ILjava/time/LocalDateTime;Ljava/time/LocalDateTime;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;)V
+	public final fun component1 ()Ljava/time/LocalDateTime;
+	public final fun component2 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;)Lorg/jellyfin/sdk/model/api/GuideInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/GuideInfo;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/GuideInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndDate ()Ljava/time/LocalDateTime;
+	public final fun getStartDate ()Ljava/time/LocalDateTime;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GuideInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/GuideInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GuideInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GuideInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/GuideInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/GuideInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/HeaderMatchType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/HeaderMatchType$Companion;
+	public static final field EQUALS Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public static final field REGEX Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public static final field SUBSTRING Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+}
+
+public final class org/jellyfin/sdk/model/api/HeaderMatchType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/HeaderMatchType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/HeaderMatchType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/HeaderMatchType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/HttpHeaderInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/HttpHeaderInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/HeaderMatchType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/HeaderMatchType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/HeaderMatchType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/HeaderMatchType;)Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/HeaderMatchType;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMatch ()Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/HttpHeaderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/HttpHeaderInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/HttpHeaderInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/IPlugin {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/IPlugin$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/UUID;
+	public final fun component4 ()Lorg/jellyfin/sdk/model/api/Version;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZLjava/lang/String;)Lorg/jellyfin/sdk/model/api/IPlugin;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/IPlugin;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/IPlugin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssemblyFilePath ()Ljava/lang/String;
+	public final fun getCanUninstall ()Z
+	public final fun getDataFolderPath ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVersion ()Lorg/jellyfin/sdk/model/api/Version;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/IPlugin;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/IPlugin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/IPlugin$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/IPlugin;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/IPlugin;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/IPlugin$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/IgnoreWaitRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto$Companion;
+	public synthetic fun <init> (IZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIgnoreWait ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/IgnoreWaitRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/IgnoreWaitRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageByNameInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageByNameInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageByNameInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ImageByNameInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ImageByNameInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContext ()Ljava/lang/String;
+	public final fun getFileLength ()J
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTheme ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageByNameInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ImageByNameInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageByNameInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageByNameInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageByNameInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageByNameInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageFormat : java/lang/Enum {
+	public static final field BMP Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageFormat$Companion;
+	public static final field GIF Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public static final field JPG Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public static final field PNG Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public static final field WEBP Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageFormat;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageFormat$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageFormat$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageFormat;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageFormat$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageInfo$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;JLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;J)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/ImageType;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()J
+	public final fun copy (Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;J)Lorg/jellyfin/sdk/model/api/ImageInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ImageInfo;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;JILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ImageInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlurHash ()Ljava/lang/String;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getImageIndex ()Ljava/lang/Integer;
+	public final fun getImageTag ()Ljava/lang/String;
+	public final fun getImageType ()Lorg/jellyfin/sdk/model/api/ImageType;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getSize ()J
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ImageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageOption {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageOption$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/ImageType;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/ImageType;II)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/ImageType;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Lorg/jellyfin/sdk/model/api/ImageType;II)Lorg/jellyfin/sdk/model/api/ImageOption;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ImageOption;Lorg/jellyfin/sdk/model/api/ImageType;IIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ImageOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLimit ()I
+	public final fun getMinWidth ()I
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/ImageType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageOption;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ImageOption$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageOption$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageOption;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageOption;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageOption$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageOrientation : java/lang/Enum {
+	public static final field BOTTOM_LEFT Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static final field BOTTOM_RIGHT Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageOrientation$Companion;
+	public static final field LEFT_BOTTOM Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static final field LEFT_TOP Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static final field RIGHT_BOTTOM Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static final field RIGHT_TOP Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static final field TOP_LEFT Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static final field TOP_RIGHT Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageOrientation;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageOrientation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageOrientation$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageOrientation;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageOrientation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageProviderInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageProviderInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/ImageProviderInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ImageProviderInfo;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ImageProviderInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSupportedImages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageProviderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ImageProviderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageProviderInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageProviderInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageProviderInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageProviderInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageSavingConvention : java/lang/Enum {
+	public static final field COMPATIBLE Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageSavingConvention$Companion;
+	public static final field LEGACY Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageSavingConvention$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageSavingConvention$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageSavingConvention;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageSavingConvention$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageType : java/lang/Enum {
+	public static final field ART Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field BACKDROP Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field BANNER Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field BOX Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field BOX_REAR Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field CHAPTER Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageType$Companion;
+	public static final field DISC Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field LOGO Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field MENU Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field PRIMARY Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field PROFILE Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field SCREENSHOT Lorg/jellyfin/sdk/model/api/ImageType;
+	public static final field THUMB Lorg/jellyfin/sdk/model/api/ImageType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageType;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ImageType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ImageType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/InstallationInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/InstallationInfo$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PackageInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PackageInfo;)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PackageInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/Version;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lorg/jellyfin/sdk/model/api/PackageInfo;
+	public final fun copy (Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PackageInfo;)Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/InstallationInfo;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PackageInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChangelog ()Ljava/lang/String;
+	public final fun getChecksum ()Ljava/lang/String;
+	public final fun getGuid ()Ljava/util/UUID;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPackageInfo ()Lorg/jellyfin/sdk/model/api/PackageInfo;
+	public final fun getSourceUrl ()Ljava/lang/String;
+	public final fun getVersion ()Lorg/jellyfin/sdk/model/api/Version;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/InstallationInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/InstallationInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/InstallationInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/InstallationInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/InstallationInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/IsoType : java/lang/Enum {
+	public static final field BLU_RAY Lorg/jellyfin/sdk/model/api/IsoType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/IsoType$Companion;
+	public static final field DVD Lorg/jellyfin/sdk/model/api/IsoType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/IsoType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/IsoType;
+}
+
+public final class org/jellyfin/sdk/model/api/IsoType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/IsoType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/IsoType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/IsoType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/IsoType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemCounts {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ItemCounts$Companion;
+	public fun <init> (IIIIIIIIIIII)V
+	public synthetic fun <init> (IIIIIIIIIIIIILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()I
+	public final fun component11 ()I
+	public final fun component12 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (IIIIIIIIIIII)Lorg/jellyfin/sdk/model/api/ItemCounts;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ItemCounts;IIIIIIIIIIIIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ItemCounts;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlbumCount ()I
+	public final fun getArtistCount ()I
+	public final fun getBookCount ()I
+	public final fun getBoxSetCount ()I
+	public final fun getEpisodeCount ()I
+	public final fun getItemCount ()I
+	public final fun getMovieCount ()I
+	public final fun getMusicVideoCount ()I
+	public final fun getProgramCount ()I
+	public final fun getSeriesCount ()I
+	public final fun getSongCount ()I
+	public final fun getTrailerCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ItemCounts;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ItemCounts$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ItemCounts$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ItemCounts;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ItemCounts;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemCounts$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemFields : java/lang/Enum {
+	public static final field AIR_TIME Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field BASIC_SYNC_INFO Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CAN_DELETE Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CAN_DOWNLOAD Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CHANNEL_IMAGE Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CHANNEL_INFO Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CHAPTERS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CHILD_COUNT Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CUMULATIVE_RUN_TIME_TICKS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field CUSTOM_RATING Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ItemFields$Companion;
+	public static final field DATE_CREATED Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field DATE_LAST_MEDIA_ADDED Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field DATE_LAST_REFRESHED Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field DATE_LAST_SAVED Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field DISPLAY_PREFERENCES_ID Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field ENABLE_MEDIA_SOURCE_DISPLAY Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field ETAG Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field EXTERNAL_ETAG Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field EXTERNAL_SERIES_ID Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field EXTERNAL_URLS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field EXTRA_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field GENRES Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field HEIGHT Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field HOME_PAGE_URL Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field INHERITED_PARENTAL_RATING_VALUE Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field IS_HD Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field ITEM_COUNTS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field LOCAL_TRAILER_COUNT Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field MEDIA_SOURCES Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field MEDIA_SOURCE_COUNT Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field MEDIA_STREAMS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field ORIGINAL_TITLE Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field OVERVIEW Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PARENT_ID Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PATH Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PEOPLE Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PLAY_ACCESS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PRESENTATION_UNIQUE_KEY Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PRIMARY_IMAGE_ASPECT_RATIO Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PRODUCTION_LOCATIONS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field PROVIDER_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field RECURSIVE_ITEM_COUNT Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field REFRESH_STATE Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field REMOTE_TRAILERS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SCREENSHOT_IMAGE_TAGS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SEASON_USER_DATA Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SERIES_PRESENTATION_UNIQUE_KEY Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SERIES_PRIMARY_IMAGE Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SERIES_STUDIO Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SERVICE_NAME Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SETTINGS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SORT_NAME Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SPECIAL_EPISODE_NUMBERS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SPECIAL_FEATURE_COUNT Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field STUDIOS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field SYNC_INFO Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field TAGLINES Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field TAGS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field THEME_SONG_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field THEME_VIDEO_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field WIDTH Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ItemFields;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemFields$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ItemFields$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ItemFields;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ItemFields;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemFields$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemFilter : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ItemFilter$Companion;
+	public static final field DISLIKES Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field IS_FAVORITE Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field IS_FAVORITE_OR_LIKES Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field IS_FOLDER Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field IS_NOT_FOLDER Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field IS_PLAYED Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field IS_RESUMABLE Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field IS_UNPLAYED Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static final field LIKES Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ItemFilter;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemFilter$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ItemFilter$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ItemFilter;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ItemFilter$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/JoinGroupRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/JoinGroupRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/JoinGroupRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/KeepUntil : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/KeepUntil$Companion;
+	public static final field UNTIL_DATE Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public static final field UNTIL_DELETED Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public static final field UNTIL_SPACE_NEEDED Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public static final field UNTIL_WATCHED Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/KeepUntil;
+}
+
+public final class org/jellyfin/sdk/model/api/KeepUntil$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/KeepUntil$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/KeepUntil;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/KeepUntil$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptionInfoDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultEnabled ()Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptionInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptionInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptions {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LibraryOptions$Companion;
+	public synthetic fun <init> (IZZZZLjava/util/List;ZZZZZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZLjava/util/List;ZZLjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZZZZLjava/util/List;ZZZZZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZLjava/util/List;ZZLjava/util/List;)V
+	public synthetic fun <init> (ZZZZLjava/util/List;ZZZZZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZLjava/util/List;ZZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Z
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component20 ()Z
+	public final fun component21 ()Z
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Z
+	public final fun component24 ()Z
+	public final fun component25 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (ZZZZLjava/util/List;ZZZZZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZLjava/util/List;ZZLjava/util/List;)Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LibraryOptions;ZZZZLjava/util/List;ZZZZZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZLjava/util/List;ZZLjava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutomaticRefreshIntervalDays ()I
+	public final fun getDisabledLocalMetadataReaders ()Ljava/util/List;
+	public final fun getDisabledSubtitleFetchers ()Ljava/util/List;
+	public final fun getEnableAutomaticSeriesGrouping ()Z
+	public final fun getEnableChapterImageExtraction ()Z
+	public final fun getEnableEmbeddedEpisodeInfos ()Z
+	public final fun getEnableEmbeddedTitles ()Z
+	public final fun getEnableInternetProviders ()Z
+	public final fun getEnablePhotos ()Z
+	public final fun getEnableRealtimeMonitor ()Z
+	public final fun getExtractChapterImagesDuringLibraryScan ()Z
+	public final fun getLocalMetadataReaderOrder ()Ljava/util/List;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataSavers ()Ljava/util/List;
+	public final fun getPathInfos ()Ljava/util/List;
+	public final fun getPreferredMetadataLanguage ()Ljava/lang/String;
+	public final fun getRequirePerfectSubtitleMatch ()Z
+	public final fun getSaveLocalMetadata ()Z
+	public final fun getSaveSubtitlesWithMedia ()Z
+	public final fun getSeasonZeroDisplayName ()Ljava/lang/String;
+	public final fun getSkipSubtitlesIfAudioTrackMatches ()Z
+	public final fun getSkipSubtitlesIfEmbeddedSubtitlesPresent ()Z
+	public final fun getSubtitleDownloadLanguages ()Ljava/util/List;
+	public final fun getSubtitleFetcherOrder ()Ljava/util/List;
+	public final fun getTypeOptions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryOptions$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LibraryOptions;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptionsResultDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMetadataReaders ()Ljava/util/List;
+	public final fun getMetadataSavers ()Ljava/util/List;
+	public final fun getSubtitleFetchers ()Ljava/util/List;
+	public final fun getTypeOptions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptionsResultDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryOptionsResultDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryTypeOptionsDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultImageOptions ()Ljava/util/List;
+	public final fun getImageFetchers ()Ljava/util/List;
+	public final fun getMetadataFetchers ()Ljava/util/List;
+	public final fun getSupportedImageTypes ()Ljava/util/List;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryTypeOptionsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryTypeOptionsDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryUpdateInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Z
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollectionFolders ()Ljava/util/List;
+	public final fun getFoldersAddedTo ()Ljava/util/List;
+	public final fun getFoldersRemovedFrom ()Ljava/util/List;
+	public final fun getItemsAdded ()Ljava/util/List;
+	public final fun getItemsRemoved ()Ljava/util/List;
+	public final fun getItemsUpdated ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryUpdateInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LibraryUpdateInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ListingsProviderInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ListingsProviderInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelMappings ()Ljava/util/List;
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getEnableAllTuners ()Z
+	public final fun getEnabledTuners ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKidsCategories ()Ljava/util/List;
+	public final fun getListingsId ()Ljava/lang/String;
+	public final fun getMovieCategories ()Ljava/util/List;
+	public final fun getMoviePrefix ()Ljava/lang/String;
+	public final fun getNewsCategories ()Ljava/util/List;
+	public final fun getPassword ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPreferredLanguage ()Ljava/lang/String;
+	public final fun getSportsCategories ()Ljava/util/List;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUserAgent ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
+	public final fun getZipCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ListingsProviderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ListingsProviderInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ListingsProviderInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveStreamResponse {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LiveStreamResponse$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/MediaSourceInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/MediaSourceInfo;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/MediaSourceInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/MediaSourceInfo;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/MediaSourceInfo;)Lorg/jellyfin/sdk/model/api/LiveStreamResponse;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LiveStreamResponse;Lorg/jellyfin/sdk/model/api/MediaSourceInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LiveStreamResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMediaSource ()Lorg/jellyfin/sdk/model/api/MediaSourceInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LiveStreamResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LiveStreamResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveStreamResponse$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveStreamResponse;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LiveStreamResponse;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveStreamResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LiveTvInfo$Companion;
+	public synthetic fun <init> (ILjava/util/List;ZLjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;ZLjava/util/List;)Lorg/jellyfin/sdk/model/api/LiveTvInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LiveTvInfo;Ljava/util/List;ZLjava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LiveTvInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabledUsers ()Ljava/util/List;
+	public final fun getServices ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isEnabled ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LiveTvInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveTvInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveTvInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LiveTvInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvServiceInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;)Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHasUpdateAvailable ()Z
+	public final fun getHomePageUrl ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStatus ()Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public final fun getStatusMessage ()Ljava/lang/String;
+	public final fun getTuners ()Ljava/util/List;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isVisible ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvServiceInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvServiceInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus$Companion;
+	public static final field OK Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public static final field UNAVAILABLE Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LocalizationOption {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LocalizationOption$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LocalizationOption;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LocalizationOption;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LocalizationOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LocalizationOption;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LocalizationOption$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LocalizationOption$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LocalizationOption;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LocalizationOption;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LocalizationOption$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LocationType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LocationType$Companion;
+	public static final field FILE_SYSTEM Lorg/jellyfin/sdk/model/api/LocationType;
+	public static final field OFFLINE Lorg/jellyfin/sdk/model/api/LocationType;
+	public static final field REMOTE Lorg/jellyfin/sdk/model/api/LocationType;
+	public static final field VIRTUAL Lorg/jellyfin/sdk/model/api/LocationType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LocationType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/LocationType;
+}
+
+public final class org/jellyfin/sdk/model/api/LocationType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LocationType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LocationType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LocationType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LocationType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LogFile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LogFile$Companion;
+	public synthetic fun <init> (ILjava/time/LocalDateTime;Ljava/time/LocalDateTime;JLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;JLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/time/LocalDateTime;
+	public final fun component2 ()Ljava/time/LocalDateTime;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;JLjava/lang/String;)Lorg/jellyfin/sdk/model/api/LogFile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/LogFile;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;JLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/LogFile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDateCreated ()Ljava/time/LocalDateTime;
+	public final fun getDateModified ()Ljava/time/LocalDateTime;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSize ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LogFile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/LogFile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LogFile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LogFile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LogFile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LogFile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LogLevel : java/lang/Enum {
+	public static final field CRITICAL Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/LogLevel$Companion;
+	public static final field DEBUG Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static final field ERROR Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static final field INFORMATION Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static final field NONE Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static final field TRACE Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static final field WARNING Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LogLevel;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/LogLevel;
+}
+
+public final class org/jellyfin/sdk/model/api/LogLevel$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LogLevel$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LogLevel;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/LogLevel;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/LogLevel$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaAttachment {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaAttachment$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaAttachment;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaAttachment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaAttachment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCodec ()Ljava/lang/String;
+	public final fun getCodecTag ()Ljava/lang/String;
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getDeliveryUrl ()Ljava/lang/String;
+	public final fun getFileName ()Ljava/lang/String;
+	public final fun getIndex ()I
+	public final fun getMimeType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaAttachment;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaAttachment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaAttachment$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaAttachment;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaAttachment;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaAttachment$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaEncoderPathDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPathType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaEncoderPathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaEncoderPathDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaPathDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaPathDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/MediaPathInfo;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;)Lorg/jellyfin/sdk/model/api/MediaPathDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaPathDto;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaPathDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPathInfo ()Lorg/jellyfin/sdk/model/api/MediaPathInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaPathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaPathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaPathDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaPathDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaPathDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaPathDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaPathInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaPathInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaPathInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaPathInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaPathInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNetworkPath ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaPathInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaPathInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaPathInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaPathInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaPathInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaPathInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaProtocol : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaProtocol$Companion;
+	public static final field FILE Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static final field FTP Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static final field HTTP Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static final field RTMP Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static final field RTP Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static final field RTSP Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static final field UDP Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/MediaProtocol;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaProtocol$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaProtocol$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaProtocol;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaProtocol$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaSourceInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaSourceInfo$Companion;
+	public synthetic fun <init> (IILorg/jellyfin/sdk/model/api/MediaProtocol;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaProtocol;Lorg/jellyfin/sdk/model/api/MediaSourceType;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Long;ZZZZZZZZZLjava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;ZZLorg/jellyfin/sdk/model/api/VideoType;Lorg/jellyfin/sdk/model/api/IsoType;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/MediaProtocol;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaProtocol;Lorg/jellyfin/sdk/model/api/MediaSourceType;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Long;ZZZZZZZZZLjava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;ZZLorg/jellyfin/sdk/model/api/VideoType;Lorg/jellyfin/sdk/model/api/IsoType;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/MediaProtocol;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaProtocol;Lorg/jellyfin/sdk/model/api/MediaSourceType;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Long;ZZZZZZZZZLjava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;ZZLorg/jellyfin/sdk/model/api/VideoType;Lorg/jellyfin/sdk/model/api/IsoType;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13 ()Z
+	public final fun component14 ()Z
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Z
+	public final fun component18 ()Z
+	public final fun component19 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Z
+	public final fun component21 ()Z
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Z
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component25 ()Ljava/lang/Integer;
+	public final fun component26 ()Z
+	public final fun component27 ()Z
+	public final fun component28 ()Lorg/jellyfin/sdk/model/api/VideoType;
+	public final fun component29 ()Lorg/jellyfin/sdk/model/api/IsoType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component30 ()Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public final fun component31 ()Ljava/util/List;
+	public final fun component32 ()Ljava/util/List;
+	public final fun component33 ()Ljava/util/List;
+	public final fun component34 ()Ljava/lang/Integer;
+	public final fun component35 ()Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public final fun component36 ()Ljava/util/Map;
+	public final fun component37 ()Ljava/lang/String;
+	public final fun component38 ()Ljava/lang/String;
+	public final fun component39 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component40 ()Ljava/lang/Integer;
+	public final fun component41 ()Ljava/lang/Integer;
+	public final fun component42 ()Ljava/lang/Integer;
+	public final fun component5 ()Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public final fun component6 ()Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/MediaProtocol;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaProtocol;Lorg/jellyfin/sdk/model/api/MediaSourceType;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Long;ZZZZZZZZZLjava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;ZZLorg/jellyfin/sdk/model/api/VideoType;Lorg/jellyfin/sdk/model/api/IsoType;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lorg/jellyfin/sdk/model/api/MediaSourceInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaSourceInfo;Lorg/jellyfin/sdk/model/api/MediaProtocol;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaProtocol;Lorg/jellyfin/sdk/model/api/MediaSourceType;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Long;ZZZZZZZZZLjava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;ZZLorg/jellyfin/sdk/model/api/VideoType;Lorg/jellyfin/sdk/model/api/IsoType;Lorg/jellyfin/sdk/model/api/Video3dFormat;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaSourceInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnalyzeDurationMs ()Ljava/lang/Integer;
+	public final fun getBitrate ()Ljava/lang/Integer;
+	public final fun getBufferMs ()Ljava/lang/Integer;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getDefaultAudioStreamIndex ()Ljava/lang/Integer;
+	public final fun getDefaultSubtitleStreamIndex ()Ljava/lang/Integer;
+	public final fun getETag ()Ljava/lang/String;
+	public final fun getEncoderPath ()Ljava/lang/String;
+	public final fun getEncoderProtocol ()Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public final fun getFormats ()Ljava/util/List;
+	public final fun getGenPtsInput ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIgnoreDts ()Z
+	public final fun getIgnoreIndex ()Z
+	public final fun getIsoType ()Lorg/jellyfin/sdk/model/api/IsoType;
+	public final fun getLiveStreamId ()Ljava/lang/String;
+	public final fun getMediaAttachments ()Ljava/util/List;
+	public final fun getMediaStreams ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOpenToken ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getProtocol ()Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public final fun getReadAtNativeFramerate ()Z
+	public final fun getRequiredHttpHeaders ()Ljava/util/Map;
+	public final fun getRequiresClosing ()Z
+	public final fun getRequiresLooping ()Z
+	public final fun getRequiresOpening ()Z
+	public final fun getRunTimeTicks ()Ljava/lang/Long;
+	public final fun getSize ()Ljava/lang/Long;
+	public final fun getSupportsDirectPlay ()Z
+	public final fun getSupportsDirectStream ()Z
+	public final fun getSupportsProbing ()Z
+	public final fun getSupportsTranscoding ()Z
+	public final fun getTimestamp ()Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public final fun getTranscodingContainer ()Ljava/lang/String;
+	public final fun getTranscodingSubProtocol ()Ljava/lang/String;
+	public final fun getTranscodingUrl ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public final fun getVideo3dFormat ()Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public final fun getVideoType ()Lorg/jellyfin/sdk/model/api/VideoType;
+	public fun hashCode ()I
+	public final fun isInfiniteStream ()Z
+	public final fun isRemote ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaSourceInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaSourceInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaSourceInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaSourceInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaSourceInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaSourceInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaSourceType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaSourceType$Companion;
+	public static final field DEFAULT Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public static final field GROUPING Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public static final field PLACEHOLDER Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/MediaSourceType;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaSourceType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaSourceType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaSourceType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaSourceType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaStream {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaStream$Companion;
+	public synthetic fun <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaStreamType;Ljava/lang/String;ILjava/lang/Integer;ZLorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/Boolean;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaStreamType;Ljava/lang/String;ILjava/lang/Integer;ZLorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/Boolean;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaStreamType;Ljava/lang/String;ILjava/lang/Integer;ZLorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/Boolean;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Z
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/Integer;
+	public final fun component22 ()Ljava/lang/Integer;
+	public final fun component23 ()Ljava/lang/Integer;
+	public final fun component24 ()Ljava/lang/Integer;
+	public final fun component25 ()Ljava/lang/Integer;
+	public final fun component26 ()Ljava/lang/Integer;
+	public final fun component27 ()Z
+	public final fun component28 ()Z
+	public final fun component29 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component30 ()Ljava/lang/Integer;
+	public final fun component31 ()Ljava/lang/Float;
+	public final fun component32 ()Ljava/lang/Float;
+	public final fun component33 ()Ljava/lang/String;
+	public final fun component34 ()Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public final fun component35 ()Ljava/lang/String;
+	public final fun component36 ()I
+	public final fun component37 ()Ljava/lang/Integer;
+	public final fun component38 ()Z
+	public final fun component39 ()Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component40 ()Ljava/lang/String;
+	public final fun component41 ()Ljava/lang/Boolean;
+	public final fun component42 ()Z
+	public final fun component43 ()Z
+	public final fun component44 ()Ljava/lang/String;
+	public final fun component45 ()Ljava/lang/String;
+	public final fun component46 ()Ljava/lang/Double;
+	public final fun component47 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaStreamType;Ljava/lang/String;ILjava/lang/Integer;ZLorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/Boolean;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;)Lorg/jellyfin/sdk/model/api/MediaStream;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaStream;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaStreamType;Ljava/lang/String;ILjava/lang/Integer;ZLorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/Boolean;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaStream;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAspectRatio ()Ljava/lang/String;
+	public final fun getAverageFrameRate ()Ljava/lang/Float;
+	public final fun getBitDepth ()Ljava/lang/Integer;
+	public final fun getBitRate ()Ljava/lang/Integer;
+	public final fun getChannelLayout ()Ljava/lang/String;
+	public final fun getChannels ()Ljava/lang/Integer;
+	public final fun getCodec ()Ljava/lang/String;
+	public final fun getCodecTag ()Ljava/lang/String;
+	public final fun getCodecTimeBase ()Ljava/lang/String;
+	public final fun getColorPrimaries ()Ljava/lang/String;
+	public final fun getColorRange ()Ljava/lang/String;
+	public final fun getColorSpace ()Ljava/lang/String;
+	public final fun getColorTransfer ()Ljava/lang/String;
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getDeliveryMethod ()Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public final fun getDeliveryUrl ()Ljava/lang/String;
+	public final fun getDisplayTitle ()Ljava/lang/String;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getIndex ()I
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLevel ()Ljava/lang/Double;
+	public final fun getLocalizedDefault ()Ljava/lang/String;
+	public final fun getLocalizedForced ()Ljava/lang/String;
+	public final fun getLocalizedUndefined ()Ljava/lang/String;
+	public final fun getNalLengthSize ()Ljava/lang/String;
+	public final fun getPacketLength ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPixelFormat ()Ljava/lang/String;
+	public final fun getProfile ()Ljava/lang/String;
+	public final fun getRealFrameRate ()Ljava/lang/Float;
+	public final fun getRefFrames ()Ljava/lang/Integer;
+	public final fun getSampleRate ()Ljava/lang/Integer;
+	public final fun getScore ()Ljava/lang/Integer;
+	public final fun getSupportsExternalStream ()Z
+	public final fun getTimeBase ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public final fun getVideoRange ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAnamorphic ()Ljava/lang/Boolean;
+	public final fun isAvc ()Ljava/lang/Boolean;
+	public final fun isDefault ()Z
+	public final fun isExternal ()Z
+	public final fun isExternalUrl ()Ljava/lang/Boolean;
+	public final fun isForced ()Z
+	public final fun isInterlaced ()Z
+	public final fun isTextSubtitleStream ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaStream;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaStream$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaStream$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaStream;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaStream;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaStream$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaStreamType : java/lang/Enum {
+	public static final field AUDIO Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaStreamType$Companion;
+	public static final field EMBEDDED_IMAGE Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public static final field SUBTITLE Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public static final field VIDEO Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/MediaStreamType;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaStreamType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaStreamType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaStreamType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaStreamType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUpdateInfoDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdates ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUpdateInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUpdateInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUpdateInfoPathDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getUpdateType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUpdateInfoPathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUpdateInfoPathDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUrl {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaUrl$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaUrl;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MediaUrl;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MediaUrl;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaUrl;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUrl$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaUrl$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaUrl;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MediaUrl;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MediaUrl$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataEditorInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MetadataEditorInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContentType ()Ljava/lang/String;
+	public final fun getContentTypeOptions ()Ljava/util/List;
+	public final fun getCountries ()Ljava/util/List;
+	public final fun getCultures ()Ljava/util/List;
+	public final fun getExternalIdInfos ()Ljava/util/List;
+	public final fun getParentalRatingOptions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataEditorInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataEditorInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataEditorInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataField : java/lang/Enum {
+	public static final field CAST Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MetadataField$Companion;
+	public static final field GENRES Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field NAME Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field OFFICIAL_RATING Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field OVERVIEW Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field PRODUCTION_LOCATIONS Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field RUNTIME Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field STUDIOS Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static final field TAGS Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataField;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/MetadataField;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataField$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataField$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataField;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MetadataField;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataField$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataOptions {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MetadataOptions$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/MetadataOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MetadataOptions;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MetadataOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisabledImageFetchers ()Ljava/util/List;
+	public final fun getDisabledMetadataFetchers ()Ljava/util/List;
+	public final fun getDisabledMetadataSavers ()Ljava/util/List;
+	public final fun getImageFetcherOrder ()Ljava/util/List;
+	public final fun getItemType ()Ljava/lang/String;
+	public final fun getLocalMetadataReaderOrder ()Ljava/util/List;
+	public final fun getMetadataFetcherOrder ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MetadataOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataOptions$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataOptions;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MetadataOptions;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataRefreshMode : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MetadataRefreshMode$Companion;
+	public static final field DEFAULT Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public static final field FULL_REFRESH Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public static final field NONE Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public static final field VALIDATION_ONLY Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataRefreshMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataRefreshMode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MetadataRefreshMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MovePlaylistItemRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;I)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/UUID;I)Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;Ljava/util/UUID;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNewIndex ()I
+	public final fun getPlaylistItemId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MovePlaylistItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MovePlaylistItemRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MovieInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MovieInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)Lorg/jellyfin/sdk/model/api/MovieInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MovieInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MovieInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MovieInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MovieInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MovieInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MovieInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MovieInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MovieInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/MovieInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/MovieInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/MovieInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/MovieInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/MovieInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/MovieInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/MovieInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MusicVideoInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MusicVideoInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;)Lorg/jellyfin/sdk/model/api/MusicVideoInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MusicVideoInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MusicVideoInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArtists ()Ljava/util/List;
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MusicVideoInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MusicVideoInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MusicVideoInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MusicVideoInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MusicVideoInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MusicVideoInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/MusicVideoInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/MusicVideoInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/MusicVideoInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/MusicVideoInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/MusicVideoInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/MusicVideoInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/MusicVideoInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NameGuidPair {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NameGuidPair$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/UUID;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/UUID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun copy (Ljava/lang/String;Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/NameGuidPair;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NameGuidPair;Ljava/lang/String;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NameGuidPair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NameGuidPair;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NameGuidPair$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NameGuidPair$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NameGuidPair;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NameGuidPair;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NameGuidPair$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NameIdPair {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NameIdPair$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/NameIdPair;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NameIdPair;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NameIdPair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NameIdPair;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NameIdPair$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NameIdPair$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NameIdPair;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NameIdPair;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NameIdPair$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NameValuePair {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NameValuePair$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/NameValuePair;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NameValuePair;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NameValuePair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NameValuePair;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NameValuePair$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NameValuePair$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NameValuePair;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NameValuePair;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NameValuePair$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NewGroupRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NewGroupRequestDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NewGroupRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NewGroupRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NewGroupRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NextItemRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NextItemRequestDto$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/NextItemRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NextItemRequestDto;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NextItemRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlaylistItemId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NextItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NextItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NextItemRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NextItemRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NextItemRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NextItemRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NotificationDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/time/LocalDateTime;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;)Lorg/jellyfin/sdk/model/api/NotificationDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NotificationDto;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/NotificationLevel;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NotificationDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Ljava/time/LocalDateTime;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLevel ()Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isRead ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NotificationDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationLevel : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NotificationLevel$Companion;
+	public static final field ERROR Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public static final field NORMAL Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public static final field WARNING Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/NotificationLevel;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationLevel$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationLevel$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NotificationLevel;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationLevel$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationResultDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NotificationResultDto$Companion;
+	public synthetic fun <init> (ILjava/util/List;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;I)V
+	public synthetic fun <init> (Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/List;I)Lorg/jellyfin/sdk/model/api/NotificationResultDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NotificationResultDto;Ljava/util/List;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NotificationResultDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNotifications ()Ljava/util/List;
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationResultDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationResultDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationResultDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationResultDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NotificationResultDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationResultDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationTypeInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NotificationTypeInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Z)Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getEnabled ()Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isBasedOnUserEvent ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationTypeInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationTypeInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationTypeInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationsSummaryDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto$Companion;
+	public synthetic fun <init> (IILorg/jellyfin/sdk/model/api/NotificationLevel;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ILorg/jellyfin/sdk/model/api/NotificationLevel;)V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/NotificationLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun copy (ILorg/jellyfin/sdk/model/api/NotificationLevel;)Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;ILorg/jellyfin/sdk/model/api/NotificationLevel;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxUnreadNotificationLevel ()Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun getUnreadCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationsSummaryDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/NotificationsSummaryDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ObjectGroupUpdate {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/GroupUpdateType;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/GroupUpdateType;Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/GroupUpdateType;Lkotlinx/serialization/json/JsonElement;)Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/GroupUpdateType;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getGroupId ()Ljava/util/UUID;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ObjectGroupUpdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ObjectGroupUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/OpenLiveStreamDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/util/UUID;
+	public final fun copy (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioStreamIndex ()Ljava/lang/Integer;
+	public final fun getDeviceProfile ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun getDirectPlayProtocols ()Ljava/util/List;
+	public final fun getEnableDirectPlay ()Ljava/lang/Boolean;
+	public final fun getEnableDirectStream ()Ljava/lang/Boolean;
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getMaxAudioChannels ()Ljava/lang/Integer;
+	public final fun getMaxStreamingBitrate ()Ljava/lang/Integer;
+	public final fun getOpenToken ()Ljava/lang/String;
+	public final fun getPlaySessionId ()Ljava/lang/String;
+	public final fun getStartTimeTicks ()Ljava/lang/Long;
+	public final fun getSubtitleStreamIndex ()Ljava/lang/Integer;
+	public final fun getUserId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/OpenLiveStreamDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/OpenLiveStreamDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PackageInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PackageInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PackageInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PackageInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PackageInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getGuid ()Ljava/lang/String;
+	public final fun getImageUrl ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getOwner ()Ljava/lang/String;
+	public final fun getVersions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PackageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PackageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PackageInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PackageInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PackageInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PackageInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ParentalRating {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ParentalRating$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;I)V
+	public synthetic fun <init> (Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lorg/jellyfin/sdk/model/api/ParentalRating;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ParentalRating;Ljava/lang/String;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ParentalRating;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ParentalRating;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ParentalRating$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ParentalRating$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ParentalRating;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ParentalRating;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ParentalRating$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PathSubstitution {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PathSubstitution$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PathSubstitution;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PathSubstitution;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PathSubstitution;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()Ljava/lang/String;
+	public final fun getTo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PathSubstitution;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PathSubstitution$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PathSubstitution$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PathSubstitution;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PathSubstitution;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PathSubstitution$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PersonLookupInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PersonLookupInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)Lorg/jellyfin/sdk/model/api/PersonLookupInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PersonLookupInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PersonLookupInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PersonLookupInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PersonLookupInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PersonLookupInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PersonLookupInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PersonLookupInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PersonLookupInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/PersonLookupInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/PersonLookupInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/PersonLookupInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/PersonLookupInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/PersonLookupInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/PersonLookupInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/PersonLookupInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PinRedeemResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PinRedeemResult$Companion;
+	public synthetic fun <init> (IZLjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLjava/util/List;)V
+	public synthetic fun <init> (ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/List;)Lorg/jellyfin/sdk/model/api/PinRedeemResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PinRedeemResult;ZLjava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PinRedeemResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSuccess ()Z
+	public final fun getUsersReset ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PinRedeemResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PinRedeemResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PinRedeemResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PinRedeemResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PinRedeemResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PinRedeemResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PingRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PingRequestDto$Companion;
+	public synthetic fun <init> (IJLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lorg/jellyfin/sdk/model/api/PingRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PingRequestDto;JILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PingRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPing ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PingRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PingRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PingRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PingRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PingRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PingRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayAccess : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlayAccess$Companion;
+	public static final field FULL Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public static final field NONE Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlayAccess;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayAccess$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayAccess$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlayAccess;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayAccess$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayCommand : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlayCommand$Companion;
+	public static final field PLAY_INSTANT_MIX Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public static final field PLAY_LAST Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public static final field PLAY_NEXT Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public static final field PLAY_NOW Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public static final field PLAY_SHUFFLE Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlayCommand;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayCommand$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlayCommand;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayCommand$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayMethod : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlayMethod$Companion;
+	public static final field DIRECT_PLAY Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public static final field DIRECT_STREAM Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public static final field TRANSCODE Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlayMethod;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayMethod$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayMethod$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlayMethod;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayMethod$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayRequest {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlayRequest$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayCommand;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayCommand;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayCommand;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public final fun component4 ()Ljava/util/UUID;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/util/List;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayCommand;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;)Lorg/jellyfin/sdk/model/api/PlayRequest;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlayRequest;Ljava/util/List;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/PlayCommand;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlayRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioStreamIndex ()Ljava/lang/Integer;
+	public final fun getControllingUserId ()Ljava/util/UUID;
+	public final fun getItemIds ()Ljava/util/List;
+	public final fun getMediaSourceId ()Ljava/lang/String;
+	public final fun getPlayCommand ()Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public final fun getStartIndex ()Ljava/lang/Integer;
+	public final fun getStartPositionTicks ()Ljava/lang/Long;
+	public final fun getSubtitleStreamIndex ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlayRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlayRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayRequest$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayRequest;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlayRequest;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlayRequestDto$Companion;
+	public synthetic fun <init> (ILjava/util/List;IJLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;IJ)V
+	public synthetic fun <init> (Ljava/util/List;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun copy (Ljava/util/List;IJ)Lorg/jellyfin/sdk/model/api/PlayRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlayRequestDto;Ljava/util/List;IJILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlayRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlayingItemPosition ()I
+	public final fun getPlayingQueue ()Ljava/util/List;
+	public final fun getStartPositionTicks ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlayRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlayRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlayRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackErrorCode : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaybackErrorCode$Companion;
+	public static final field NOT_ALLOWED Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public static final field NO_COMPATIBLE_STREAM Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public static final field RATE_LIMIT_EXCEEDED Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackErrorCode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackErrorCode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackErrorCode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackInfoDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaybackInfoDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun copy (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DeviceProfile;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowAudioStreamCopy ()Ljava/lang/Boolean;
+	public final fun getAllowVideoStreamCopy ()Ljava/lang/Boolean;
+	public final fun getAudioStreamIndex ()Ljava/lang/Integer;
+	public final fun getAutoOpenLiveStream ()Ljava/lang/Boolean;
+	public final fun getDeviceProfile ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun getEnableDirectPlay ()Ljava/lang/Boolean;
+	public final fun getEnableDirectStream ()Ljava/lang/Boolean;
+	public final fun getEnableTranscoding ()Ljava/lang/Boolean;
+	public final fun getLiveStreamId ()Ljava/lang/String;
+	public final fun getMaxAudioChannels ()Ljava/lang/Integer;
+	public final fun getMaxStreamingBitrate ()Ljava/lang/Integer;
+	public final fun getMediaSourceId ()Ljava/lang/String;
+	public final fun getStartTimeTicks ()Ljava/lang/Long;
+	public final fun getSubtitleStreamIndex ()Ljava/lang/Integer;
+	public final fun getUserId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackInfoDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackInfoResponse {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;)Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;Ljava/util/List;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorCode ()Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public final fun getMediaSources ()Ljava/util/List;
+	public final fun getPlaySessionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackInfoResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackInfoResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackProgressInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo$Companion;
+	public synthetic fun <init> (IZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/lang/Integer;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/UUID;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAspectRatio ()Ljava/lang/String;
+	public final fun getAudioStreamIndex ()Ljava/lang/Integer;
+	public final fun getBrightness ()Ljava/lang/Integer;
+	public final fun getCanSeek ()Z
+	public final fun getItem ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getLiveStreamId ()Ljava/lang/String;
+	public final fun getMediaSourceId ()Ljava/lang/String;
+	public final fun getNowPlayingQueue ()Ljava/util/List;
+	public final fun getPlayMethod ()Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun getPlaySessionId ()Ljava/lang/String;
+	public final fun getPlaybackStartTimeTicks ()Ljava/lang/Long;
+	public final fun getPlaylistItemId ()Ljava/lang/String;
+	public final fun getPositionTicks ()Ljava/lang/Long;
+	public final fun getRepeatMode ()Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getSubtitleStreamIndex ()Ljava/lang/Integer;
+	public final fun getVolumeLevel ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isMuted ()Z
+	public final fun isPaused ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackProgressInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackProgressInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackStartInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaybackStartInfo$Companion;
+	public synthetic fun <init> (IZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/lang/Integer;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/UUID;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;ZLorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RepeatMode;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAspectRatio ()Ljava/lang/String;
+	public final fun getAudioStreamIndex ()Ljava/lang/Integer;
+	public final fun getBrightness ()Ljava/lang/Integer;
+	public final fun getCanSeek ()Z
+	public final fun getItem ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getLiveStreamId ()Ljava/lang/String;
+	public final fun getMediaSourceId ()Ljava/lang/String;
+	public final fun getNowPlayingQueue ()Ljava/util/List;
+	public final fun getPlayMethod ()Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun getPlaySessionId ()Ljava/lang/String;
+	public final fun getPlaybackStartTimeTicks ()Ljava/lang/Long;
+	public final fun getPlaylistItemId ()Ljava/lang/String;
+	public final fun getPositionTicks ()Ljava/lang/Long;
+	public final fun getRepeatMode ()Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getSubtitleStreamIndex ()Ljava/lang/Integer;
+	public final fun getVolumeLevel ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isMuted ()Z
+	public final fun isPaused ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackStartInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackStartInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackStartInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackStopInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaybackStopInfo$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailed ()Z
+	public final fun getItem ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getLiveStreamId ()Ljava/lang/String;
+	public final fun getMediaSourceId ()Ljava/lang/String;
+	public final fun getNextMediaType ()Ljava/lang/String;
+	public final fun getNowPlayingQueue ()Ljava/util/List;
+	public final fun getPlaySessionId ()Ljava/lang/String;
+	public final fun getPlaylistItemId ()Ljava/lang/String;
+	public final fun getPositionTicks ()Ljava/lang/Long;
+	public final fun getSessionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackStopInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackStopInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaybackStopInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayerStateInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlayerStateInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/Long;ZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Lorg/jellyfin/sdk/model/api/RepeatMode;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;ZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Lorg/jellyfin/sdk/model/api/RepeatMode;)V
+	public synthetic fun <init> (Ljava/lang/Long;ZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Lorg/jellyfin/sdk/model/api/RepeatMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component10 ()Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun copy (Ljava/lang/Long;ZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Lorg/jellyfin/sdk/model/api/RepeatMode;)Lorg/jellyfin/sdk/model/api/PlayerStateInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlayerStateInfo;Ljava/lang/Long;ZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/PlayMethod;Lorg/jellyfin/sdk/model/api/RepeatMode;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlayerStateInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioStreamIndex ()Ljava/lang/Integer;
+	public final fun getCanSeek ()Z
+	public final fun getMediaSourceId ()Ljava/lang/String;
+	public final fun getPlayMethod ()Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun getPositionTicks ()Ljava/lang/Long;
+	public final fun getRepeatMode ()Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun getSubtitleStreamIndex ()Ljava/lang/Integer;
+	public final fun getVolumeLevel ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isMuted ()Z
+	public final fun isPaused ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlayerStateInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlayerStateInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayerStateInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayerStateInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlayerStateInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlayerStateInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaylistCreationResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaylistCreationResult$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlaylistCreationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaylistCreationResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaylistCreationResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaystateCommand : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaystateCommand$Companion;
+	public static final field FAST_FORWARD Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field NEXT_TRACK Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field PAUSE Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field PLAY_PAUSE Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field PREVIOUS_TRACK Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field REWIND Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field SEEK Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field STOP Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static final field UNPAUSE Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaystateCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaystateCommand$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaystateCommand;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaystateCommand$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaystateRequest {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PlaystateRequest$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/PlaystateCommand;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/PlaystateCommand;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/PlaystateCommand;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/PlaystateCommand;Ljava/lang/Long;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaystateRequest;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PlaystateRequest;Lorg/jellyfin/sdk/model/api/PlaystateCommand;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PlaystateRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommand ()Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public final fun getControllingUserId ()Ljava/lang/String;
+	public final fun getSeekPositionTicks ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaystateRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PlaystateRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaystateRequest$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaystateRequest;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PlaystateRequest;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PlaystateRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PluginInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PluginInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZZLorg/jellyfin/sdk/model/api/PluginStatus;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZZLorg/jellyfin/sdk/model/api/PluginStatus;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZZLorg/jellyfin/sdk/model/api/PluginStatus;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/Version;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/UUID;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public final fun copy (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZZLorg/jellyfin/sdk/model/api/PluginStatus;)Lorg/jellyfin/sdk/model/api/PluginInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PluginInfo;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;ZZLorg/jellyfin/sdk/model/api/PluginStatus;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PluginInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCanUninstall ()Z
+	public final fun getConfigurationFileName ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getHasImage ()Z
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStatus ()Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public final fun getVersion ()Lorg/jellyfin/sdk/model/api/Version;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PluginInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PluginInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PluginInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PluginInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PluginInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PluginInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PluginSecurityInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PluginSecurityInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSupporterKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isMbSupporter ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PluginSecurityInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PluginSecurityInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PluginSecurityInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PluginStatus : java/lang/Enum {
+	public static final field ACTIVE Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PluginStatus$Companion;
+	public static final field DELETED Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static final field DISABLED Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static final field MALFUNCTIONED Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static final field NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static final field RESTART Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static final field SUPERCEDED Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/PluginStatus;
+}
+
+public final class org/jellyfin/sdk/model/api/PluginStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PluginStatus$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PluginStatus;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PluginStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PreviousItemRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlaylistItemId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PreviousItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PreviousItemRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProblemDetails {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ProblemDetails$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProblemDetails;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ProblemDetails;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProblemDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDetail ()Ljava/lang/String;
+	public final fun getInstance ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/Integer;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ProblemDetails;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ProblemDetails$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProblemDetails$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProblemDetails;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ProblemDetails;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProblemDetails$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileCondition {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ProfileCondition$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/ProfileConditionType;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/ProfileConditionType;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/ProfileConditionType;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/ProfileConditionType;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ProfileCondition;Lorg/jellyfin/sdk/model/api/ProfileConditionType;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCondition ()Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public final fun getProperty ()Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isRequired ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ProfileCondition;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileCondition$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProfileCondition$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ProfileCondition;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileCondition$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileConditionType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ProfileConditionType$Companion;
+	public static final field EQUALS Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public static final field EQUALS_ANY Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public static final field GREATER_THAN_EQUAL Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public static final field LESS_THAN_EQUAL Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public static final field NOT_EQUALS Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileConditionType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProfileConditionType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ProfileConditionType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileConditionType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileConditionValue : java/lang/Enum {
+	public static final field AUDIO_BITRATE Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field AUDIO_BIT_DEPTH Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field AUDIO_CHANNELS Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field AUDIO_PROFILE Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field AUDIO_SAMPLE_RATE Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ProfileConditionValue$Companion;
+	public static final field HAS_64_BIT_OFFSETS Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field HEIGHT Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field IS_ANAMORPHIC Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field IS_AVC Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field IS_INTERLACED Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field IS_SECONDARY_AUDIO Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field NUM_AUDIO_STREAMS Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field NUM_VIDEO_STREAMS Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field PACKET_LENGTH Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field REF_FRAMES Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field VIDEO_BITRATE Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field VIDEO_BIT_DEPTH Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field VIDEO_CODEC_TAG Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field VIDEO_FRAMERATE Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field VIDEO_LEVEL Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field VIDEO_PROFILE Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field VIDEO_TIMESTAMP Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static final field WIDTH Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileConditionValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProfileConditionValue$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProfileConditionValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProgramAudio : java/lang/Enum {
+	public static final field ATMOS Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ProgramAudio$Companion;
+	public static final field DOLBY Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public static final field DOLBY_DIGITAL Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public static final field MONO Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public static final field STEREO Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public static final field THX Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ProgramAudio;
+}
+
+public final class org/jellyfin/sdk/model/api/ProgramAudio$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProgramAudio$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ProgramAudio;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ProgramAudio$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PublicSystemInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/PublicSystemInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLocalAddress ()Ljava/lang/String;
+	public final fun getOperatingSystem ()Ljava/lang/String;
+	public final fun getProductName ()Ljava/lang/String;
+	public final fun getServerName ()Ljava/lang/String;
+	public final fun getStartupWizardCompleted ()Ljava/lang/Boolean;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/PublicSystemInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PublicSystemInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/PublicSystemInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueryFilters {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/QueryFilters$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/QueryFilters;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/QueryFilters;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/QueryFilters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGenres ()Ljava/util/List;
+	public final fun getTags ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueryFilters;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/QueryFilters$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueryFilters$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueryFilters;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/QueryFilters;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueryFilters$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueryFiltersLegacy {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGenres ()Ljava/util/List;
+	public final fun getOfficialRatings ()Ljava/util/List;
+	public final fun getTags ()Ljava/util/List;
+	public final fun getYears ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/QueryFiltersLegacy$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueryFiltersLegacy$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueueItem {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/QueueItem$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/UUID;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/QueueItem;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/QueueItem;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/QueueItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getPlaylistItemId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueueItem;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/QueueItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueueItem$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueueItem;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/QueueItem;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueueItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueueRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/QueueRequestDto$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lorg/jellyfin/sdk/model/api/GroupQueueMode;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lorg/jellyfin/sdk/model/api/GroupQueueMode;)V
+	public synthetic fun <init> (Ljava/util/List;Lorg/jellyfin/sdk/model/api/GroupQueueMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public final fun copy (Ljava/util/List;Lorg/jellyfin/sdk/model/api/GroupQueueMode;)Lorg/jellyfin/sdk/model/api/QueueRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/QueueRequestDto;Ljava/util/List;Lorg/jellyfin/sdk/model/api/GroupQueueMode;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/QueueRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItemIds ()Ljava/util/List;
+	public final fun getMode ()Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueueRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/QueueRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueueRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueueRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/QueueRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QueueRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/QuickConnectDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/QuickConnectDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/QuickConnectDto;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/QuickConnectDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QuickConnectDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QuickConnectDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QuickConnectDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/QuickConnectDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/QuickConnectResult$Companion;
+	public synthetic fun <init> (IZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/time/LocalDateTime;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;)Lorg/jellyfin/sdk/model/api/QuickConnectResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/QuickConnectResult;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/QuickConnectResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthenticated ()Z
+	public final fun getAuthentication ()Ljava/lang/String;
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getDateAdded ()Ljava/time/LocalDateTime;
+	public final fun getError ()Ljava/lang/String;
+	public final fun getSecret ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QuickConnectResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QuickConnectResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QuickConnectResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/QuickConnectResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectState : java/lang/Enum {
+	public static final field ACTIVE Lorg/jellyfin/sdk/model/api/QuickConnectState;
+	public static final field AVAILABLE Lorg/jellyfin/sdk/model/api/QuickConnectState;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/QuickConnectState$Companion;
+	public static final field UNAVAILABLE Lorg/jellyfin/sdk/model/api/QuickConnectState;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/QuickConnectState;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/QuickConnectState;
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QuickConnectState$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QuickConnectState;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/QuickConnectState;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/QuickConnectState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RatingType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RatingType$Companion;
+	public static final field LIKES Lorg/jellyfin/sdk/model/api/RatingType;
+	public static final field SCORE Lorg/jellyfin/sdk/model/api/RatingType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RatingType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/RatingType;
+}
+
+public final class org/jellyfin/sdk/model/api/RatingType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RatingType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RatingType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RatingType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RatingType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ReadyRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ReadyRequestDto$Companion;
+	public synthetic fun <init> (ILjava/time/LocalDateTime;JZLjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/time/LocalDateTime;JZLjava/util/UUID;)V
+	public final fun component1 ()Ljava/time/LocalDateTime;
+	public final fun component2 ()J
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/UUID;
+	public final fun copy (Ljava/time/LocalDateTime;JZLjava/util/UUID;)Lorg/jellyfin/sdk/model/api/ReadyRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ReadyRequestDto;Ljava/time/LocalDateTime;JZLjava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ReadyRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlaylistItemId ()Ljava/util/UUID;
+	public final fun getPositionTicks ()J
+	public final fun getWhen ()Ljava/time/LocalDateTime;
+	public fun hashCode ()I
+	public final fun isPlaying ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ReadyRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ReadyRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ReadyRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ReadyRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ReadyRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ReadyRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RecommendationDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RecommendationDto$Companion;
+	public synthetic fun <init> (ILjava/util/List;Lorg/jellyfin/sdk/model/api/RecommendationType;Ljava/lang/String;Ljava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lorg/jellyfin/sdk/model/api/RecommendationType;Ljava/lang/String;Ljava/util/UUID;)V
+	public synthetic fun <init> (Ljava/util/List;Lorg/jellyfin/sdk/model/api/RecommendationType;Ljava/lang/String;Ljava/util/UUID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/List;Lorg/jellyfin/sdk/model/api/RecommendationType;Ljava/lang/String;Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/RecommendationDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/RecommendationDto;Ljava/util/List;Lorg/jellyfin/sdk/model/api/RecommendationType;Ljava/lang/String;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/RecommendationDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaselineItemName ()Ljava/lang/String;
+	public final fun getCategoryId ()Ljava/util/UUID;
+	public final fun getItems ()Ljava/util/List;
+	public final fun getRecommendationType ()Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RecommendationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/RecommendationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RecommendationDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RecommendationDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RecommendationDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RecommendationDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RecommendationType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RecommendationType$Companion;
+	public static final field HAS_ACTOR_FROM_RECENTLY_PLAYED Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public static final field HAS_DIRECTOR_FROM_RECENTLY_PLAYED Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public static final field HAS_LIKED_ACTOR Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public static final field HAS_LIKED_DIRECTOR Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public static final field SIMILAR_TO_LIKED_ITEM Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public static final field SIMILAR_TO_RECENTLY_PLAYED Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/RecommendationType;
+}
+
+public final class org/jellyfin/sdk/model/api/RecommendationType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RecommendationType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RecommendationType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RecommendationType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RecordingStatus : java/lang/Enum {
+	public static final field CANCELLED Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static final field COMPLETED Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static final field CONFLICTED_NOT_OK Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static final field CONFLICTED_OK Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RecordingStatus$Companion;
+	public static final field ERROR Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static final field IN_PROGRESS Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static final field NEW Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/RecordingStatus;
+}
+
+public final class org/jellyfin/sdk/model/api/RecordingStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RecordingStatus$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RecordingStatus;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RecordingStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteImageInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RemoteImageInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Lorg/jellyfin/sdk/model/api/RatingType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Lorg/jellyfin/sdk/model/api/RatingType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Lorg/jellyfin/sdk/model/api/RatingType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lorg/jellyfin/sdk/model/api/RatingType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Double;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lorg/jellyfin/sdk/model/api/ImageType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Lorg/jellyfin/sdk/model/api/RatingType;)Lorg/jellyfin/sdk/model/api/RemoteImageInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/RemoteImageInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageType;Lorg/jellyfin/sdk/model/api/RatingType;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/RemoteImageInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommunityRating ()Ljava/lang/Double;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getProviderName ()Ljava/lang/String;
+	public final fun getRatingType ()Lorg/jellyfin/sdk/model/api/RatingType;
+	public final fun getThumbnailUrl ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/ImageType;
+	public final fun getUrl ()Ljava/lang/String;
+	public final fun getVoteCount ()Ljava/lang/Integer;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteImageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteImageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteImageInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteImageInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RemoteImageInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteImageInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteImageResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RemoteImageResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;ILjava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;ILjava/util/List;)Lorg/jellyfin/sdk/model/api/RemoteImageResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/RemoteImageResult;Ljava/util/List;ILjava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/RemoteImageResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImages ()Ljava/util/List;
+	public final fun getProviders ()Ljava/util/List;
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteImageResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteImageResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteImageResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteImageResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RemoteImageResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteImageResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteSearchResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RemoteSearchResult$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Lorg/jellyfin/sdk/model/api/RemoteSearchResult;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/time/LocalDateTime;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/RemoteSearchResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/RemoteSearchResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlbumArtist ()Lorg/jellyfin/sdk/model/api/RemoteSearchResult;
+	public final fun getArtists ()Ljava/util/List;
+	public final fun getImageUrl ()Ljava/lang/String;
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getIndexNumberEnd ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProductionYear ()Ljava/lang/Integer;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteSearchResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteSearchResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteSearchResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteSearchResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteSubtitleInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/time/LocalDateTime;
+	public final fun component9 ()Ljava/lang/Float;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;)Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor ()Ljava/lang/String;
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getCommunityRating ()Ljava/lang/Float;
+	public final fun getDateCreated ()Ljava/time/LocalDateTime;
+	public final fun getDownloadCount ()Ljava/lang/Integer;
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getProviderName ()Ljava/lang/String;
+	public final fun getThreeLetterIsoLanguageName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isHashMatch ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteSubtitleInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoteSubtitleInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlaylistItemIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RepeatMode : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RepeatMode$Companion;
+	public static final field REPEAT_ALL Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public static final field REPEAT_NONE Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public static final field REPEAT_ONE Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/RepeatMode;
+}
+
+public final class org/jellyfin/sdk/model/api/RepeatMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RepeatMode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RepeatMode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RepeatMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RepositoryInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/RepositoryInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/RepositoryInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/RepositoryInfo;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/RepositoryInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RepositoryInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/RepositoryInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RepositoryInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RepositoryInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/RepositoryInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/RepositoryInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ResponseProfile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ResponseProfile$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/ResponseProfile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ResponseProfile;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ResponseProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioCodec ()Ljava/lang/String;
+	public final fun getConditions ()Ljava/util/List;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getOrgPn ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun getVideoCodec ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ResponseProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ResponseProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ResponseProfile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ResponseProfile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ResponseProfile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ResponseProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ScrollDirection : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ScrollDirection$Companion;
+	public static final field HORIZONTAL Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public static final field VERTICAL Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/ScrollDirection;
+}
+
+public final class org/jellyfin/sdk/model/api/ScrollDirection$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ScrollDirection$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ScrollDirection;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ScrollDirection$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SearchHint {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SearchHint$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Double;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Double;)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Long;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/time/LocalDateTime;
+	public final fun component18 ()Ljava/time/LocalDateTime;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/util/UUID;
+	public final fun component23 ()Ljava/lang/String;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Ljava/lang/Integer;
+	public final fun component26 ()Ljava/lang/Integer;
+	public final fun component27 ()Ljava/util/UUID;
+	public final fun component28 ()Ljava/lang/String;
+	public final fun component29 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Double;)Lorg/jellyfin/sdk/model/api/SearchHint;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SearchHint;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Double;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SearchHint;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlbum ()Ljava/lang/String;
+	public final fun getAlbumArtist ()Ljava/lang/String;
+	public final fun getAlbumId ()Ljava/util/UUID;
+	public final fun getArtists ()Ljava/util/List;
+	public final fun getBackdropImageItemId ()Ljava/lang/String;
+	public final fun getBackdropImageTag ()Ljava/lang/String;
+	public final fun getChannelId ()Ljava/util/UUID;
+	public final fun getChannelName ()Ljava/lang/String;
+	public final fun getEndDate ()Ljava/time/LocalDateTime;
+	public final fun getEpisodeCount ()Ljava/lang/Integer;
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getMatchedTerm ()Ljava/lang/String;
+	public final fun getMediaType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPrimaryImageAspectRatio ()Ljava/lang/Double;
+	public final fun getPrimaryImageTag ()Ljava/lang/String;
+	public final fun getProductionYear ()Ljava/lang/Integer;
+	public final fun getRunTimeTicks ()Ljava/lang/Long;
+	public final fun getSeries ()Ljava/lang/String;
+	public final fun getSongCount ()Ljava/lang/Integer;
+	public final fun getStartDate ()Ljava/time/LocalDateTime;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getThumbImageItemId ()Ljava/lang/String;
+	public final fun getThumbImageTag ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isFolder ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SearchHint;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SearchHint$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SearchHint$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SearchHint;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SearchHint;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SearchHint$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SearchHintResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SearchHintResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;I)V
+	public synthetic fun <init> (Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/List;I)Lorg/jellyfin/sdk/model/api/SearchHintResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SearchHintResult;Ljava/util/List;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SearchHintResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSearchHints ()Ljava/util/List;
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SearchHintResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SearchHintResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SearchHintResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SearchHintResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SearchHintResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SearchHintResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeekRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SeekRequestDto$Companion;
+	public synthetic fun <init> (IJLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lorg/jellyfin/sdk/model/api/SeekRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SeekRequestDto;JILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SeekRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPositionTicks ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeekRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SeekRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeekRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeekRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SeekRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeekRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SendCommand {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SendCommand$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/SendCommandType;Ljava/time/LocalDateTime;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/SendCommandType;Ljava/time/LocalDateTime;)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/SendCommandType;Ljava/time/LocalDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/time/LocalDateTime;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public final fun component6 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/SendCommandType;Ljava/time/LocalDateTime;)Lorg/jellyfin/sdk/model/api/SendCommand;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SendCommand;Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/SendCommandType;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SendCommand;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommand ()Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public final fun getEmittedAt ()Ljava/time/LocalDateTime;
+	public final fun getGroupId ()Ljava/util/UUID;
+	public final fun getPlaylistItemId ()Ljava/util/UUID;
+	public final fun getPositionTicks ()Ljava/lang/Long;
+	public final fun getWhen ()Ljava/time/LocalDateTime;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SendCommand;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SendCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SendCommand$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SendCommand;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SendCommand;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SendCommand$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SendCommandType : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SendCommandType$Companion;
+	public static final field PAUSE Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public static final field SEEK Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public static final field STOP Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public static final field UNPAUSE Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/SendCommandType;
+}
+
+public final class org/jellyfin/sdk/model/api/SendCommandType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SendCommandType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SendCommandType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SendCommandType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)Lorg/jellyfin/sdk/model/api/SeriesInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SeriesInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SeriesInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SeriesInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/SeriesInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/SeriesInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/SeriesInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/SeriesInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/SeriesInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/SeriesInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/SeriesInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesStatus : java/lang/Enum {
+	public static final field CONTINUING Lorg/jellyfin/sdk/model/api/SeriesStatus;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesStatus$Companion;
+	public static final field ENDED Lorg/jellyfin/sdk/model/api/SeriesStatus;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesStatus;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/SeriesStatus;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesStatus$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesStatus;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SeriesStatus;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto$Companion;
+	public synthetic fun <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/time/LocalDateTime;
+	public final fun component14 ()Ljava/time/LocalDateTime;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()I
+	public final fun component17 ()I
+	public final fun component18 ()I
+	public final fun component19 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Z
+	public final fun component23 ()Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public final fun component24 ()Z
+	public final fun component25 ()Z
+	public final fun component26 ()Z
+	public final fun component27 ()I
+	public final fun component28 ()Z
+	public final fun component29 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component30 ()Lorg/jellyfin/sdk/model/api/DayPattern;
+	public final fun component31 ()Ljava/util/Map;
+	public final fun component32 ()Ljava/lang/String;
+	public final fun component33 ()Ljava/lang/String;
+	public final fun component34 ()Ljava/lang/String;
+	public final fun component35 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/UUID;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelId ()Ljava/util/UUID;
+	public final fun getChannelName ()Ljava/lang/String;
+	public final fun getChannelPrimaryImageTag ()Ljava/lang/String;
+	public final fun getDayPattern ()Lorg/jellyfin/sdk/model/api/DayPattern;
+	public final fun getDays ()Ljava/util/List;
+	public final fun getEndDate ()Ljava/time/LocalDateTime;
+	public final fun getExternalChannelId ()Ljava/lang/String;
+	public final fun getExternalId ()Ljava/lang/String;
+	public final fun getExternalProgramId ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImageTags ()Ljava/util/Map;
+	public final fun getKeepUntil ()Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public final fun getKeepUpTo ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getParentBackdropImageTags ()Ljava/util/List;
+	public final fun getParentBackdropItemId ()Ljava/lang/String;
+	public final fun getParentPrimaryImageItemId ()Ljava/lang/String;
+	public final fun getParentPrimaryImageTag ()Ljava/lang/String;
+	public final fun getParentThumbImageTag ()Ljava/lang/String;
+	public final fun getParentThumbItemId ()Ljava/lang/String;
+	public final fun getPostPaddingSeconds ()I
+	public final fun getPrePaddingSeconds ()I
+	public final fun getPriority ()I
+	public final fun getProgramId ()Ljava/lang/String;
+	public final fun getRecordAnyChannel ()Z
+	public final fun getRecordAnyTime ()Z
+	public final fun getRecordNewOnly ()Z
+	public final fun getServerId ()Ljava/lang/String;
+	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getSkipEpisodesInLibrary ()Z
+	public final fun getStartDate ()Ljava/time/LocalDateTime;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPostPaddingRequired ()Z
+	public final fun isPrePaddingRequired ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;II)V
+	public synthetic fun <init> (Ljava/util/List;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;II)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;Ljava/util/List;IIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getStartIndex ()I
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ServerConfiguration {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ServerConfiguration$Companion;
+	public synthetic fun <init> (IIIIZLjava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZZIZLjava/lang/String;ZZZLjava/lang/String;IIZLjava/lang/String;IZZLjava/lang/String;Ljava/util/List;ZZIIIZZLjava/lang/String;Ljava/lang/String;ZZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IIIIIIZLorg/jellyfin/sdk/model/api/ImageSavingConvention;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;IZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;ZILjava/util/List;Ljava/util/List;ZJLjava/util/List;Ljava/util/List;Ljava/lang/Integer;IIZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (IZLjava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZZIZLjava/lang/String;ZZZLjava/lang/String;IIZLjava/lang/String;IZZLjava/lang/String;Ljava/util/List;ZZIIIZZLjava/lang/String;Ljava/lang/String;ZZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IIIIIIZLorg/jellyfin/sdk/model/api/ImageSavingConvention;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;IZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;ZILjava/util/List;Ljava/util/List;ZJLjava/util/List;Ljava/util/List;Ljava/lang/Integer;IIZ)V
+	public synthetic fun <init> (IZLjava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZZIZLjava/lang/String;ZZZLjava/lang/String;IIZLjava/lang/String;IZZLjava/lang/String;Ljava/util/List;ZZIIIZZLjava/lang/String;Ljava/lang/String;ZZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IIIIIIZLorg/jellyfin/sdk/model/api/ImageSavingConvention;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;IZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;ZILjava/util/List;Ljava/util/List;ZJLjava/util/List;Ljava/util/List;Ljava/lang/Integer;IIZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Z
+	public final fun component12 ()Z
+	public final fun component13 ()Z
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()I
+	public final fun component16 ()I
+	public final fun component17 ()Z
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()I
+	public final fun component2 ()Z
+	public final fun component20 ()Z
+	public final fun component21 ()Z
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Z
+	public final fun component25 ()Z
+	public final fun component26 ()I
+	public final fun component27 ()I
+	public final fun component28 ()I
+	public final fun component29 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component30 ()Z
+	public final fun component31 ()Ljava/lang/String;
+	public final fun component32 ()Ljava/lang/String;
+	public final fun component33 ()Z
+	public final fun component34 ()Z
+	public final fun component35 ()Z
+	public final fun component36 ()Z
+	public final fun component37 ()Z
+	public final fun component38 ()Ljava/lang/String;
+	public final fun component39 ()Ljava/lang/String;
+	public final fun component4 ()Lorg/jellyfin/sdk/model/api/Version;
+	public final fun component40 ()Ljava/lang/String;
+	public final fun component41 ()Ljava/lang/String;
+	public final fun component42 ()Ljava/util/List;
+	public final fun component43 ()Ljava/util/List;
+	public final fun component44 ()Ljava/util/List;
+	public final fun component45 ()I
+	public final fun component46 ()I
+	public final fun component47 ()I
+	public final fun component48 ()I
+	public final fun component49 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component50 ()I
+	public final fun component51 ()Z
+	public final fun component52 ()Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public final fun component53 ()Ljava/util/List;
+	public final fun component54 ()Z
+	public final fun component55 ()Ljava/lang/String;
+	public final fun component56 ()Ljava/lang/String;
+	public final fun component57 ()Ljava/lang/String;
+	public final fun component58 ()Z
+	public final fun component59 ()Ljava/util/List;
+	public final fun component6 ()Z
+	public final fun component60 ()I
+	public final fun component61 ()Z
+	public final fun component62 ()Z
+	public final fun component63 ()Z
+	public final fun component64 ()Ljava/util/List;
+	public final fun component65 ()Ljava/util/List;
+	public final fun component66 ()Ljava/util/List;
+	public final fun component67 ()Ljava/util/List;
+	public final fun component68 ()Z
+	public final fun component69 ()Z
+	public final fun component7 ()Z
+	public final fun component70 ()Z
+	public final fun component71 ()Ljava/util/List;
+	public final fun component72 ()Z
+	public final fun component73 ()I
+	public final fun component74 ()Ljava/util/List;
+	public final fun component75 ()Ljava/util/List;
+	public final fun component76 ()Z
+	public final fun component77 ()J
+	public final fun component78 ()Ljava/util/List;
+	public final fun component79 ()Ljava/util/List;
+	public final fun component8 ()I
+	public final fun component80 ()Ljava/lang/Integer;
+	public final fun component81 ()I
+	public final fun component82 ()I
+	public final fun component83 ()Z
+	public final fun component9 ()Z
+	public final fun copy (IZLjava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZZIZLjava/lang/String;ZZZLjava/lang/String;IIZLjava/lang/String;IZZLjava/lang/String;Ljava/util/List;ZZIIIZZLjava/lang/String;Ljava/lang/String;ZZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IIIIIIZLorg/jellyfin/sdk/model/api/ImageSavingConvention;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;IZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;ZILjava/util/List;Ljava/util/List;ZJLjava/util/List;Ljava/util/List;Ljava/lang/Integer;IIZ)Lorg/jellyfin/sdk/model/api/ServerConfiguration;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ServerConfiguration;IZLjava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;ZZIZLjava/lang/String;ZZZLjava/lang/String;IIZLjava/lang/String;IZZLjava/lang/String;Ljava/util/List;ZZIIIZZLjava/lang/String;Ljava/lang/String;ZZZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IIIIIIZLorg/jellyfin/sdk/model/api/ImageSavingConvention;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;IZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;ZILjava/util/List;Ljava/util/List;ZJLjava/util/List;Ljava/util/List;Ljava/lang/Integer;IIZIIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ServerConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityLogRetentionDays ()Ljava/lang/Integer;
+	public final fun getAutoDiscovery ()Z
+	public final fun getAutoDiscoveryTracing ()Z
+	public final fun getBaseUrl ()Ljava/lang/String;
+	public final fun getCachePath ()Ljava/lang/String;
+	public final fun getCertificatePassword ()Ljava/lang/String;
+	public final fun getCertificatePath ()Ljava/lang/String;
+	public final fun getCodecsUsed ()Ljava/util/List;
+	public final fun getContentTypes ()Ljava/util/List;
+	public final fun getCorsHosts ()Ljava/util/List;
+	public final fun getDisableLiveTvChannelUserDataName ()Z
+	public final fun getDisplaySpecialsWithinSeasons ()Z
+	public final fun getEnableCaseSensitiveItemIds ()Z
+	public final fun getEnableDashboardResponseCaching ()Z
+	public final fun getEnableExternalContentInSuggestions ()Z
+	public final fun getEnableFolderView ()Z
+	public final fun getEnableGroupingIntoCollections ()Z
+	public final fun getEnableHttps ()Z
+	public final fun getEnableIpv4 ()Z
+	public final fun getEnableIpv6 ()Z
+	public final fun getEnableMetrics ()Z
+	public final fun getEnableMultiSocketBinding ()Z
+	public final fun getEnableNewOmdbSupport ()Z
+	public final fun getEnableNormalizedItemByNameIds ()Z
+	public final fun getEnableRemoteAccess ()Z
+	public final fun getEnableSlowResponseWarning ()Z
+	public final fun getEnableSsdpTracing ()Z
+	public final fun getEnableUPnP ()Z
+	public final fun getGatewayMonitorPeriod ()I
+	public final fun getHdHomerunPortRange ()Ljava/lang/String;
+	public final fun getHttpServerPortNumber ()I
+	public final fun getHttpsPortNumber ()I
+	public final fun getIgnoreVirtualInterfaces ()Z
+	public final fun getImageExtractionTimeoutMs ()I
+	public final fun getImageSavingConvention ()Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public final fun getKnownProxies ()Ljava/util/List;
+	public final fun getLibraryMetadataRefreshConcurrency ()I
+	public final fun getLibraryMonitorDelay ()I
+	public final fun getLibraryScanFanoutConcurrency ()I
+	public final fun getLocalNetworkAddresses ()Ljava/util/List;
+	public final fun getLocalNetworkSubnets ()Ljava/util/List;
+	public final fun getLogFileRetentionDays ()I
+	public final fun getMaxAudiobookResume ()I
+	public final fun getMaxResumePct ()I
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataNetworkPath ()Ljava/lang/String;
+	public final fun getMetadataOptions ()Ljava/util/List;
+	public final fun getMetadataPath ()Ljava/lang/String;
+	public final fun getMinAudiobookResume ()I
+	public final fun getMinResumeDurationSeconds ()I
+	public final fun getMinResumePct ()I
+	public final fun getPathSubstitutions ()Ljava/util/List;
+	public final fun getPluginRepositories ()Ljava/util/List;
+	public final fun getPreferredMetadataLanguage ()Ljava/lang/String;
+	public final fun getPreviousVersion ()Lorg/jellyfin/sdk/model/api/Version;
+	public final fun getPreviousVersionStr ()Ljava/lang/String;
+	public final fun getPublicHttpsPort ()I
+	public final fun getPublicPort ()I
+	public final fun getPublishedServerUriBySubnet ()Ljava/util/List;
+	public final fun getQuickConnectAvailable ()Z
+	public final fun getRemoteClientBitrateLimit ()I
+	public final fun getRemoteIpFilter ()Ljava/util/List;
+	public final fun getRemoveOldPlugins ()Z
+	public final fun getRequireHttps ()Z
+	public final fun getSaveMetadataHidden ()Z
+	public final fun getServerName ()Ljava/lang/String;
+	public final fun getSkipDeserializationForBasicTypes ()Z
+	public final fun getSlowResponseThresholdMs ()J
+	public final fun getSortRemoveCharacters ()Ljava/util/List;
+	public final fun getSortRemoveWords ()Ljava/util/List;
+	public final fun getSortReplaceCharacters ()Ljava/util/List;
+	public final fun getSsdpTracingFilter ()Ljava/lang/String;
+	public final fun getTrustAllIp6Interfaces ()Z
+	public final fun getUPnPCreateHttpPortMap ()Z
+	public final fun getUdpPortRange ()Ljava/lang/String;
+	public final fun getUdpSendCount ()I
+	public final fun getUdpSendDelay ()I
+	public final fun getUiCulture ()Ljava/lang/String;
+	public final fun getUninstalledPlugins ()Ljava/util/List;
+	public final fun getVirtualInterfaceNames ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPortAuthorized ()Z
+	public final fun isRemoteIpFilterBlacklist ()Z
+	public final fun isStartupWizardCompleted ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ServerConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ServerConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ServerConfiguration$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ServerConfiguration;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ServerConfiguration;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ServerConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SessionInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SessionInfo$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/PlayerStateInfo;Ljava/util/List;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lorg/jellyfin/sdk/model/api/BaseItem;Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TranscodingInfo;ZZZLjava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/PlayerStateInfo;Ljava/util/List;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lorg/jellyfin/sdk/model/api/BaseItem;Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TranscodingInfo;ZZZLjava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/PlayerStateInfo;Ljava/util/List;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lorg/jellyfin/sdk/model/api/BaseItem;Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TranscodingInfo;ZZZLjava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/PlayerStateInfo;
+	public final fun component10 ()Ljava/time/LocalDateTime;
+	public final fun component11 ()Ljava/time/LocalDateTime;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun component15 ()Lorg/jellyfin/sdk/model/api/BaseItem;
+	public final fun component16 ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Lorg/jellyfin/sdk/model/api/TranscodingInfo;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Z
+	public final fun component21 ()Z
+	public final fun component22 ()Z
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Z
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Ljava/lang/String;
+	public final fun component27 ()Ljava/lang/String;
+	public final fun component28 ()Ljava/util/List;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/ClientCapabilities;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/UUID;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/PlayerStateInfo;Ljava/util/List;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lorg/jellyfin/sdk/model/api/BaseItem;Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TranscodingInfo;ZZZLjava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/SessionInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SessionInfo;Lorg/jellyfin/sdk/model/api/PlayerStateInfo;Ljava/util/List;Lorg/jellyfin/sdk/model/api/ClientCapabilities;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lorg/jellyfin/sdk/model/api/BaseItem;Lorg/jellyfin/sdk/model/api/BaseItemDto;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TranscodingInfo;ZZZLjava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SessionInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdditionalUsers ()Ljava/util/List;
+	public final fun getApplicationVersion ()Ljava/lang/String;
+	public final fun getCapabilities ()Lorg/jellyfin/sdk/model/api/ClientCapabilities;
+	public final fun getClient ()Ljava/lang/String;
+	public final fun getDeviceId ()Ljava/lang/String;
+	public final fun getDeviceName ()Ljava/lang/String;
+	public final fun getDeviceType ()Ljava/lang/String;
+	public final fun getFullNowPlayingItem ()Lorg/jellyfin/sdk/model/api/BaseItem;
+	public final fun getHasCustomDeviceName ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLastActivityDate ()Ljava/time/LocalDateTime;
+	public final fun getLastPlaybackCheckIn ()Ljava/time/LocalDateTime;
+	public final fun getNowPlayingItem ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun getNowPlayingQueue ()Ljava/util/List;
+	public final fun getNowViewingItem ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun getPlayState ()Lorg/jellyfin/sdk/model/api/PlayerStateInfo;
+	public final fun getPlayableMediaTypes ()Ljava/util/List;
+	public final fun getPlaylistItemId ()Ljava/lang/String;
+	public final fun getRemoteEndPoint ()Ljava/lang/String;
+	public final fun getServerId ()Ljava/lang/String;
+	public final fun getSupportedCommands ()Ljava/util/List;
+	public final fun getSupportsMediaControl ()Z
+	public final fun getSupportsRemoteControl ()Z
+	public final fun getTranscodingInfo ()Lorg/jellyfin/sdk/model/api/TranscodingInfo;
+	public final fun getUserId ()Ljava/util/UUID;
+	public final fun getUserName ()Ljava/lang/String;
+	public final fun getUserPrimaryImageTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isActive ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SessionInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SessionInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SessionInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SessionInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SessionInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SessionInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SessionMessageType : java/lang/Enum {
+	public static final field ACTIVITY_LOG_ENTRY Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field ACTIVITY_LOG_ENTRY_START Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field ACTIVITY_LOG_ENTRY_STOP Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SessionMessageType$Companion;
+	public static final field FORCE_KEEP_ALIVE Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field GENERAL_COMMAND Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field KEEP_ALIVE Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field LIBRARY_CHANGED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field PACKAGE_INSTALLATION_CANCELLED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field PACKAGE_INSTALLATION_COMPLETED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field PACKAGE_INSTALLATION_FAILED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field PACKAGE_INSTALLING Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field PACKAGE_UNINSTALLED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field PLAY Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field PLAYSTATE Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field REFRESH_PROGRESS Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field RESTART_REQUIRED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SCHEDULED_TASKS_INFO Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SCHEDULED_TASKS_INFO_START Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SCHEDULED_TASKS_INFO_STOP Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SCHEDULED_TASK_ENDED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SERIES_TIMER_CANCELLED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SERIES_TIMER_CREATED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SERVER_RESTARTING Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SERVER_SHUTTING_DOWN Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SESSIONS Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SESSIONS_START Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SESSIONS_STOP Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SYNC_PLAY_COMMAND Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field SYNC_PLAY_GROUP_UPDATE Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field TIMER_CANCELLED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field TIMER_CREATED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field USER_DATA_CHANGED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field USER_DELETED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static final field USER_UPDATED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/SessionMessageType;
+}
+
+public final class org/jellyfin/sdk/model/api/SessionMessageType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SessionMessageType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SessionMessageType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SessionMessageType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SessionUserInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SessionUserInfo$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/UUID;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SessionUserInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SessionUserInfo;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SessionUserInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUserId ()Ljava/util/UUID;
+	public final fun getUserName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SessionUserInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SessionUserInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SessionUserInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SessionUserInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SessionUserInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SessionUserInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetChannelMappingDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SetChannelMappingDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProviderChannelId ()Ljava/lang/String;
+	public final fun getProviderId ()Ljava/lang/String;
+	public final fun getTunerChannelId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SetChannelMappingDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetChannelMappingDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetChannelMappingDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetPlaylistItemRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlaylistItemId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SetPlaylistItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetPlaylistItemRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetRepeatModeRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/GroupRepeatMode;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/GroupRepeatMode;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/GroupRepeatMode;)Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;Lorg/jellyfin/sdk/model/api/GroupRepeatMode;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMode ()Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SetRepeatModeRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetRepeatModeRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetShuffleModeRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/GroupShuffleMode;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/GroupShuffleMode;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public final fun copy (Lorg/jellyfin/sdk/model/api/GroupShuffleMode;)Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;Lorg/jellyfin/sdk/model/api/GroupShuffleMode;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMode ()Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SetShuffleModeRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SetShuffleModeRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SongInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SongInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/SongInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SongInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLjava/util/List;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SongInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlbum ()Ljava/lang/String;
+	public final fun getAlbumArtists ()Ljava/util/List;
+	public final fun getArtists ()Ljava/util/List;
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SongInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SongInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SongInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SongInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SongInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SongInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SortOrder : java/lang/Enum {
+	public static final field ASCENDING Lorg/jellyfin/sdk/model/api/SortOrder;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SortOrder$Companion;
+	public static final field DESCENDING Lorg/jellyfin/sdk/model/api/SortOrder;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SortOrder;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/SortOrder;
+}
+
+public final class org/jellyfin/sdk/model/api/SortOrder$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SortOrder$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SortOrder;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SortOrder;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SortOrder$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SpecialViewOptionDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SpecialViewOptionDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SpecialViewOptionDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/StartupConfigurationDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/StartupConfigurationDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getPreferredMetadataLanguage ()Ljava/lang/String;
+	public final fun getUiCulture ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/StartupConfigurationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/StartupConfigurationDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/StartupConfigurationDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/StartupRemoteAccessDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto$Companion;
+	public synthetic fun <init> (IZZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZZ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;ZZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnableAutomaticPortMapping ()Z
+	public final fun getEnableRemoteAccess ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/StartupRemoteAccessDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/StartupRemoteAccessDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/StartupUserDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/StartupUserDto$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/StartupUserDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/StartupUserDto;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/StartupUserDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPassword ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/StartupUserDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/StartupUserDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/StartupUserDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/StartupUserDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/StartupUserDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/StartupUserDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod$Companion;
+	public static final field EMBED Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public static final field ENCODE Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public static final field EXTERNAL Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public static final field HLS Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode : java/lang/Enum {
+	public static final field ALWAYS Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode$Companion;
+	public static final field DEFAULT Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public static final field NONE Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public static final field ONLY_FORCED Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public static final field SMART Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitleProfile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SubtitleProfile$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SubtitleProfile;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getDidlMode ()Ljava/lang/String;
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getMethod ()Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SubtitleProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitleProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SubtitleProfile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SubtitleProfile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SubtitleProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType : java/lang/Enum {
+	public static final field CREATE_AND_JOIN_GROUPS Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType$Companion;
+	public static final field JOIN_GROUPS Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public static final field NONE Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+}
+
+public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SystemInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/SystemInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ZZZILjava/util/List;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLorg/jellyfin/sdk/model/api/FFmpegLocation;Lorg/jellyfin/sdk/model/api/Architecture;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ZZZILjava/util/List;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLorg/jellyfin/sdk/model/api/FFmpegLocation;Lorg/jellyfin/sdk/model/api/Architecture;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ZZZILjava/util/List;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLorg/jellyfin/sdk/model/api/FFmpegLocation;Lorg/jellyfin/sdk/model/api/Architecture;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Z
+	public final fun component13 ()I
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Ljava/lang/String;
+	public final fun component24 ()Z
+	public final fun component25 ()Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public final fun component26 ()Lorg/jellyfin/sdk/model/api/Architecture;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ZZZILjava/util/List;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLorg/jellyfin/sdk/model/api/FFmpegLocation;Lorg/jellyfin/sdk/model/api/Architecture;)Lorg/jellyfin/sdk/model/api/SystemInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SystemInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ZZZILjava/util/List;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLorg/jellyfin/sdk/model/api/FFmpegLocation;Lorg/jellyfin/sdk/model/api/Architecture;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SystemInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCachePath ()Ljava/lang/String;
+	public final fun getCanLaunchWebBrowser ()Z
+	public final fun getCanSelfRestart ()Z
+	public final fun getCompletedInstallations ()Ljava/util/List;
+	public final fun getEncoderLocation ()Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public final fun getHasPendingRestart ()Z
+	public final fun getHasUpdateAvailable ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInternalMetadataPath ()Ljava/lang/String;
+	public final fun getItemsByNamePath ()Ljava/lang/String;
+	public final fun getLocalAddress ()Ljava/lang/String;
+	public final fun getLogPath ()Ljava/lang/String;
+	public final fun getOperatingSystem ()Ljava/lang/String;
+	public final fun getOperatingSystemDisplayName ()Ljava/lang/String;
+	public final fun getPackageName ()Ljava/lang/String;
+	public final fun getProductName ()Ljava/lang/String;
+	public final fun getProgramDataPath ()Ljava/lang/String;
+	public final fun getServerName ()Ljava/lang/String;
+	public final fun getStartupWizardCompleted ()Ljava/lang/Boolean;
+	public final fun getSupportsLibraryMonitor ()Z
+	public final fun getSystemArchitecture ()Lorg/jellyfin/sdk/model/api/Architecture;
+	public final fun getTranscodingTempPath ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public final fun getWebPath ()Ljava/lang/String;
+	public final fun getWebSocketPortNumber ()I
+	public fun hashCode ()I
+	public final fun isShuttingDown ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SystemInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/SystemInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SystemInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SystemInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/SystemInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/SystemInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskCompletionStatus : java/lang/Enum {
+	public static final field ABORTED Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public static final field CANCELLED Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public static final field COMPLETED Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TaskCompletionStatus$Companion;
+	public static final field FAILED Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskCompletionStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskCompletionStatus$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskCompletionStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TaskInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lorg/jellyfin/sdk/model/api/TaskState;Ljava/lang/Double;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskState;Ljava/lang/Double;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskState;Ljava/lang/Double;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/TaskState;
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lorg/jellyfin/sdk/model/api/TaskResult;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskState;Ljava/lang/Double;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TaskInfo;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskState;Ljava/lang/Double;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/TaskResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TaskInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getCurrentProgressPercentage ()Ljava/lang/Double;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLastExecutionResult ()Lorg/jellyfin/sdk/model/api/TaskResult;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getState ()Lorg/jellyfin/sdk/model/api/TaskState;
+	public final fun getTriggers ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isHidden ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TaskInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TaskInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TaskInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TaskResult$Companion;
+	public synthetic fun <init> (ILjava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/time/LocalDateTime;
+	public final fun component2 ()Ljava/time/LocalDateTime;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TaskResult;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TaskResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndTimeUtc ()Ljava/time/LocalDateTime;
+	public final fun getErrorMessage ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLongErrorMessage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStartTimeUtc ()Ljava/time/LocalDateTime;
+	public final fun getStatus ()Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TaskResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TaskResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TaskResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskState : java/lang/Enum {
+	public static final field CANCELLING Lorg/jellyfin/sdk/model/api/TaskState;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TaskState$Companion;
+	public static final field IDLE Lorg/jellyfin/sdk/model/api/TaskState;
+	public static final field RUNNING Lorg/jellyfin/sdk/model/api/TaskState;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskState;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/TaskState;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskState$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskState;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TaskState;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskTriggerInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TaskTriggerInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/DayOfWeek;Ljava/lang/Long;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/DayOfWeek;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/DayOfWeek;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/DayOfWeek;Ljava/lang/Long;)Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/DayOfWeek;Ljava/lang/Long;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDayOfWeek ()Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public final fun getIntervalTicks ()Ljava/lang/Long;
+	public final fun getMaxRuntimeTicks ()Ljava/lang/Long;
+	public final fun getTimeOfDayTicks ()Ljava/lang/Long;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TaskTriggerInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskTriggerInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TaskTriggerInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ThemeMediaResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ThemeMediaResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;IILjava/util/UUID;)V
+	public synthetic fun <init> (Ljava/util/List;IILjava/util/UUID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/List;IILjava/util/UUID;)Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Ljava/util/List;IILjava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getOwnerId ()Ljava/util/UUID;
+	public final fun getStartIndex ()I
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ThemeMediaResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ThemeMediaResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ThemeMediaResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ThemeMediaResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TimerEventInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TimerEventInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/UUID;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/UUID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun copy (Ljava/lang/String;Ljava/util/UUID;)Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TimerEventInfo;Ljava/lang/String;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getProgramId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TimerEventInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TimerEventInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TimerEventInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TimerEventInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TimerInfoDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TimerInfoDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/time/LocalDateTime;
+	public final fun component14 ()Ljava/time/LocalDateTime;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()I
+	public final fun component17 ()I
+	public final fun component18 ()I
+	public final fun component19 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Z
+	public final fun component23 ()Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public final fun component24 ()Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Ljava/lang/String;
+	public final fun component27 ()Ljava/lang/Long;
+	public final fun component28 ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/UUID;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TimerInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelId ()Ljava/util/UUID;
+	public final fun getChannelName ()Ljava/lang/String;
+	public final fun getChannelPrimaryImageTag ()Ljava/lang/String;
+	public final fun getEndDate ()Ljava/time/LocalDateTime;
+	public final fun getExternalChannelId ()Ljava/lang/String;
+	public final fun getExternalId ()Ljava/lang/String;
+	public final fun getExternalProgramId ()Ljava/lang/String;
+	public final fun getExternalSeriesTimerId ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKeepUntil ()Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getParentBackdropImageTags ()Ljava/util/List;
+	public final fun getParentBackdropItemId ()Ljava/lang/String;
+	public final fun getPostPaddingSeconds ()I
+	public final fun getPrePaddingSeconds ()I
+	public final fun getPriority ()I
+	public final fun getProgramId ()Ljava/lang/String;
+	public final fun getProgramInfo ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
+	public final fun getRunTimeTicks ()Ljava/lang/Long;
+	public final fun getSeriesTimerId ()Ljava/lang/String;
+	public final fun getServerId ()Ljava/lang/String;
+	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getStartDate ()Ljava/time/LocalDateTime;
+	public final fun getStatus ()Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPostPaddingRequired ()Z
+	public final fun isPrePaddingRequired ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TimerInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TimerInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TimerInfoDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TimerInfoDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TimerInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TimerInfoDtoQueryResult {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult$Companion;
+	public synthetic fun <init> (ILjava/util/List;IILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;II)V
+	public synthetic fun <init> (Ljava/util/List;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;II)Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;Ljava/util/List;IIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getStartIndex ()I
+	public final fun getTotalRecordCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TimerInfoDtoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TimerInfoDtoQueryResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TrailerInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TrailerInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Z)Lorg/jellyfin/sdk/model/api/TrailerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TrailerInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TrailerInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexNumber ()Ljava/lang/Integer;
+	public final fun getMetadataCountryCode ()Ljava/lang/String;
+	public final fun getMetadataLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentIndexNumber ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPremiereDate ()Ljava/time/LocalDateTime;
+	public final fun getProviderIds ()Ljava/util/Map;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAutomated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TrailerInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TrailerInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TrailerInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TrailerInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TrailerInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TrailerInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery$Companion;
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/api/TrailerInfo;Ljava/util/UUID;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/TrailerInfo;Ljava/util/UUID;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/TrailerInfo;Ljava/util/UUID;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/api/TrailerInfo;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Lorg/jellyfin/sdk/model/api/TrailerInfo;Ljava/util/UUID;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;Lorg/jellyfin/sdk/model/api/TrailerInfo;Ljava/util/UUID;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeDisabledProviders ()Z
+	public final fun getItemId ()Ljava/util/UUID;
+	public final fun getSearchInfo ()Lorg/jellyfin/sdk/model/api/TrailerInfo;
+	public final fun getSearchProviderName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodeReason : java/lang/Enum {
+	public static final field ANAMORPHIC_VIDEO_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field AUDIO_BITRATE_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field AUDIO_BIT_DEPTH_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field AUDIO_CHANNELS_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field AUDIO_CODEC_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field AUDIO_PROFILE_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field AUDIO_SAMPLE_RATE_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field CONTAINER_BITRATE_EXCEEDS_LIMIT Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field CONTAINER_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TranscodeReason$Companion;
+	public static final field DIRECT_PLAY_ERROR Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field INTERLACED_VIDEO_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field REF_FRAMES_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field SECONDARY_AUDIO_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field SUBTITLE_CODEC_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field UNKNOWN_AUDIO_STREAM_INFO Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field UNKNOWN_VIDEO_STREAM_INFO Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field VIDEO_BITRATE_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field VIDEO_BIT_DEPTH_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field VIDEO_CODEC_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field VIDEO_FRAMERATE_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field VIDEO_LEVEL_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field VIDEO_PROFILE_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static final field VIDEO_RESOLUTION_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/TranscodeReason;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodeReason$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodeReason$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TranscodeReason;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodeReason$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo : java/lang/Enum {
+	public static final field AUTO Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public static final field BYTES Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo$Companion;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodingInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TranscodingInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Float;
+	public final fun component8 ()Ljava/lang/Double;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/TranscodingInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TranscodingInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TranscodingInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioChannels ()Ljava/lang/Integer;
+	public final fun getAudioCodec ()Ljava/lang/String;
+	public final fun getBitrate ()Ljava/lang/Integer;
+	public final fun getCompletionPercentage ()Ljava/lang/Double;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getFramerate ()Ljava/lang/Float;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getTranscodeReasons ()Ljava/util/List;
+	public final fun getVideoCodec ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAudioDirect ()Z
+	public final fun isVideoDirect ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TranscodingInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodingInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodingInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodingInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TranscodingInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodingInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodingProfile {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TranscodingProfile$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLorg/jellyfin/sdk/model/api/TranscodeSeekInfo;ZLorg/jellyfin/sdk/model/api/EncodingContext;ZLjava/lang/String;IIZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLorg/jellyfin/sdk/model/api/TranscodeSeekInfo;ZLorg/jellyfin/sdk/model/api/EncodingContext;ZLjava/lang/String;IIZ)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLorg/jellyfin/sdk/model/api/TranscodeSeekInfo;ZLorg/jellyfin/sdk/model/api/EncodingContext;ZLjava/lang/String;IIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public final fun component11 ()Z
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()I
+	public final fun component14 ()I
+	public final fun component15 ()Z
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLorg/jellyfin/sdk/model/api/TranscodeSeekInfo;ZLorg/jellyfin/sdk/model/api/EncodingContext;ZLjava/lang/String;IIZ)Lorg/jellyfin/sdk/model/api/TranscodingProfile;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TranscodingProfile;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DlnaProfileType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLorg/jellyfin/sdk/model/api/TranscodeSeekInfo;ZLorg/jellyfin/sdk/model/api/EncodingContext;ZLjava/lang/String;IIZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TranscodingProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioCodec ()Ljava/lang/String;
+	public final fun getBreakOnNonKeyFrames ()Z
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getContext ()Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public final fun getCopyTimestamps ()Z
+	public final fun getEnableMpegtsM2TsMode ()Z
+	public final fun getEnableSubtitlesInManifest ()Z
+	public final fun getEstimateContentLength ()Z
+	public final fun getMaxAudioChannels ()Ljava/lang/String;
+	public final fun getMinSegments ()I
+	public final fun getProtocol ()Ljava/lang/String;
+	public final fun getSegmentLength ()I
+	public final fun getTranscodeSeekInfo ()Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun getVideoCodec ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TranscodingProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodingProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodingProfile$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodingProfile;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TranscodingProfile;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TranscodingProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp$Companion;
+	public static final field NONE Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public static final field VALID Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public static final field ZERO Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+}
+
+public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TunerChannelMapping {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TunerChannelMapping$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TunerChannelMapping;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TunerChannelMapping;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TunerChannelMapping;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getProviderChannelId ()Ljava/lang/String;
+	public final fun getProviderChannelName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TunerChannelMapping;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TunerChannelMapping$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TunerChannelMapping$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TunerChannelMapping;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TunerChannelMapping;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TunerChannelMapping$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TunerHostInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TunerHostInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;ILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()I
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;ILjava/lang/String;)Lorg/jellyfin/sdk/model/api/TunerHostInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TunerHostInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZLjava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TunerHostInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowHwTranscoding ()Z
+	public final fun getDeviceId ()Ljava/lang/String;
+	public final fun getEnableStreamLooping ()Z
+	public final fun getFriendlyName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImportFavoritesOnly ()Z
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTunerCount ()I
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public final fun getUserAgent ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TunerHostInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TunerHostInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TunerHostInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TunerHostInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TunerHostInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TunerHostInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TypeOptions {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/TypeOptions$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jellyfin/sdk/model/api/TypeOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TypeOptions;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TypeOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImageFetcherOrder ()Ljava/util/List;
+	public final fun getImageFetchers ()Ljava/util/List;
+	public final fun getImageOptions ()Ljava/util/List;
+	public final fun getMetadataFetcherOrder ()Ljava/util/List;
+	public final fun getMetadataFetchers ()Ljava/util/List;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TypeOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/TypeOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TypeOptions$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TypeOptions;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/TypeOptions;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/TypeOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UnratedItem : java/lang/Enum {
+	public static final field BOOK Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field CHANNEL_CONTENT Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UnratedItem$Companion;
+	public static final field LIVE_TV_CHANNEL Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field LIVE_TV_PROGRAM Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field MOVIE Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field MUSIC Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field OTHER Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field SERIES Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static final field TRAILER Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/UnratedItem;
+}
+
+public final class org/jellyfin/sdk/model/api/UnratedItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UnratedItem$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UnratedItem;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UnratedItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateLibraryOptionsDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryOptions;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryOptions;)V
+	public synthetic fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryOptions;)Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryOptions;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getLibraryOptions ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateLibraryOptionsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateLibraryOptionsDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateMediaPathRequestDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/MediaPathInfo;
+	public final fun copy (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;)Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/MediaPathInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPathInfo ()Lorg/jellyfin/sdk/model/api/MediaPathInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateMediaPathRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateMediaPathRequestDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateUserEasyPassword {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNewPassword ()Ljava/lang/String;
+	public final fun getNewPw ()Ljava/lang/String;
+	public final fun getResetPassword ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateUserEasyPassword$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateUserEasyPassword$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateUserPassword {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UpdateUserPassword$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/UpdateUserPassword;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UpdateUserPassword;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UpdateUserPassword;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrentPassword ()Ljava/lang/String;
+	public final fun getCurrentPw ()Ljava/lang/String;
+	public final fun getNewPw ()Ljava/lang/String;
+	public final fun getResetPassword ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateUserPassword;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateUserPassword$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateUserPassword$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateUserPassword;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UpdateUserPassword;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UpdateUserPassword$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UploadSubtitleDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UploadSubtitleDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isForced ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UploadSubtitleDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UploadSubtitleDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UploadSubtitleDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserConfiguration {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UserConfiguration$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZZZZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZZZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Z
+	public final fun component13 ()Z
+	public final fun component14 ()Z
+	public final fun component15 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZZZZ)Lorg/jellyfin/sdk/model/api/UserConfiguration;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UserConfiguration;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ZZZZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UserConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioLanguagePreference ()Ljava/lang/String;
+	public final fun getDisplayCollectionsView ()Z
+	public final fun getDisplayMissingEpisodes ()Z
+	public final fun getEnableLocalPassword ()Z
+	public final fun getEnableNextEpisodeAutoPlay ()Z
+	public final fun getGroupedFolders ()Ljava/util/List;
+	public final fun getHidePlayedInLatest ()Z
+	public final fun getLatestItemsExcludes ()Ljava/util/List;
+	public final fun getMyMediaExcludes ()Ljava/util/List;
+	public final fun getOrderedViews ()Ljava/util/List;
+	public final fun getPlayDefaultAudioTrack ()Z
+	public final fun getRememberAudioSelections ()Z
+	public final fun getRememberSubtitleSelections ()Z
+	public final fun getSubtitleLanguagePreference ()Ljava/lang/String;
+	public final fun getSubtitleMode ()Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UserConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserConfiguration$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserConfiguration;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UserConfiguration;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UserDto$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;ZZZLjava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/UserConfiguration;Lorg/jellyfin/sdk/model/api/UserPolicy;Ljava/lang/Double;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;ZZZLjava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/UserConfiguration;Lorg/jellyfin/sdk/model/api/UserPolicy;Ljava/lang/Double;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;ZZZLjava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/UserConfiguration;Lorg/jellyfin/sdk/model/api/UserPolicy;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/time/LocalDateTime;
+	public final fun component11 ()Ljava/time/LocalDateTime;
+	public final fun component12 ()Lorg/jellyfin/sdk/model/api/UserConfiguration;
+	public final fun component13 ()Lorg/jellyfin/sdk/model/api/UserPolicy;
+	public final fun component14 ()Ljava/lang/Double;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/UUID;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;ZZZLjava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/UserConfiguration;Lorg/jellyfin/sdk/model/api/UserPolicy;Ljava/lang/Double;)Lorg/jellyfin/sdk/model/api/UserDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UserDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;ZZZLjava/lang/Boolean;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lorg/jellyfin/sdk/model/api/UserConfiguration;Lorg/jellyfin/sdk/model/api/UserPolicy;Ljava/lang/Double;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UserDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfiguration ()Lorg/jellyfin/sdk/model/api/UserConfiguration;
+	public final fun getEnableAutoLogin ()Ljava/lang/Boolean;
+	public final fun getHasConfiguredEasyPassword ()Z
+	public final fun getHasConfiguredPassword ()Z
+	public final fun getHasPassword ()Z
+	public final fun getId ()Ljava/util/UUID;
+	public final fun getLastActivityDate ()Ljava/time/LocalDateTime;
+	public final fun getLastLoginDate ()Ljava/time/LocalDateTime;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPolicy ()Lorg/jellyfin/sdk/model/api/UserPolicy;
+	public final fun getPrimaryImageAspectRatio ()Ljava/lang/Double;
+	public final fun getPrimaryImageTag ()Ljava/lang/String;
+	public final fun getServerId ()Ljava/lang/String;
+	public final fun getServerName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UserDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UserDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserItemDataDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UserItemDataDto$Companion;
+	public synthetic fun <init> (ILjava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;JIZLjava/lang/Boolean;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;JIZLjava/lang/Boolean;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;JIZLjava/lang/Boolean;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Double;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()J
+	public final fun component5 ()I
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/time/LocalDateTime;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;JIZLjava/lang/Boolean;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/UserItemDataDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UserItemDataDto;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Integer;JIZLjava/lang/Boolean;Ljava/time/LocalDateTime;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UserItemDataDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItemId ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLastPlayedDate ()Ljava/time/LocalDateTime;
+	public final fun getLikes ()Ljava/lang/Boolean;
+	public final fun getPlayCount ()I
+	public final fun getPlaybackPositionTicks ()J
+	public final fun getPlayed ()Z
+	public final fun getPlayedPercentage ()Ljava/lang/Double;
+	public final fun getRating ()Ljava/lang/Double;
+	public final fun getUnplayedItemCount ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isFavorite ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserItemDataDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UserItemDataDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserItemDataDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserItemDataDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UserItemDataDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserItemDataDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserPolicy {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UserPolicy$Companion;
+	public synthetic fun <init> (IIZZZLjava/lang/Integer;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ZZZZZZZZZZZLjava/util/List;ZZZLjava/util/List;ZLjava/util/List;ZLjava/util/List;ZIIIZLjava/util/List;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZZZLjava/lang/Integer;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ZZZZZZZZZZZLjava/util/List;ZZZLjava/util/List;ZLjava/util/List;ZLjava/util/List;ZIIIZLjava/util/List;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;)V
+	public synthetic fun <init> (ZZZLjava/lang/Integer;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ZZZZZZZZZZZLjava/util/List;ZZZLjava/util/List;ZLjava/util/List;ZLjava/util/List;ZIIIZLjava/util/List;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Z
+	public final fun component13 ()Z
+	public final fun component14 ()Z
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Z
+	public final fun component18 ()Z
+	public final fun component19 ()Z
+	public final fun component2 ()Z
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Z
+	public final fun component22 ()Z
+	public final fun component23 ()Z
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Z
+	public final fun component26 ()Ljava/util/List;
+	public final fun component27 ()Z
+	public final fun component28 ()Ljava/util/List;
+	public final fun component29 ()Z
+	public final fun component3 ()Z
+	public final fun component30 ()I
+	public final fun component31 ()I
+	public final fun component32 ()I
+	public final fun component33 ()Z
+	public final fun component34 ()Ljava/util/List;
+	public final fun component35 ()Ljava/util/List;
+	public final fun component36 ()I
+	public final fun component37 ()Ljava/lang/String;
+	public final fun component38 ()Ljava/lang/String;
+	public final fun component39 ()Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Z
+	public final fun copy (ZZZLjava/lang/Integer;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ZZZZZZZZZZZLjava/util/List;ZZZLjava/util/List;ZLjava/util/List;ZLjava/util/List;ZIIIZLjava/util/List;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;)Lorg/jellyfin/sdk/model/api/UserPolicy;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UserPolicy;ZZZLjava/lang/Integer;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ZZZZZZZZZZZLjava/util/List;ZZZLjava/util/List;ZLjava/util/List;ZLjava/util/List;ZIIIZLjava/util/List;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UserPolicy;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessSchedules ()Ljava/util/List;
+	public final fun getAuthenticationProviderId ()Ljava/lang/String;
+	public final fun getBlockUnratedItems ()Ljava/util/List;
+	public final fun getBlockedChannels ()Ljava/util/List;
+	public final fun getBlockedMediaFolders ()Ljava/util/List;
+	public final fun getBlockedTags ()Ljava/util/List;
+	public final fun getEnableAllChannels ()Z
+	public final fun getEnableAllDevices ()Z
+	public final fun getEnableAllFolders ()Z
+	public final fun getEnableAudioPlaybackTranscoding ()Z
+	public final fun getEnableContentDeletion ()Z
+	public final fun getEnableContentDeletionFromFolders ()Ljava/util/List;
+	public final fun getEnableContentDownloading ()Z
+	public final fun getEnableLiveTvAccess ()Z
+	public final fun getEnableLiveTvManagement ()Z
+	public final fun getEnableMediaConversion ()Z
+	public final fun getEnableMediaPlayback ()Z
+	public final fun getEnablePlaybackRemuxing ()Z
+	public final fun getEnablePublicSharing ()Z
+	public final fun getEnableRemoteAccess ()Z
+	public final fun getEnableRemoteControlOfOtherUsers ()Z
+	public final fun getEnableSharedDeviceControl ()Z
+	public final fun getEnableSyncTranscoding ()Z
+	public final fun getEnableUserPreferenceAccess ()Z
+	public final fun getEnableVideoPlaybackTranscoding ()Z
+	public final fun getEnabledChannels ()Ljava/util/List;
+	public final fun getEnabledDevices ()Ljava/util/List;
+	public final fun getEnabledFolders ()Ljava/util/List;
+	public final fun getForceRemoteSourceTranscoding ()Z
+	public final fun getInvalidLoginAttemptCount ()I
+	public final fun getLoginAttemptsBeforeLockout ()I
+	public final fun getMaxActiveSessions ()I
+	public final fun getMaxParentalRating ()Ljava/lang/Integer;
+	public final fun getPasswordResetProviderId ()Ljava/lang/String;
+	public final fun getRemoteClientBitrateLimit ()I
+	public final fun getSyncPlayAccess ()Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public fun hashCode ()I
+	public final fun isAdministrator ()Z
+	public final fun isDisabled ()Z
+	public final fun isHidden ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserPolicy;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UserPolicy$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserPolicy$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserPolicy;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UserPolicy;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UserPolicy$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UtcTimeResponse {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/UtcTimeResponse$Companion;
+	public synthetic fun <init> (ILjava/time/LocalDateTime;Ljava/time/LocalDateTime;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;)V
+	public final fun component1 ()Ljava/time/LocalDateTime;
+	public final fun component2 ()Ljava/time/LocalDateTime;
+	public final fun copy (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;)Lorg/jellyfin/sdk/model/api/UtcTimeResponse;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/UtcTimeResponse;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/UtcTimeResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestReceptionTime ()Ljava/time/LocalDateTime;
+	public final fun getResponseTransmissionTime ()Ljava/time/LocalDateTime;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UtcTimeResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/UtcTimeResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UtcTimeResponse$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UtcTimeResponse;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/UtcTimeResponse;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/UtcTimeResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ValidatePathDto {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/ValidatePathDto$Companion;
+	public synthetic fun <init> (IZLjava/lang/String;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLjava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/Boolean;)Lorg/jellyfin/sdk/model/api/ValidatePathDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/ValidatePathDto;ZLjava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ValidatePathDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getValidateWritable ()Z
+	public fun hashCode ()I
+	public final fun isFile ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ValidatePathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/ValidatePathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ValidatePathDto$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ValidatePathDto;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/ValidatePathDto;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/ValidatePathDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/Version {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/Version$Companion;
+	public fun <init> (IIIIII)V
+	public synthetic fun <init> (IIIIIIILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun copy (IIIIII)Lorg/jellyfin/sdk/model/api/Version;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/Version;IIIIIIILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/Version;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuild ()I
+	public final fun getMajor ()I
+	public final fun getMajorRevision ()I
+	public final fun getMinor ()I
+	public final fun getMinorRevision ()I
+	public final fun getRevision ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/Version;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/Version$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/Version$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/Version;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/Version;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/Version$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/VersionInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/VersionInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/Version;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/VersionInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/VersionInfo;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/Version;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/VersionInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChangelog ()Ljava/lang/String;
+	public final fun getChecksum ()Ljava/lang/String;
+	public final fun getRepositoryName ()Ljava/lang/String;
+	public final fun getRepositoryUrl ()Ljava/lang/String;
+	public final fun getSourceUrl ()Ljava/lang/String;
+	public final fun getTargetAbi ()Ljava/lang/String;
+	public final fun getTimestamp ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public final fun getVersionNumber ()Lorg/jellyfin/sdk/model/api/Version;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/VersionInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/VersionInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/VersionInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/VersionInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/VersionInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/VersionInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/Video3dFormat : java/lang/Enum {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/Video3dFormat$Companion;
+	public static final field FULL_SIDE_BY_SIDE Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public static final field FULL_TOP_AND_BOTTOM Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public static final field HALF_SIDE_BY_SIDE Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public static final field HALF_TOP_AND_BOTTOM Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public static final field MVC Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/Video3dFormat;
+}
+
+public final class org/jellyfin/sdk/model/api/Video3dFormat$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/Video3dFormat$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/Video3dFormat;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/Video3dFormat$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/VideoType : java/lang/Enum {
+	public static final field BLU_RAY Lorg/jellyfin/sdk/model/api/VideoType;
+	public static final field Companion Lorg/jellyfin/sdk/model/api/VideoType$Companion;
+	public static final field DVD Lorg/jellyfin/sdk/model/api/VideoType;
+	public static final field ISO Lorg/jellyfin/sdk/model/api/VideoType;
+	public static final field VIDEO_FILE Lorg/jellyfin/sdk/model/api/VideoType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/VideoType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/api/VideoType;
+}
+
+public final class org/jellyfin/sdk/model/api/VideoType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/VideoType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/VideoType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/VideoType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/VideoType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/VirtualFolderInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/VirtualFolderInfo$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Lorg/jellyfin/sdk/model/api/LibraryOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Lorg/jellyfin/sdk/model/api/LibraryOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Lorg/jellyfin/sdk/model/api/LibraryOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public final fun component4 ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Double;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Lorg/jellyfin/sdk/model/api/LibraryOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;Ljava/lang/String;Ljava/util/List;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Lorg/jellyfin/sdk/model/api/LibraryOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollectionType ()Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public final fun getItemId ()Ljava/lang/String;
+	public final fun getLibraryOptions ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
+	public final fun getLocations ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPrimaryImageItemId ()Ljava/lang/String;
+	public final fun getRefreshProgress ()Ljava/lang/Double;
+	public final fun getRefreshStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/VirtualFolderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/VirtualFolderInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/VirtualFolderInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/WakeOnLanInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/WakeOnLanInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;I)V
+	public synthetic fun <init> (Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;Ljava/lang/String;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMacAddress ()Ljava/lang/String;
+	public final fun getPort ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/WakeOnLanInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/WakeOnLanInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/WakeOnLanInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/XmlAttribute {
+	public static final field Companion Lorg/jellyfin/sdk/model/api/XmlAttribute$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/XmlAttribute;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/XmlAttribute;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/XmlAttribute;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/XmlAttribute;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/api/XmlAttribute$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/XmlAttribute$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/XmlAttribute;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/api/XmlAttribute;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/api/XmlAttribute$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/discovery/DiscoveryServerInfo {
+	public static final field Companion Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/discovery/DiscoveryServerInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/discovery/DiscoveryServerInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/discovery/DiscoveryServerInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/discovery/ServerVersion {
+	public static final field Companion Lorg/jellyfin/sdk/model/discovery/ServerVersion$Companion;
+	public synthetic fun <init> (IIIILjava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (IIILjava/lang/Integer;)V
+	public synthetic fun <init> (IIILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun compareTo (Lorg/jellyfin/sdk/model/discovery/ServerVersion;)I
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (IIILjava/lang/Integer;)Lorg/jellyfin/sdk/model/discovery/ServerVersion;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/discovery/ServerVersion;IIILjava/lang/Integer;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/discovery/ServerVersion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuild ()Ljava/lang/Integer;
+	public final fun getMajor ()I
+	public final fun getMinor ()I
+	public final fun getPatch ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/discovery/ServerVersion;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/discovery/ServerVersion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/discovery/ServerVersion$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/discovery/ServerVersion;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/discovery/ServerVersion;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/discovery/ServerVersion$Companion {
+	public final fun fromString (Ljava/lang/String;)Lorg/jellyfin/sdk/model/discovery/ServerVersion;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/serializer/LocalDateTimeSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/time/LocalDateTime;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/time/LocalDateTime;)V
+}
+
+public final class org/jellyfin/sdk/model/serializer/UUIDSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/UUID;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/UUID;)V
+}
+
+public final class org/jellyfin/sdk/model/serializer/UUIDSerializerKt {
+	public static final fun toUUID (Ljava/lang/String;)Ljava/util/UUID;
+	public static final fun toUUIDOrNull (Ljava/lang/String;)Ljava/util/UUID;
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/UUID;Ljava/util/List;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;Ljava/util/UUID;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage : org/jellyfin/sdk/model/socket/OutgoingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public final fun copy (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPeriod ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage : org/jellyfin/sdk/model/socket/OutgoingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ForceKeepAliveMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;I)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/UUID;I)Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;Ljava/util/UUID;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ForceKeepAliveMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ForceKeepAliveMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/GeneralCommandMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/socket/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/socket/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/socket/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public final fun component3 ()Ljava/util/UUID;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/socket/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;)Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/socket/GeneralCommandType;Ljava/util/UUID;Ljava/util/Map;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Ljava/util/Map;
+	public final fun getCommand ()Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getUserId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/GeneralCommandMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/GeneralCommandMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/GeneralCommandType : java/lang/Enum {
+	public static final field Back Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field ChannelDown Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field ChannelUp Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/GeneralCommandType$Companion;
+	public static final field DisplayContent Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field DisplayMessage Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field GoHome Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field GoToSearch Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field GoToSettings Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field Guide Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field MoveDown Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field MoveLeft Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field MoveRight Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field MoveUp Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field Mute Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field NextLetter Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field PageDown Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field PageUp Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field PlayMediaSource Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field PlayTrailers Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field PreviousLetter Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field Select Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field SendKey Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field SendString Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field SetAudioStreamIndex Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field SetMaxStreamingBitrate Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field SetRepeatMode Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field SetSubtitleStreamIndex Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field SetVolume Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field TakeScreenshot Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field ToggleContextMenu Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field ToggleFullscreen Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field ToggleMute Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field ToggleOsd Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field ToggleStats Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field Unmute Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field VolumeDown Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static final field VolumeUp Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public static fun values ()[Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+}
+
+public final class org/jellyfin/sdk/model/socket/GeneralCommandType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/GeneralCommandType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/GeneralCommandType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/GeneralCommandType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class org/jellyfin/sdk/model/socket/IncomingSocketMessage : org/jellyfin/sdk/model/socket/SocketMessage {
+	public abstract fun getMessageId ()Ljava/util/UUID;
+}
+
+public final class org/jellyfin/sdk/model/socket/KeepAliveMessage : org/jellyfin/sdk/model/socket/OutgoingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/KeepAliveMessage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/KeepAliveMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/KeepAliveMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/KeepAliveMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/KeepAliveMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/KeepAliveMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/KeepAliveMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/LibraryChangedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;)Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/LibraryChangedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/LibraryChangedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class org/jellyfin/sdk/model/socket/OutgoingSocketMessage : org/jellyfin/sdk/model/socket/SocketMessage {
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationFailedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationFailedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallationFailedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallingMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;)Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/InstallationInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/InstallationInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallingMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageInstallingMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageUninstalledMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/IPlugin;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/IPlugin;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/IPlugin;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/IPlugin;)Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/IPlugin;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getPlugin ()Lorg/jellyfin/sdk/model/api/IPlugin;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageUninstalledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PackageUninstalledMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PeriodicListenerPeriod {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod$Companion;
+	public fun <init> ()V
+	public fun <init> (JJ)V
+	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;JJILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInitialDelay ()J
+	public final fun getInterval ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/model/socket/PeriodicListenerPeriod$Companion {
+	public final fun fromString (Ljava/lang/String;)Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PeriodicListenerPeriod$Serializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PlayMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PlayMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/PlayRequest;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlayRequest;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/PlayRequest;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlayRequest;)Lorg/jellyfin/sdk/model/socket/PlayMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PlayMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlayRequest;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PlayMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getRequest ()Lorg/jellyfin/sdk/model/api/PlayRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PlayMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PlayMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PlayMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PlayMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PlayMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PlayMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PlayStateMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/PlayStateMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/PlaystateRequest;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlaystateRequest;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/PlaystateRequest;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlaystateRequest;)Lorg/jellyfin/sdk/model/socket/PlayStateMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/PlayStateMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/PlaystateRequest;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/PlayStateMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getRequest ()Lorg/jellyfin/sdk/model/api/PlaystateRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PlayStateMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/PlayStateMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PlayStateMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PlayStateMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/PlayStateMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/PlayStateMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/RefreshProgressMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/UUID;Ljava/util/Map;)Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;Ljava/util/UUID;Ljava/util/Map;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/util/Map;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/RefreshProgressMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/RefreshProgressMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/RestartRequiredMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/RestartRequiredMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/RestartRequiredMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/TaskResult;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TaskResult;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/TaskResult;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TaskResult;)Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TaskResult;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/TaskResult;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/UUID;Ljava/util/List;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;Ljava/util/UUID;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Ljava/util/List;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage : org/jellyfin/sdk/model/socket/OutgoingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public final fun copy (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPeriod ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage : org/jellyfin/sdk/model/socket/OutgoingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ServerRestartingMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ServerRestartingMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ServerRestartingMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ServerShuttingDownMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun copy (Ljava/util/UUID;)Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;Ljava/util/UUID;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/ServerShuttingDownMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/ServerShuttingDownMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/SessionsMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/UUID;Ljava/util/List;)Lorg/jellyfin/sdk/model/socket/SessionsMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/SessionsMessage;Ljava/util/UUID;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/SessionsMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getSession ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SessionsMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SessionsMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SessionsMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/SessionsMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsStartMessage : org/jellyfin/sdk/model/socket/OutgoingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/SessionsStartMessage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public final fun copy (Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;)Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPeriod ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsStartMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SessionsStartMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsStartMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsStopMessage : org/jellyfin/sdk/model/socket/OutgoingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/SessionsStopMessage$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SessionsStopMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsStopMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SessionsStopMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SessionsStopMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/SessionsStopMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SessionsStopMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class org/jellyfin/sdk/model/socket/SocketMessage {
+}
+
+public final class org/jellyfin/sdk/model/socket/SyncPlayCommandMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/SendCommand;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/SendCommand;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/SendCommand;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/SendCommand;)Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/SendCommand;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommand ()Lorg/jellyfin/sdk/model/api/SendCommand;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/SyncPlayCommandMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SyncPlayCommandMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;)Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getUpdate ()Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/TimerCancelledMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/TimerCancelledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/TimerCancelledMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/TimerCreatedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;)Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/TimerEventInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lorg/jellyfin/sdk/model/api/TimerEventInfo;
+	public fun getMessageId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/TimerCreatedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/TimerCreatedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/UserDataChangedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/util/UUID;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;)Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getUserDataList ()Ljava/util/List;
+	public final fun getUserId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/UserDataChangedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/UserDataChangedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/UserDeletedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/UserDeletedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/UUID;Ljava/lang/String;)Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/UserDeletedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/UserDeletedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/UserDeletedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/UserUpdatedMessage : org/jellyfin/sdk/model/socket/IncomingSocketMessage {
+	public static final field Companion Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage$Companion;
+	public synthetic fun <init> (ILjava/util/UUID;Lorg/jellyfin/sdk/model/api/UserDto;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UserDto;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Lorg/jellyfin/sdk/model/api/UserDto;
+	public final fun copy (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UserDto;)Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/UserDto;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessageId ()Ljava/util/UUID;
+	public final fun getUser ()Lorg/jellyfin/sdk/model/api/UserDto;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/jellyfin/sdk/model/socket/UserUpdatedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/jellyfin/sdk/model/socket/UserUpdatedMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/jellyfin-platform-android/api/jellyfin-platform-android.api
+++ b/jellyfin-platform-android/api/jellyfin-platform-android.api
@@ -1,0 +1,20 @@
+public final class org/jellyfin/sdk/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class org/jellyfin/sdk/JellyfinAndroidKt {
+	public static final fun android (Lorg/jellyfin/sdk/JellyfinOptions$Builder;Landroid/content/Context;)V
+}
+
+public final class org/jellyfin/sdk/discovery/AndroidBroadcastAddressesProvider : org/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider {
+	public fun <init> (Landroid/content/Context;)V
+	public fun getBroadcastAddresses (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/interaction/AndroidDeviceKt {
+	public static final fun androidDevice (Landroid/content/Context;)Lorg/jellyfin/sdk/model/DeviceInfo;
+}
+


### PR DESCRIPTION
This PR adds the binary compatibility validator plugin to validate the exposed API with the last known in the repository. This can be used to automatically detect breaking changes.

The CI will run the `apiCheck` task and report any changes, this forces the contributor to update the API files using the `apiDump` task. This will create a git diff that shows the changes API to the maintainers, we can then chose to accept the API change or request changes.

Errors look like this:
```txt
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jellyfin-api:apiCheck'.
> API check failed for project jellyfin-api.
  --- .....\jellyfin-sdk-kotlin\jellyfin-api\api\jellyfin-api.api
  +++ .....\jellyfin-sdk-kotlin\jellyfin-api\build\api\jellyfin-api.api
  @@ -66,6 +66,7 @@
   
   public final class org/jellyfin/sdk/api/client/extensions/UserApiExtensionsKt {
   	public static final fun authenticateUserByName (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
  +	public static synthetic fun authenticateUserByName$default (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
   }
   
   public final class org/jellyfin/sdk/api/info/ApiConstants {
  
   You can run :jellyfin-api:apiDump task to overwrite API declarations

```

- [More info](https://github.com/Kotlin/binary-compatibility-validator)