### PR TITLE
Use experimental centralized dependency versions and type-safe project dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-	id("io.github.gradle-nexus.publish-plugin").version(Dependencies.nexusPublishPluginVersion)
-	id("io.gitlab.arturbosch.detekt").version(Dependencies.detektVersion)
-	id("org.jetbrains.dokka").version(Dependencies.dokkaVersion)
-	id("org.jetbrains.kotlinx.binary-compatibility-validator").version(Dependencies.KotlinX.binaryCompatibilityValidatorVersion)
+	id("io.github.gradle-nexus.publish-plugin").version(Plugins.Versions.nexusPublish)
+	id("io.gitlab.arturbosch.detekt").version(Plugins.Versions.detekt)
+	id("org.jetbrains.dokka").version(Plugins.Versions.dokka)
+	id("org.jetbrains.kotlinx.binary-compatibility-validator").version(Plugins.Versions.binaryCompatibilityValidatorVersion)
 }
 
 // Versioning
@@ -18,8 +18,8 @@ buildscript {
 	repositories.defaultRepositories()
 
 	dependencies {
-		classpath(Dependencies.Android.buildTools)
-		classpath(Dependencies.Kotlin.gradlePlugin)
+		classpath(Plugins.androidBuildTools)
+		classpath(Plugins.kotlin)
 	}
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -80,17 +80,3 @@ object Dependencies {
 	const val nexusPublishPluginVersion = "1.0.0"
 	const val dokkaVersion = "1.4.30"
 }
-
-/**
- * Add given project as api
- */
-fun DependencyHandler.apiProject(path: String) {
-	add("api", project(path))
-}
-
-/**
- * Add given project as implementation
- */
-fun DependencyHandler.implementationProject(path: String) {
-	add("implementation", project(path))
-}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,4 @@
-import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.kotlin.dsl.project
 
 fun RepositoryHandler.defaultRepositories() {
 	google()
@@ -8,75 +6,16 @@ fun RepositoryHandler.defaultRepositories() {
 	jcenter()
 }
 
-object Dependencies {
-	object Kotlin {
-		const val version = "1.4.30"
-		private fun item(library: String) = "org.jetbrains.kotlin:kotlin-$library:$version"
-
-		val stdlib = item("stdlib")
-		val gradlePlugin = item("gradle-plugin")
-
-		object Test {
-			private fun testItem(library: String) = item("test-$library")
-
-			val junit = testItem("junit")
-		}
-	}
-
-	object KotlinX {
-		private fun item(module: String, version: String) = "org.jetbrains.kotlinx:kotlinx-${module}:${version}"
-
-		val coroutinesCore = item("coroutines-core", "1.4.2")
-		val serializationJson = item("serialization-json", "1.0.1")
+object Plugins {
+	object Versions {
+		const val kotlin = "1.4.30"
 		const val binaryCompatibilityValidatorVersion = "0.5.0"
+		const val detekt = "1.14.2"
+		const val nexusPublish = "1.0.0"
+		const val dokka = "1.4.30"
+		const val androidBuildTools = "4.1.2"
 	}
 
-	object Android {
-		const val buildTools = "com.android.tools.build:gradle:4.1.2"
-		const val desugarJdkLibs = "com.android.tools:desugar_jdk_libs:1.1.0"
-	}
-
-	object AndroidX {
-		private fun item(library: String, module: String = library, version: String) = "androidx.${library}:${module}:${version}"
-
-		val core = item("core", "core-ktx", "1.3.2")
-		val annotation = item("annotation", version = "1.1.0")
-	}
-
-	object Ktor {
-		private const val version = "1.5.1"
-		private fun item(library: String) = "io.ktor:ktor-$library:$version"
-
-		val okhttp = item("client-okhttp")
-		val serialization = item("client-serialization-jvm")
-
-		val http = item("http")
-		val io = item("io")
-	}
-
-	object Koin {
-		private const val version = "2.2.2"
-		private fun item(module: String) = "org.koin:koin-$module:$version"
-
-		val core = item("core")
-	}
-
-	object Slf4j {
-		private const val version = "1.6.1"
-		private fun item(module: String) = "org.slf4j:slf4j-$module:$version"
-
-		val api = item("api")
-		val simple = item("simple")
-	}
-
-	// Non-categorised dependencies
-	const val swaggerParser = "io.swagger.parser.v3:swagger-parser:2.0.23"
-	const val kotlinPoet = "com.squareup:kotlinpoet:1.7.2"
-	const val kasechange = "net.pearx.kasechange:kasechange:1.3.0"
-	const val clikt = "com.github.ajalt.clikt:clikt:3.0.1"
-
-	// Gradle plugins
-	const val detektVersion = "1.14.2"
-	const val nexusPublishPluginVersion = "1.0.0"
-	const val dokkaVersion = "1.4.30"
+	const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
+	const val androidBuildTools = "com.android.tools.build:gradle:${Versions.androidBuildTools}"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+[versions]
+kotlin = "1.4.30"
+kotlinx-coroutines = "1.4.2"
+kotlinx-serialization = "1.0.1"
+ktor = "1.5.1"
+slf4j = "1.6.1
+
+[libraries]
+android-desugarLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version = "1.1.0" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version = "1.1.0" }
+androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.3.2" }
+clikt = { group = "com.github.ajalt.clikt", name = "clikt", version = "3.0.1" }
+kasechange = { group = "net.pearx.kasechange", name = "kasechange", version = "1.3.0" }
+koin = { group = "org.koin", name = "koin-core", version = "2.2.2" }
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
+kotlinPoet = { group = "com.squareup", name = "kotlinpoet", version = "1.7.2" }
+kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+ktor-http = { group = "io.ktor", name = "ktor-http", version.ref = "ktor" }
+ktor-io = { group = "io.ktor", name = "ktor-io", version.ref = "ktor" }
+ktor-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-serialization = { group = "io.ktor", name = "ktor-client-serialization-jvm", version.ref = "ktor" }
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+swaggerParser = { group = "io.swagger.parser.v3", name = "swagger-parser", version = "2.0.23" }

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-	implementationProject(":jellyfin-model")
+	implementation(projects.jellyfinModel)
 
 	// HTTP
 	implementation(Dependencies.KotlinX.coroutinesCore)

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -6,16 +6,16 @@ dependencies {
 	implementation(projects.jellyfinModel)
 
 	// HTTP
-	implementation(Dependencies.KotlinX.coroutinesCore)
-	implementation(Dependencies.Ktor.okhttp)
-	implementation(Dependencies.Ktor.serialization)
+	implementation(libs.kotlinx.coroutines)
+	implementation(libs.ktor.okhttp)
+	implementation(libs.ktor.serialization)
 
 	// Logging
-	implementation(Dependencies.Slf4j.api)
-	testImplementation(Dependencies.Slf4j.simple)
+	implementation(libs.slf4j.api)
+	testImplementation(libs.slf4j.simple)
 
 	// Unit testing
-	testImplementation(Dependencies.Kotlin.Test.junit)
+	testImplementation(libs.kotlin.test.junit)
 }
 
 kotlin {

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-	apiProject(":jellyfin-api")
-	apiProject(":jellyfin-model")
+	api(projects.jellyfinApi)
+	api(projects.jellyfinModel)
 
 	implementation(Dependencies.KotlinX.coroutinesCore)
 	implementation(Dependencies.KotlinX.serializationJson)

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -6,17 +6,17 @@ dependencies {
 	api(projects.jellyfinApi)
 	api(projects.jellyfinModel)
 
-	implementation(Dependencies.KotlinX.coroutinesCore)
-	implementation(Dependencies.KotlinX.serializationJson)
+	implementation(libs.kotlinx.coroutines)
+	implementation(libs.kotlinx.serialization.json)
 
-	api(Dependencies.Ktor.http)
+	api(libs.ktor.http)
 
 	// Logging
-	implementation(Dependencies.Slf4j.api)
-	testImplementation(Dependencies.Slf4j.simple)
+	implementation(libs.slf4j.api)
+	testImplementation(libs.slf4j.simple)
 
 	// Testing
-	testImplementation(Dependencies.Kotlin.Test.junit)
+	testImplementation(libs.kotlin.test.junit)
 }
 
 kotlin {

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -1,14 +1,14 @@
 plugins {
 	id("kotlin")
-	kotlin("plugin.serialization") version Dependencies.Kotlin.version
+	kotlin("plugin.serialization") version Plugins.Versions.kotlin
 }
 
 dependencies {
-	compileOnly(Dependencies.KotlinX.serializationJson)
+	compileOnly(libs.kotlinx.serialization.json)
 
 	// Testing
-	testImplementation(Dependencies.Kotlin.Test.junit)
-	testImplementation(Dependencies.KotlinX.serializationJson)
+	testImplementation(libs.kotlin.test.junit)
+	testImplementation(libs.kotlinx.serialization.json)
 }
 
 kotlin {

--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -71,12 +71,10 @@ afterEvaluate {
 dependencies {
 	api(projects.jellyfinCore)
 
-	implementation(Dependencies.Kotlin.stdlib)
+	implementation(libs.androidx.core)
+	implementation(libs.androidx.annotation)
 
-	implementation(Dependencies.AndroidX.core)
-	implementation(Dependencies.AndroidX.annotation)
+	testImplementation(libs.kotlin.test.junit)
 
-	testImplementation(Dependencies.Kotlin.Test.junit)
-
-	coreLibraryDesugaring(Dependencies.Android.desugarJdkLibs)
+	coreLibraryDesugaring(libs.android.desugarLibs)
 }

--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -69,7 +69,7 @@ afterEvaluate {
 }
 
 dependencies {
-	apiProject(":jellyfin-core")
+	api(projects.jellyfinCore)
 
 	implementation(Dependencies.Kotlin.stdlib)
 

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -13,25 +13,25 @@ application {
 
 dependencies {
 	// Reading OpenAPI
-	implementation(Dependencies.swaggerParser)
+	implementation(libs.swaggerParser)
 
 	// Capitalization helper
-	implementation(Dependencies.kasechange)
+	implementation(libs.kasechange)
 
 	// Kotlin code generation
-	implementation(Dependencies.kotlinPoet)
+	implementation(libs.kotlinPoet)
 
 	// Needed for the kotlinx.serialization annotations
-	implementation(Dependencies.KotlinX.serializationJson)
+	implementation(libs.kotlinx.serialization.json)
 
 	// Needed for the ByteReadChannel class
-	implementation(Dependencies.Ktor.io)
+	implementation(libs.ktor.io)
 
 	// Dependency Injection
-	implementation(Dependencies.Koin.core)
+	implementation(libs.koin)
 
 	// Testing
-	testImplementation(Dependencies.Kotlin.Test.junit)
+	testImplementation(libs.kotlin.test.junit)
 }
 
 val openApiFile = file("../openapi.json")

--- a/samples/kotlin-cli/build.gradle.kts
+++ b/samples/kotlin-cli/build.gradle.kts
@@ -9,7 +9,7 @@ application {
 
 dependencies {
 	// Depend on the library project
-	implementationProject(":jellyfin-core")
+	implementation(projects.jellyfinCore)
 
 	// Use Kotlin stdlib
 	implementation(Dependencies.Kotlin.stdlib)

--- a/samples/kotlin-cli/build.gradle.kts
+++ b/samples/kotlin-cli/build.gradle.kts
@@ -11,15 +11,12 @@ dependencies {
 	// Depend on the library project
 	implementation(projects.jellyfinCore)
 
-	// Use Kotlin stdlib
-	implementation(Dependencies.Kotlin.stdlib)
-
 	// Use Kotlin coroutines to interact with the library
-	implementation(Dependencies.KotlinX.coroutinesCore)
+	implementation(libs.kotlinx.coroutines)
 
 	// The CLI library
-	implementation(Dependencies.clikt)
+	implementation(libs.clikt)
 
 	// Logging
-	implementation(Dependencies.Slf4j.simple)
+	implementation(libs.slf4j.simple)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+enableFeaturePreview("VERSION_CATALOGS")
 
 // Core
 include(":jellyfin-core")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 // Core
 include(":jellyfin-core")
 include(":jellyfin-model")


### PR DESCRIPTION
Also removed kotlin-stdlib dependency for the two projects still using it.

Plugins and buildscript dependencies cannot use the dependency catalog right now, I'm not sure if that is intended. I kept the old method for that (using buildSrc).