### PR TITLE
Add GitHub workflow to automatically update OpenAPI spec and generated sources

### DIFF
--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -1,4 +1,4 @@
-name: SDK Update API Spec
+name: SDK Update API from from Spec
 
 on:
   schedule:
@@ -24,14 +24,18 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Set Stable API Version EnvVar
+        run: |
+          VERSION=$(curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json | jq -r .info.version)
+          echo "STABLE_API_VERSION=${VERSION}" >> $GITHUB_ENV
       - name: Update generated Jellyfin API from spec
         uses: technote-space/create-pr-action@v2
         with:
           EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info updateApiSpecStable apiDump
-          COMMIT_MESSAGE: 'update generated Jellyfin API spec'
+          COMMIT_MESSAGE: 'update generated Jellyfin API from spec'
           COMMIT_NAME: 'jellyfin-bot'
           COMMIT_EMAIL: 'team@jellyfin.org'
           PR_BRANCH_PREFIX: 'openapi-update-'
           PR_BRANCH_NAME: '${PR_ID}'
-          PR_TITLE: 'Update OpenAPI'
+          PR_TITLE: 'Update OpenAPI to ${{ env.STABLE_API_VERSION }}'
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -1,0 +1,36 @@
+name: SDK Update API Spec
+
+on:
+  schedule:
+    - cron: '0 12 * * 3'
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+
+      - name: Setup Gradle cache
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-java-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-java-gradle-
+            ${{ runner.os }}-java-
+
+      - name: Run test task
+        run: ./gradlew --build-cache --no-daemon --info updateApiSpecStable
+
+      - name: Check diff
+        run: git diff

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -6,18 +6,15 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build:
+  api-spec-update:
     runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'jellyfin/jellyfin-sdk-kotlin' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: 11
-
       - name: Setup Gradle cache
         uses: actions/cache@v2.1.4
         with:
@@ -28,9 +25,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-java-gradle-
             ${{ runner.os }}-java-
-
-      - name: Run test task
-        run: ./gradlew --build-cache --no-daemon --info updateApiSpecStable
-
-      - name: Check diff
-        run: git diff
+      - name: Update generated Jellyfin API spec
+        uses: technote-space/create-pr-action@v2
+        with:
+          EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info updateApiSpecStable
+          COMMIT_MESSAGE: 'update generated Jellyfin API spec'
+          COMMIT_NAME: 'jellyfin-bot'
+          COMMIT_EMAIL: 'team@jellyfin.org'
+          PR_BRANCH_PREFIX: 'chore/'
+          PR_BRANCH_NAME: 'api-gen-update-${PR_ID}'
+          PR_TITLE: 'chore(api-gen): update generated Jellyfin API spec'
+          GITHUB_TOKEN: ${{ github.GITHUB_TOKEN }}

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -24,15 +24,15 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Set Stable API Version EnvVar
+      - name: Set STABLE_API_VERSION
         run: |
           VERSION=$(curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json | jq -r .info.version)
           echo "STABLE_API_VERSION=${VERSION}" >> $GITHUB_ENV
-      - name: Update generated Jellyfin API from spec
+      - name: Update generated sources and create pull request
         uses: technote-space/create-pr-action@v2
         with:
           EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info updateApiSpecStable apiDump
-          COMMIT_MESSAGE: 'update generated Jellyfin API from spec'
+          COMMIT_MESSAGE: 'Update generated sources to ${{ env.STABLE_API_VERSION }}'
           COMMIT_NAME: 'jellyfin-bot'
           COMMIT_EMAIL: 'team@jellyfin.org'
           PR_BRANCH_PREFIX: 'openapi-update-'

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -2,8 +2,8 @@ name: SDK Update API Spec
 
 on:
   schedule:
-    - cron: '0 12 * * 3'
-  workflow_dispatch: {}
+    - cron: '0 4 * * *'
+  workflow_dispatch:
 
 jobs:
   api-spec-update:
@@ -21,18 +21,17 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-java-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-java-gradle-
-            ${{ runner.os }}-java-
-      - name: Update generated Jellyfin API spec
+            ${{ runner.os }}-gradle-
+      - name: Update generated Jellyfin API from spec
         uses: technote-space/create-pr-action@v2
         with:
-          EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info updateApiSpecStable
+          EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info updateApiSpecStable apiDump
           COMMIT_MESSAGE: 'update generated Jellyfin API spec'
           COMMIT_NAME: 'jellyfin-bot'
           COMMIT_EMAIL: 'team@jellyfin.org'
-          PR_BRANCH_PREFIX: 'chore/'
-          PR_BRANCH_NAME: 'api-gen-update-${PR_ID}'
-          PR_TITLE: 'chore(api-gen): update generated Jellyfin API spec'
-          GITHUB_TOKEN: ${{ github.GITHUB_TOKEN }}
+          PR_BRANCH_PREFIX: 'openapi-update-'
+          PR_BRANCH_NAME: '${PR_ID}'
+          PR_TITLE: 'Update OpenAPI'
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -1,4 +1,4 @@
-name: SDK Update API from from Spec
+name: Update generated SDK sources
 
 on:
   schedule:


### PR DESCRIPTION
### Description

This PR adds a GH Action workflow to run a weekly API gen (via `updateApiSpecStable`) and open a PR if changes are detected. 

### Changes

* add workflow to check for generated jellyfin API changes

### Issues

* closes #210 

### NOTE

if you want to the PR to be opened by jellyfin-bot I think you can, but we woul have to change to token used in the `technote-space/create-pr-action` action