### PR TITLE
Fix path variable replacement

### DIFF
--- a/jellyfin-api/src/test/kotlin/org/jellyfin/sdk/api/client/KtorClientTests.kt
+++ b/jellyfin-api/src/test/kotlin/org/jellyfin/sdk/api/client/KtorClientTests.kt
@@ -7,7 +7,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
 public class KtorClientTests {
-	private fun createClient() = KtorClient("https://demo.jellyfin.org/stable/", null, ClientInfo("Test", "0"), DeviceInfo("test", "test"))
+	private fun createClient() =
+		KtorClient("https://demo.jellyfin.org/stable/", null, ClientInfo("Test", "0"), DeviceInfo("test", "test"))
 
 	@Test
 	public fun `createPath replaces values`() {
@@ -20,6 +21,19 @@ public class KtorClientTests {
 		)
 
 		assertEquals("test/1/2/three", instance.createPath(path, parameters))
+	}
+
+	@Test
+	public fun `createPath replaces values not separated by a slash`() {
+		val instance = createClient()
+		val path = "/test/{twe}{lve}/three"
+		val parameters = mapOf(
+			"twe" to "1",
+			"lve" to "2",
+			"three" to "3"
+		)
+
+		assertEquals("test/12/three", instance.createPath(path, parameters))
 	}
 
 	@Test


### PR DESCRIPTION
Previously, path variables were only replaced properly if they were enclosed within slashes.
Cases like e.g. `/{one}.{two}/` caused a missing path variable error for `one}.{two`.

This commit fixes those cases by iterating over the path manually,
detecting variable start/end manually, while still replacing duplicate slashes.