### PR TITLE
 Use the Jellyfin Bot for all tasks using GitHub tokens

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,3 @@ updates:
       - ci
       - github-actions
       - dependencies
-    commit-message:
-      prefix: ci
-      include: scope

--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -12,4 +12,4 @@ jobs:
       - uses: mschilde/auto-label-merge-conflicts@v2.0
         with:
           CONFLICT_LABEL_NAME: merge conflict
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -38,4 +38,4 @@ jobs:
         with:
           asset_paths: '["**/distributions/*-${{ env.JELLYFIN_VERSION }}.zip", "**/libs/*-${{ env.JELLYFIN_VERSION }}.jar", "**/outputs/aar/*.aar"]'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
- Use the Jellyfin Bot for all tasks using GitHub tokens
- Use default commit message for Dependabot
