### PR TITLE
ci(deps): update used actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - ci
+      - github-actions
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -16,8 +16,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Set JELLYFIN_VERSION
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -34,7 +35,7 @@ jobs:
         run: ./gradlew --no-daemon --info build assembleDist -x check
       - name: Upload release assets
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        uses: alexellis/upload-assets@0.2.2
+        uses: alexellis/upload-assets@0.3.0
         with:
           asset_paths: '["**/distributions/*-${{ env.JELLYFIN_VERSION }}.zip", "**/libs/*-${{ env.JELLYFIN_VERSION }}.jar", "**/outputs/aar/*.aar"]'
         env:

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -24,7 +24,6 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
       - name: Run publish task
-        if: github.repository == 'jellyfin/jellyfin-sdk-kotlin'
         run: ./gradlew --no-daemon --info publish closeAndReleaseSonatypeStagingRepository
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -18,8 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Setup Gradle cache
         uses: actions/cache@v2
@@ -40,8 +41,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Setup Gradle cache
         uses: actions/cache@v2


### PR DESCRIPTION
### Description

This PR aims to update the used GitHub Actions in the CI workflows and provides a dependabot config to keep them up-to-date in the future. (this includes the `actions/setup-java` v2 update and sets it to use `adopt`)

### Change

* various GitHub actions version bumps
* dependabot config to check for action updates on a weekly basis

### Issues

* n/a

### NOTE

You might want to add the Labels `ci` and `github-actions` similar to the [android repo](https://github.com/jellyfin/jellyfin-android/pull/336#issuecomment-815265645), since dependabot is odd and only wants to auto create its own default labels :sweat_smile: 