### PR TITLE
Rename recommendedVersion to minimumVersion

### DIFF
--- a/jellyfin-core/api/jellyfin-core.api
+++ b/jellyfin-core/api/jellyfin-core.api
@@ -11,7 +11,7 @@ public final class org/jellyfin/sdk/Jellyfin {
 
 public final class org/jellyfin/sdk/Jellyfin$Companion {
 	public final fun getApiVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
-	public final fun getRecommendedVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public final fun getMinimumVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 }
 
 public final class org/jellyfin/sdk/JellyfinOptions {

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -58,7 +58,14 @@ public class Jellyfin(
 	}
 
 	public companion object {
-		public val recommendedVersion: ServerVersion = ServerVersion(10, 7, 0, 0)
+		/**
+		 * The minimum server version expected to work. Lower versions may work but are not supported.
+		 */
+		public val minimumVersion: ServerVersion = ServerVersion(10, 7, 0, 0)
+
+		/**
+		 * The exact server version used to generate the API. Should be equal or higher than [minimumVersion].
+		 */
 		public val apiVersion: ServerVersion = ServerVersion.fromString(ApiConstants.apiVersion)!!
 	}
 }

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
@@ -15,6 +15,12 @@ public class RecommendedServerDiscovery(
 ) {
 	private val logger = LoggerFactory.getLogger("RecommendedServerDiscovery")
 
+	private companion object {
+		private const val HTTP_OK = 200
+		private const val HTTPS_PREFIX = "https://"
+		private const val PRODUCT_NAME = "Jellyfin Server"
+	}
+
 	private data class SystemInfoResult(
 		val address: String,
 		val systemInfo: PublicSystemInfo?,
@@ -41,10 +47,9 @@ public class RecommendedServerDiscovery(
 		}
 		val endTime = System.currentTimeMillis()
 
-		@Suppress("MagicNumber")
 		return SystemInfoResult(
 			address = address,
-			systemInfo = if (info != null && info.status == 200) info.content else null,
+			systemInfo = if (info != null && info.status == HTTP_OK) info.content else null,
 			responseTime = endTime - startTime,
 		)
 	}
@@ -54,7 +59,7 @@ public class RecommendedServerDiscovery(
 		var points = 0
 
 		// Security
-		if (result.address.startsWith("https://")) points += 3
+		if (result.address.startsWith(HTTPS_PREFIX)) points += 3
 
 		// Speed
 		when {
@@ -71,7 +76,7 @@ public class RecommendedServerDiscovery(
 		}
 
 		val productName = result.systemInfo?.productName
-		if (productName != null && !productName.equals("Jellyfin Server", ignoreCase = true)) points = 0
+		if (productName != null && !productName.equals(PRODUCT_NAME, ignoreCase = true)) points = 0
 
 		// Minimum amount of points: 0
 		// Maximum amount of points: 8


### PR DESCRIPTION
The recommended version should always be the latest server version (which is stored in apiVersion). The minimumVersion should be the latest server version without significant API changes and is manually updated.

Also added an additional check to the server discovery score system. Non-jellyfin servers now return a BAD score for obvious reasons.