### PR TITLE
add missed dependencies label for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     labels:
       - ci
       - github-actions
+      - dependencies
     commit-message:
       prefix: ci
       include: scope


### PR DESCRIPTION
I should have added it to begin with :facepalm: