### PR TITLE
Update Android Gradle plugin to 4.2

### DIFF
--- a/.github/workflows/sdk-lint.yaml
+++ b/.github/workflows/sdk-lint.yaml
@@ -27,8 +27,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Run detekt task
-        run: ./gradlew --build-cache --no-daemon --info detekt
+      - name: Run detekt and lint tasks
+        run: ./gradlew --build-cache --no-daemon --info detekt lint
       - name: Upload SARIF files
         uses: github/codeql-action/upload-sarif@v1
         if: ${{ always() }}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Plugins {
 		const val detekt = "1.16.0"
 		const val nexusPublish = "1.0.0"
 		const val dokka = "1.4.30"
-		const val androidBuildTools = "4.1.2"
+		const val androidBuildTools = "4.2.0"
 	}
 
 	const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"

--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -36,6 +36,7 @@ android {
 
 	lintOptions {
 		isAbortOnError = false
+		sarifReport = true
 	}
 }
 

--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -16,9 +16,6 @@ android {
 
 	compileOptions {
 		isCoreLibraryDesugaringEnabled = true
-
-		sourceCompatibility = JavaVersion.VERSION_1_8
-		targetCompatibility = JavaVersion.VERSION_1_8
 	}
 
 	kotlinOptions {


### PR DESCRIPTION
- Update Android Gradle plugin to 4.2
- Add Android linter to linting workflow

Some notes: 4.2 compiles to Java 8 by default so we can remove those settings, SARIF output is disabled by default so it should be enabled. The `lint` task does not run `detekt` by default.