### PR TITLE
Update Kotlin to version 1.5.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ fun RepositoryHandler.defaultRepositories() {
 
 object Plugins {
 	object Versions {
-		const val kotlin = "1.4.30"
+		const val kotlin = "1.5.0"
 		const val binaryCompatibilityValidatorVersion = "0.5.0"
 		const val detekt = "1.17.0-RC2"
 		const val nexusPublish = "1.0.0"

--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -43,11 +43,11 @@ public final class org/jellyfin/sdk/model/ServerVersion {
 	public final fun getPatch ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/ServerVersion;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/ServerVersion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/ServerVersion$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/ServerVersion;
@@ -81,11 +81,11 @@ public final class org/jellyfin/sdk/model/api/AccessSchedule {
 	public final fun getUserId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AccessSchedule;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AccessSchedule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AccessSchedule$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AccessSchedule;
@@ -129,11 +129,11 @@ public final class org/jellyfin/sdk/model/api/ActivityLogEntry {
 	public final fun getUserPrimaryImageTag ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ActivityLogEntry;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ActivityLogEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ActivityLogEntry$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ActivityLogEntry;
@@ -163,11 +163,11 @@ public final class org/jellyfin/sdk/model/api/ActivityLogEntryQueryResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ActivityLogEntryQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ActivityLogEntryQueryResult;
@@ -194,11 +194,11 @@ public final class org/jellyfin/sdk/model/api/AddVirtualFolderDto {
 	public final fun getLibraryOptions ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AddVirtualFolderDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;
@@ -231,11 +231,11 @@ public final class org/jellyfin/sdk/model/api/AdminNotificationDto {
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AdminNotificationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AdminNotificationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AdminNotificationDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AdminNotificationDto;
@@ -285,11 +285,11 @@ public final class org/jellyfin/sdk/model/api/AlbumInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AlbumInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AlbumInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AlbumInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AlbumInfo;
@@ -321,11 +321,11 @@ public final class org/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery;
@@ -356,11 +356,11 @@ public final class org/jellyfin/sdk/model/api/AllThemeMediaResult {
 	public final fun getThemeVideosResult ()Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AllThemeMediaResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AllThemeMediaResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AllThemeMediaResult;
@@ -387,6 +387,7 @@ public final class org/jellyfin/sdk/model/api/Architecture : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/Architecture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/Architecture$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/Architecture;
@@ -432,11 +433,11 @@ public final class org/jellyfin/sdk/model/api/ArtistInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ArtistInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ArtistInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ArtistInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ArtistInfo;
@@ -468,11 +469,11 @@ public final class org/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery;
@@ -503,11 +504,11 @@ public final class org/jellyfin/sdk/model/api/AuthenticateUserByName {
 	public final fun getUsername ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AuthenticateUserByName$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticateUserByName$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;
@@ -555,11 +556,11 @@ public final class org/jellyfin/sdk/model/api/AuthenticationInfo {
 	public fun hashCode ()I
 	public final fun isActive ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticationInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AuthenticationInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticationInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticationInfo;
@@ -589,11 +590,11 @@ public final class org/jellyfin/sdk/model/api/AuthenticationInfoQueryResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AuthenticationInfoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticationInfoQueryResult;
@@ -626,11 +627,11 @@ public final class org/jellyfin/sdk/model/api/AuthenticationResult {
 	public final fun getUser ()Lorg/jellyfin/sdk/model/api/UserDto;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/AuthenticationResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/AuthenticationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/AuthenticationResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/AuthenticationResult;
@@ -676,11 +677,11 @@ public final class org/jellyfin/sdk/model/api/BaseItem {
 	public final fun isHd ()Z
 	public final fun isShortcut ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItem;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BaseItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItem$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItem;
@@ -1006,11 +1007,11 @@ public final class org/jellyfin/sdk/model/api/BaseItemDto {
 	public final fun isSeries ()Ljava/lang/Boolean;
 	public final fun isSports ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItemDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BaseItemDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItemDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItemDto;
@@ -1040,11 +1041,11 @@ public final class org/jellyfin/sdk/model/api/BaseItemDtoQueryResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BaseItemDtoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItemDtoQueryResult;
@@ -1080,11 +1081,11 @@ public final class org/jellyfin/sdk/model/api/BaseItemPerson {
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BaseItemPerson;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BaseItemPerson$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BaseItemPerson$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BaseItemPerson;
@@ -1102,11 +1103,11 @@ public final class org/jellyfin/sdk/model/api/BasePluginConfiguration {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/BasePluginConfiguration$Companion;
 	public fun <init> ()V
 	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BasePluginConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BasePluginConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BasePluginConfiguration$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BasePluginConfiguration;
@@ -1152,11 +1153,11 @@ public final class org/jellyfin/sdk/model/api/BookInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BookInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BookInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BookInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BookInfo;
@@ -1188,11 +1189,11 @@ public final class org/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;
@@ -1236,11 +1237,11 @@ public final class org/jellyfin/sdk/model/api/BoxSetInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BoxSetInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BoxSetInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BoxSetInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BoxSetInfo;
@@ -1272,11 +1273,11 @@ public final class org/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery;
@@ -1305,11 +1306,11 @@ public final class org/jellyfin/sdk/model/api/BrandingOptions {
 	public final fun getLoginDisclaimer ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BrandingOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BrandingOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BrandingOptions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BrandingOptions;
@@ -1340,11 +1341,11 @@ public final class org/jellyfin/sdk/model/api/BufferRequestDto {
 	public fun hashCode ()I
 	public final fun isPlaying ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/BufferRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/BufferRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/BufferRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/BufferRequestDto;
@@ -1392,11 +1393,11 @@ public final class org/jellyfin/sdk/model/api/ChannelFeatures {
 	public final fun getSupportsSortOrderToggle ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ChannelFeatures;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ChannelFeatures$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelFeatures$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelFeatures;
@@ -1425,6 +1426,7 @@ public final class org/jellyfin/sdk/model/api/ChannelItemSortField : java/lang/E
 
 public final class org/jellyfin/sdk/model/api/ChannelItemSortField$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelItemSortField$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
@@ -1457,11 +1459,11 @@ public final class org/jellyfin/sdk/model/api/ChannelMappingOptionsDto {
 	public final fun getTunerChannels ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ChannelMappingOptionsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelMappingOptionsDto;
@@ -1491,6 +1493,7 @@ public final class org/jellyfin/sdk/model/api/ChannelMediaContentType : java/lan
 
 public final class org/jellyfin/sdk/model/api/ChannelMediaContentType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelMediaContentType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
@@ -1515,6 +1518,7 @@ public final class org/jellyfin/sdk/model/api/ChannelMediaType : java/lang/Enum 
 
 public final class org/jellyfin/sdk/model/api/ChannelMediaType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelMediaType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelMediaType;
@@ -1538,6 +1542,7 @@ public final class org/jellyfin/sdk/model/api/ChannelType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/ChannelType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChannelType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChannelType;
@@ -1571,11 +1576,11 @@ public final class org/jellyfin/sdk/model/api/ChapterInfo {
 	public final fun getStartPositionTicks ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ChapterInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ChapterInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ChapterInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ChapterInfo;
@@ -1619,11 +1624,11 @@ public final class org/jellyfin/sdk/model/api/ClientCapabilities {
 	public final fun getSupportsSync ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ClientCapabilities;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ClientCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ClientCapabilities$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ClientCapabilities;
@@ -1667,11 +1672,11 @@ public final class org/jellyfin/sdk/model/api/ClientCapabilitiesDto {
 	public final fun getSupportsSync ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ClientCapabilitiesDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ClientCapabilitiesDto;
@@ -1705,11 +1710,11 @@ public final class org/jellyfin/sdk/model/api/CodecProfile {
 	public final fun getType ()Lorg/jellyfin/sdk/model/api/CodecType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CodecProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/CodecProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CodecProfile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CodecProfile;
@@ -1734,6 +1739,7 @@ public final class org/jellyfin/sdk/model/api/CodecType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/CodecType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CodecType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CodecType;
@@ -1758,11 +1764,11 @@ public final class org/jellyfin/sdk/model/api/CollectionCreationResult {
 	public final fun getId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CollectionCreationResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/CollectionCreationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CollectionCreationResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CollectionCreationResult;
@@ -1792,6 +1798,7 @@ public final class org/jellyfin/sdk/model/api/CollectionTypeOptions : java/lang/
 
 public final class org/jellyfin/sdk/model/api/CollectionTypeOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CollectionTypeOptions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
@@ -1829,11 +1836,11 @@ public final class org/jellyfin/sdk/model/api/ConfigurationPageInfo {
 	public final fun getPluginId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ConfigurationPageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ConfigurationPageInfo;
@@ -1857,6 +1864,7 @@ public final class org/jellyfin/sdk/model/api/ConfigurationPageType : java/lang/
 
 public final class org/jellyfin/sdk/model/api/ConfigurationPageType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ConfigurationPageType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
@@ -1886,11 +1894,11 @@ public final class org/jellyfin/sdk/model/api/ContainerProfile {
 	public final fun getType ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ContainerProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ContainerProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ContainerProfile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ContainerProfile;
@@ -1920,11 +1928,11 @@ public final class org/jellyfin/sdk/model/api/ControlResponse {
 	public fun hashCode ()I
 	public final fun isSuccessful ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ControlResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ControlResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ControlResponse$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ControlResponse;
@@ -1957,11 +1965,11 @@ public final class org/jellyfin/sdk/model/api/CountryInfo {
 	public final fun getTwoLetterIsoRegionName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CountryInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/CountryInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CountryInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CountryInfo;
@@ -1994,11 +2002,11 @@ public final class org/jellyfin/sdk/model/api/CreatePlaylistDto {
 	public final fun getUserId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/CreatePlaylistDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CreatePlaylistDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;
@@ -2027,11 +2035,11 @@ public final class org/jellyfin/sdk/model/api/CreateUserByName {
 	public final fun getPassword ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CreateUserByName;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/CreateUserByName$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CreateUserByName$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CreateUserByName;
@@ -2066,11 +2074,11 @@ public final class org/jellyfin/sdk/model/api/CultureDto {
 	public final fun getTwoLetterIsoLanguageName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/CultureDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/CultureDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/CultureDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/CultureDto;
@@ -2099,6 +2107,7 @@ public final class org/jellyfin/sdk/model/api/DayOfWeek : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/DayOfWeek$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DayOfWeek$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DayOfWeek;
@@ -2123,6 +2132,7 @@ public final class org/jellyfin/sdk/model/api/DayPattern : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/DayPattern$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DayPattern$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DayPattern;
@@ -2149,11 +2159,11 @@ public final class org/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto {
 	public final fun getPath ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto;
@@ -2196,11 +2206,11 @@ public final class org/jellyfin/sdk/model/api/DeviceIdentification {
 	public final fun getSerialNumber ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceIdentification;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DeviceIdentification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceIdentification$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceIdentification;
@@ -2242,11 +2252,11 @@ public final class org/jellyfin/sdk/model/api/DeviceInfo {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DeviceInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceInfo;
@@ -2276,11 +2286,11 @@ public final class org/jellyfin/sdk/model/api/DeviceInfoQueryResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DeviceInfoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceInfoQueryResult;
@@ -2307,11 +2317,11 @@ public final class org/jellyfin/sdk/model/api/DeviceOptions {
 	public final fun getCustomName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DeviceOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceOptions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceOptions;
@@ -2413,11 +2423,11 @@ public final class org/jellyfin/sdk/model/api/DeviceProfile {
 	public final fun getXmlRootAttributes ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DeviceProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceProfile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceProfile;
@@ -2447,11 +2457,11 @@ public final class org/jellyfin/sdk/model/api/DeviceProfileInfo {
 	public final fun getType ()Lorg/jellyfin/sdk/model/api/DeviceProfileType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DeviceProfileInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceProfileInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceProfileInfo;
@@ -2475,6 +2485,7 @@ public final class org/jellyfin/sdk/model/api/DeviceProfileType : java/lang/Enum
 
 public final class org/jellyfin/sdk/model/api/DeviceProfileType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DeviceProfileType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DeviceProfileType;
@@ -2506,11 +2517,11 @@ public final class org/jellyfin/sdk/model/api/DirectPlayProfile {
 	public final fun getVideoCodec ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DirectPlayProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DirectPlayProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DirectPlayProfile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
@@ -2562,11 +2573,11 @@ public final class org/jellyfin/sdk/model/api/DisplayPreferencesDto {
 	public final fun getViewType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/DisplayPreferencesDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;
@@ -2591,6 +2602,7 @@ public final class org/jellyfin/sdk/model/api/DlnaProfileType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/DlnaProfileType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DlnaProfileType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DlnaProfileType;
@@ -2622,6 +2634,7 @@ public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek : java/lang/Enum 
 
 public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
@@ -2645,6 +2658,7 @@ public final class org/jellyfin/sdk/model/api/EncodingContext : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/EncodingContext$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/EncodingContext$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/EncodingContext;
@@ -2671,11 +2685,11 @@ public final class org/jellyfin/sdk/model/api/EndPointInfo {
 	public final fun isInNetwork ()Z
 	public final fun isLocal ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/EndPointInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/EndPointInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/EndPointInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/EndPointInfo;
@@ -2708,11 +2722,11 @@ public final class org/jellyfin/sdk/model/api/ExternalIdInfo {
 	public final fun getUrlFormatString ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ExternalIdInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ExternalIdInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ExternalIdInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ExternalIdInfo;
@@ -2746,6 +2760,7 @@ public final class org/jellyfin/sdk/model/api/ExternalIdMediaType : java/lang/En
 
 public final class org/jellyfin/sdk/model/api/ExternalIdMediaType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ExternalIdMediaType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
@@ -2774,11 +2789,11 @@ public final class org/jellyfin/sdk/model/api/ExternalUrl {
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ExternalUrl;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ExternalUrl$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ExternalUrl$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ExternalUrl;
@@ -2804,6 +2819,7 @@ public final class org/jellyfin/sdk/model/api/FFmpegLocation : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/FFmpegLocation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FFmpegLocation$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FFmpegLocation;
@@ -2833,11 +2849,11 @@ public final class org/jellyfin/sdk/model/api/FileSystemEntryInfo {
 	public final fun getType ()Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/FileSystemEntryInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FileSystemEntryInfo;
@@ -2863,6 +2879,7 @@ public final class org/jellyfin/sdk/model/api/FileSystemEntryType : java/lang/En
 
 public final class org/jellyfin/sdk/model/api/FileSystemEntryType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FileSystemEntryType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
@@ -2894,11 +2911,11 @@ public final class org/jellyfin/sdk/model/api/FontFile {
 	public final fun getSize ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/FontFile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/FontFile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/FontFile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/FontFile;
@@ -2923,6 +2940,7 @@ public final class org/jellyfin/sdk/model/api/ForgotPasswordAction : java/lang/E
 
 public final class org/jellyfin/sdk/model/api/ForgotPasswordAction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordAction$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
@@ -2947,11 +2965,11 @@ public final class org/jellyfin/sdk/model/api/ForgotPasswordDto {
 	public final fun getEnteredUsername ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ForgotPasswordDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordDto;
@@ -2976,11 +2994,11 @@ public final class org/jellyfin/sdk/model/api/ForgotPasswordPinDto {
 	public final fun getPin ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ForgotPasswordPinDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordPinDto;
@@ -3010,11 +3028,11 @@ public final class org/jellyfin/sdk/model/api/ForgotPasswordResult {
 	public final fun getPinFile ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ForgotPasswordResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ForgotPasswordResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ForgotPasswordResult;
@@ -3044,11 +3062,11 @@ public final class org/jellyfin/sdk/model/api/GeneralCommand {
 	public final fun getName ()Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GeneralCommand;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/GeneralCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GeneralCommand$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GeneralCommand;
@@ -3111,6 +3129,7 @@ public final class org/jellyfin/sdk/model/api/GeneralCommandType : java/lang/Enu
 
 public final class org/jellyfin/sdk/model/api/GeneralCommandType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GeneralCommandType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GeneralCommandType;
@@ -3188,11 +3207,11 @@ public final class org/jellyfin/sdk/model/api/GetProgramsDto {
 	public final fun isSeries ()Ljava/lang/Boolean;
 	public final fun isSports ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GetProgramsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/GetProgramsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GetProgramsDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GetProgramsDto;
@@ -3226,11 +3245,11 @@ public final class org/jellyfin/sdk/model/api/GroupInfoDto {
 	public final fun getState ()Lorg/jellyfin/sdk/model/api/GroupStateType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GroupInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/GroupInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupInfoDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupInfoDto;
@@ -3254,6 +3273,7 @@ public final class org/jellyfin/sdk/model/api/GroupQueueMode : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/GroupQueueMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupQueueMode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupQueueMode;
@@ -3278,6 +3298,7 @@ public final class org/jellyfin/sdk/model/api/GroupRepeatMode : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/GroupRepeatMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupRepeatMode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
@@ -3301,6 +3322,7 @@ public final class org/jellyfin/sdk/model/api/GroupShuffleMode : java/lang/Enum 
 
 public final class org/jellyfin/sdk/model/api/GroupShuffleMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupShuffleMode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
@@ -3326,6 +3348,7 @@ public final class org/jellyfin/sdk/model/api/GroupStateType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/GroupStateType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupStateType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupStateType;
@@ -3358,6 +3381,7 @@ public final class org/jellyfin/sdk/model/api/GroupUpdateType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/GroupUpdateType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GroupUpdateType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GroupUpdateType;
@@ -3384,11 +3408,11 @@ public final class org/jellyfin/sdk/model/api/GuideInfo {
 	public final fun getStartDate ()Ljava/time/LocalDateTime;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/GuideInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/GuideInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/GuideInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/GuideInfo;
@@ -3413,6 +3437,7 @@ public final class org/jellyfin/sdk/model/api/HeaderMatchType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/HeaderMatchType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/HeaderMatchType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/HeaderMatchType;
@@ -3442,11 +3467,11 @@ public final class org/jellyfin/sdk/model/api/HttpHeaderInfo {
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/HttpHeaderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/HttpHeaderInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/HttpHeaderInfo;
@@ -3484,11 +3509,11 @@ public final class org/jellyfin/sdk/model/api/IPlugin {
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/api/Version;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/IPlugin;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/IPlugin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/IPlugin$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/IPlugin;
@@ -3513,11 +3538,11 @@ public final class org/jellyfin/sdk/model/api/IgnoreWaitRequestDto {
 	public final fun getIgnoreWait ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/IgnoreWaitRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/IgnoreWaitRequestDto;
@@ -3551,11 +3576,11 @@ public final class org/jellyfin/sdk/model/api/ImageByNameInfo {
 	public final fun getTheme ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageByNameInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ImageByNameInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageByNameInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageByNameInfo;
@@ -3582,6 +3607,7 @@ public final class org/jellyfin/sdk/model/api/ImageFormat : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/ImageFormat$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageFormat$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageFormat;
@@ -3621,11 +3647,11 @@ public final class org/jellyfin/sdk/model/api/ImageInfo {
 	public final fun getWidth ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ImageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageInfo;
@@ -3654,11 +3680,11 @@ public final class org/jellyfin/sdk/model/api/ImageOption {
 	public final fun getType ()Lorg/jellyfin/sdk/model/api/ImageType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageOption;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ImageOption$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageOption$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageOption;
@@ -3688,6 +3714,7 @@ public final class org/jellyfin/sdk/model/api/ImageOrientation : java/lang/Enum 
 
 public final class org/jellyfin/sdk/model/api/ImageOrientation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageOrientation$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageOrientation;
@@ -3716,11 +3743,11 @@ public final class org/jellyfin/sdk/model/api/ImageProviderInfo {
 	public final fun getSupportedImages ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ImageProviderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ImageProviderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageProviderInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageProviderInfo;
@@ -3744,6 +3771,7 @@ public final class org/jellyfin/sdk/model/api/ImageSavingConvention : java/lang/
 
 public final class org/jellyfin/sdk/model/api/ImageSavingConvention$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageSavingConvention$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
@@ -3778,6 +3806,7 @@ public final class org/jellyfin/sdk/model/api/ImageType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/ImageType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ImageType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ImageType;
@@ -3815,11 +3844,11 @@ public final class org/jellyfin/sdk/model/api/InstallationInfo {
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/api/Version;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/InstallationInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/InstallationInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/InstallationInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/InstallationInfo;
@@ -3843,6 +3872,7 @@ public final class org/jellyfin/sdk/model/api/IsoType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/IsoType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/IsoType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/IsoType;
@@ -3889,11 +3919,11 @@ public final class org/jellyfin/sdk/model/api/ItemCounts {
 	public final fun getTrailerCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ItemCounts;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ItemCounts$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ItemCounts$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ItemCounts;
@@ -3976,6 +4006,7 @@ public final class org/jellyfin/sdk/model/api/ItemFields : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/ItemFields$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ItemFields$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ItemFields;
@@ -4006,6 +4037,7 @@ public final class org/jellyfin/sdk/model/api/ItemFilter : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/ItemFilter$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ItemFilter$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ItemFilter;
@@ -4030,11 +4062,11 @@ public final class org/jellyfin/sdk/model/api/JoinGroupRequestDto {
 	public final fun getGroupId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/JoinGroupRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/JoinGroupRequestDto;
@@ -4060,6 +4092,7 @@ public final class org/jellyfin/sdk/model/api/KeepUntil : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/KeepUntil$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/KeepUntil$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/KeepUntil;
@@ -4087,11 +4120,11 @@ public final class org/jellyfin/sdk/model/api/LibraryOptionInfoDto {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LibraryOptionInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryOptionInfoDto;
@@ -4165,11 +4198,11 @@ public final class org/jellyfin/sdk/model/api/LibraryOptions {
 	public final fun getTypeOptions ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LibraryOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryOptions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryOptions;
@@ -4202,11 +4235,11 @@ public final class org/jellyfin/sdk/model/api/LibraryOptionsResultDto {
 	public final fun getTypeOptions ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LibraryOptionsResultDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryOptionsResultDto;
@@ -4241,11 +4274,11 @@ public final class org/jellyfin/sdk/model/api/LibraryTypeOptionsDto {
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LibraryTypeOptionsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryTypeOptionsDto;
@@ -4283,11 +4316,11 @@ public final class org/jellyfin/sdk/model/api/LibraryUpdateInfo {
 	public fun hashCode ()I
 	public final fun isEmpty ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LibraryUpdateInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LibraryUpdateInfo;
@@ -4347,11 +4380,11 @@ public final class org/jellyfin/sdk/model/api/ListingsProviderInfo {
 	public final fun getZipCode ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ListingsProviderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ListingsProviderInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;
@@ -4378,11 +4411,11 @@ public final class org/jellyfin/sdk/model/api/LiveStreamResponse {
 	public final fun getMediaSource ()Lorg/jellyfin/sdk/model/api/MediaSourceInfo;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LiveStreamResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LiveStreamResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveStreamResponse$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveStreamResponse;
@@ -4412,11 +4445,11 @@ public final class org/jellyfin/sdk/model/api/LiveTvInfo {
 	public fun hashCode ()I
 	public final fun isEnabled ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LiveTvInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LiveTvInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveTvInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveTvInfo;
@@ -4456,11 +4489,11 @@ public final class org/jellyfin/sdk/model/api/LiveTvServiceInfo {
 	public fun hashCode ()I
 	public final fun isVisible ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LiveTvServiceInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveTvServiceInfo;
@@ -4484,6 +4517,7 @@ public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus : java/lang/En
 
 public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
@@ -4512,11 +4546,11 @@ public final class org/jellyfin/sdk/model/api/LocalizationOption {
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LocalizationOption;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LocalizationOption$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LocalizationOption$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LocalizationOption;
@@ -4542,6 +4576,7 @@ public final class org/jellyfin/sdk/model/api/LocationType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/LocationType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LocationType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LocationType;
@@ -4573,11 +4608,11 @@ public final class org/jellyfin/sdk/model/api/LogFile {
 	public final fun getSize ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/LogFile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/LogFile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LogFile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LogFile;
@@ -4606,6 +4641,7 @@ public final class org/jellyfin/sdk/model/api/LogLevel : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/LogLevel$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/LogLevel$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/LogLevel;
@@ -4643,11 +4679,11 @@ public final class org/jellyfin/sdk/model/api/MediaAttachment {
 	public final fun getMimeType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaAttachment;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaAttachment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaAttachment$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaAttachment;
@@ -4676,11 +4712,11 @@ public final class org/jellyfin/sdk/model/api/MediaEncoderPathDto {
 	public final fun getPathType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaEncoderPathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaEncoderPathDto;
@@ -4710,11 +4746,11 @@ public final class org/jellyfin/sdk/model/api/MediaPathDto {
 	public final fun getPathInfo ()Lorg/jellyfin/sdk/model/api/MediaPathInfo;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaPathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaPathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaPathDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaPathDto;
@@ -4743,11 +4779,11 @@ public final class org/jellyfin/sdk/model/api/MediaPathInfo {
 	public final fun getPath ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaPathInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaPathInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaPathInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaPathInfo;
@@ -4776,6 +4812,7 @@ public final class org/jellyfin/sdk/model/api/MediaProtocol : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/MediaProtocol$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaProtocol$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaProtocol;
@@ -4883,11 +4920,11 @@ public final class org/jellyfin/sdk/model/api/MediaSourceInfo {
 	public final fun isInfiniteStream ()Z
 	public final fun isRemote ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaSourceInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaSourceInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaSourceInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaSourceInfo;
@@ -4912,6 +4949,7 @@ public final class org/jellyfin/sdk/model/api/MediaSourceType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/MediaSourceType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaSourceType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaSourceType;
@@ -5029,11 +5067,11 @@ public final class org/jellyfin/sdk/model/api/MediaStream {
 	public final fun isInterlaced ()Z
 	public final fun isTextSubtitleStream ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaStream;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaStream$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaStream$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaStream;
@@ -5059,6 +5097,7 @@ public final class org/jellyfin/sdk/model/api/MediaStreamType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/MediaStreamType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaStreamType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaStreamType;
@@ -5085,11 +5124,11 @@ public final class org/jellyfin/sdk/model/api/MediaUpdateInfoDto {
 	public final fun getUpdates ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaUpdateInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoDto;
@@ -5118,11 +5157,11 @@ public final class org/jellyfin/sdk/model/api/MediaUpdateInfoPathDto {
 	public final fun getUpdateType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaUpdateInfoPathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaUpdateInfoPathDto;
@@ -5151,11 +5190,11 @@ public final class org/jellyfin/sdk/model/api/MediaUrl {
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MediaUrl;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MediaUrl$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MediaUrl$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MediaUrl;
@@ -5185,11 +5224,11 @@ public final class org/jellyfin/sdk/model/api/MessageCommand {
 	public final fun getTimeoutMs ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MessageCommand;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MessageCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MessageCommand$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MessageCommand;
@@ -5226,11 +5265,11 @@ public final class org/jellyfin/sdk/model/api/MetadataEditorInfo {
 	public final fun getParentalRatingOptions ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MetadataEditorInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataEditorInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataEditorInfo;
@@ -5261,6 +5300,7 @@ public final class org/jellyfin/sdk/model/api/MetadataField : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/MetadataField$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataField$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataField;
@@ -5299,11 +5339,11 @@ public final class org/jellyfin/sdk/model/api/MetadataOptions {
 	public final fun getMetadataFetcherOrder ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MetadataOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MetadataOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataOptions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataOptions;
@@ -5329,6 +5369,7 @@ public final class org/jellyfin/sdk/model/api/MetadataRefreshMode : java/lang/En
 
 public final class org/jellyfin/sdk/model/api/MetadataRefreshMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MetadataRefreshMode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
@@ -5355,11 +5396,11 @@ public final class org/jellyfin/sdk/model/api/MovePlaylistItemRequestDto {
 	public final fun getPlaylistItemId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MovePlaylistItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MovePlaylistItemRequestDto;
@@ -5403,11 +5444,11 @@ public final class org/jellyfin/sdk/model/api/MovieInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MovieInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MovieInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MovieInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MovieInfo;
@@ -5439,11 +5480,11 @@ public final class org/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery;
@@ -5489,11 +5530,11 @@ public final class org/jellyfin/sdk/model/api/MusicVideoInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MusicVideoInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MusicVideoInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MusicVideoInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MusicVideoInfo;
@@ -5525,11 +5566,11 @@ public final class org/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery;
@@ -5557,11 +5598,11 @@ public final class org/jellyfin/sdk/model/api/NameGuidPair {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NameGuidPair;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NameGuidPair$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NameGuidPair$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NameGuidPair;
@@ -5590,11 +5631,11 @@ public final class org/jellyfin/sdk/model/api/NameIdPair {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NameIdPair;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NameIdPair$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NameIdPair$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NameIdPair;
@@ -5623,11 +5664,11 @@ public final class org/jellyfin/sdk/model/api/NameValuePair {
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NameValuePair;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NameValuePair$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NameValuePair$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NameValuePair;
@@ -5654,11 +5695,11 @@ public final class org/jellyfin/sdk/model/api/NewGroupRequestDto {
 	public final fun getGroupName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NewGroupRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NewGroupRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;
@@ -5683,11 +5724,11 @@ public final class org/jellyfin/sdk/model/api/NextItemRequestDto {
 	public final fun getPlaylistItemId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NextItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NextItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NextItemRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NextItemRequestDto;
@@ -5727,11 +5768,11 @@ public final class org/jellyfin/sdk/model/api/NotificationDto {
 	public fun hashCode ()I
 	public final fun isRead ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NotificationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationDto;
@@ -5756,6 +5797,7 @@ public final class org/jellyfin/sdk/model/api/NotificationLevel : java/lang/Enum
 
 public final class org/jellyfin/sdk/model/api/NotificationLevel$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationLevel$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationLevel;
@@ -5783,11 +5825,11 @@ public final class org/jellyfin/sdk/model/api/NotificationResultDto {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationResultDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NotificationResultDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationResultDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationResultDto;
@@ -5821,11 +5863,11 @@ public final class org/jellyfin/sdk/model/api/NotificationTypeInfo {
 	public fun hashCode ()I
 	public final fun isBasedOnUserEvent ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NotificationTypeInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationTypeInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationTypeInfo;
@@ -5853,11 +5895,11 @@ public final class org/jellyfin/sdk/model/api/NotificationsSummaryDto {
 	public final fun getUnreadCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/NotificationsSummaryDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/NotificationsSummaryDto;
@@ -5886,11 +5928,11 @@ public final class org/jellyfin/sdk/model/api/ObjectGroupUpdate {
 	public final fun getType ()Lorg/jellyfin/sdk/model/api/GroupUpdateType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ObjectGroupUpdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;
@@ -5941,11 +5983,11 @@ public final class org/jellyfin/sdk/model/api/OpenLiveStreamDto {
 	public final fun getUserId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/OpenLiveStreamDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/OpenLiveStreamDto;
@@ -5986,11 +6028,11 @@ public final class org/jellyfin/sdk/model/api/PackageInfo {
 	public final fun getVersions ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PackageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PackageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PackageInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PackageInfo;
@@ -6018,11 +6060,11 @@ public final class org/jellyfin/sdk/model/api/ParentalRating {
 	public final fun getValue ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ParentalRating;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ParentalRating$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ParentalRating$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ParentalRating;
@@ -6051,11 +6093,11 @@ public final class org/jellyfin/sdk/model/api/PathSubstitution {
 	public final fun getTo ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PathSubstitution;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PathSubstitution$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PathSubstitution$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PathSubstitution;
@@ -6099,11 +6141,11 @@ public final class org/jellyfin/sdk/model/api/PersonLookupInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PersonLookupInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PersonLookupInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PersonLookupInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PersonLookupInfo;
@@ -6135,11 +6177,11 @@ public final class org/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery 
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery;
@@ -6167,11 +6209,11 @@ public final class org/jellyfin/sdk/model/api/PinRedeemResult {
 	public final fun getUsersReset ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PinRedeemResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PinRedeemResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PinRedeemResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PinRedeemResult;
@@ -6196,11 +6238,11 @@ public final class org/jellyfin/sdk/model/api/PingRequestDto {
 	public final fun getPing ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PingRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PingRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PingRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PingRequestDto;
@@ -6224,6 +6266,7 @@ public final class org/jellyfin/sdk/model/api/PlayAccess : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/PlayAccess$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayAccess$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayAccess;
@@ -6250,6 +6293,7 @@ public final class org/jellyfin/sdk/model/api/PlayCommand : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/PlayCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayCommand$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayCommand;
@@ -6274,6 +6318,7 @@ public final class org/jellyfin/sdk/model/api/PlayMethod : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/PlayMethod$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayMethod$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayMethod;
@@ -6313,11 +6358,11 @@ public final class org/jellyfin/sdk/model/api/PlayRequest {
 	public final fun getSubtitleStreamIndex ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlayRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlayRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayRequest$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayRequest;
@@ -6347,11 +6392,11 @@ public final class org/jellyfin/sdk/model/api/PlayRequestDto {
 	public final fun getStartPositionTicks ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlayRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlayRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayRequestDto;
@@ -6376,6 +6421,7 @@ public final class org/jellyfin/sdk/model/api/PlaybackErrorCode : java/lang/Enum
 
 public final class org/jellyfin/sdk/model/api/PlaybackErrorCode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackErrorCode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
@@ -6430,11 +6476,11 @@ public final class org/jellyfin/sdk/model/api/PlaybackInfoDto {
 	public final fun getUserId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlaybackInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackInfoDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackInfoDto;
@@ -6465,11 +6511,11 @@ public final class org/jellyfin/sdk/model/api/PlaybackInfoResponse {
 	public final fun getPlaySessionId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlaybackInfoResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackInfoResponse;
@@ -6533,11 +6579,11 @@ public final class org/jellyfin/sdk/model/api/PlaybackProgressInfo {
 	public final fun isMuted ()Z
 	public final fun isPaused ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlaybackProgressInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackProgressInfo;
@@ -6601,11 +6647,11 @@ public final class org/jellyfin/sdk/model/api/PlaybackStartInfo {
 	public final fun isMuted ()Z
 	public final fun isPaused ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlaybackStartInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackStartInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackStartInfo;
@@ -6651,11 +6697,11 @@ public final class org/jellyfin/sdk/model/api/PlaybackStopInfo {
 	public final fun getSessionId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlaybackStopInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaybackStopInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaybackStopInfo;
@@ -6699,11 +6745,11 @@ public final class org/jellyfin/sdk/model/api/PlayerStateInfo {
 	public final fun isMuted ()Z
 	public final fun isPaused ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlayerStateInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlayerStateInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlayerStateInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlayerStateInfo;
@@ -6730,11 +6776,11 @@ public final class org/jellyfin/sdk/model/api/PlaylistCreationResult {
 	public final fun getId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlaylistCreationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaylistCreationResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaylistCreationResult;
@@ -6765,6 +6811,7 @@ public final class org/jellyfin/sdk/model/api/PlaystateCommand : java/lang/Enum 
 
 public final class org/jellyfin/sdk/model/api/PlaystateCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaystateCommand$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaystateCommand;
@@ -6794,11 +6841,11 @@ public final class org/jellyfin/sdk/model/api/PlaystateRequest {
 	public final fun getSeekPositionTicks ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PlaystateRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PlaystateRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PlaystateRequest$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PlaystateRequest;
@@ -6838,11 +6885,11 @@ public final class org/jellyfin/sdk/model/api/PluginInfo {
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/api/Version;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PluginInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PluginInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PluginInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PluginInfo;
@@ -6870,11 +6917,11 @@ public final class org/jellyfin/sdk/model/api/PluginSecurityInfo {
 	public fun hashCode ()I
 	public final fun isMbSupporter ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PluginSecurityInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PluginSecurityInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PluginSecurityInfo;
@@ -6903,6 +6950,7 @@ public final class org/jellyfin/sdk/model/api/PluginStatus : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/PluginStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PluginStatus$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PluginStatus;
@@ -6927,11 +6975,11 @@ public final class org/jellyfin/sdk/model/api/PreviousItemRequestDto {
 	public final fun getPlaylistItemId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PreviousItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PreviousItemRequestDto;
@@ -6966,11 +7014,11 @@ public final class org/jellyfin/sdk/model/api/ProblemDetails {
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ProblemDetails;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ProblemDetails$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProblemDetails$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProblemDetails;
@@ -7002,11 +7050,11 @@ public final class org/jellyfin/sdk/model/api/ProfileCondition {
 	public fun hashCode ()I
 	public final fun isRequired ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ProfileCondition;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ProfileCondition$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProfileCondition$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
@@ -7033,6 +7081,7 @@ public final class org/jellyfin/sdk/model/api/ProfileConditionType : java/lang/E
 
 public final class org/jellyfin/sdk/model/api/ProfileConditionType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProfileConditionType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProfileConditionType;
@@ -7077,6 +7126,7 @@ public final class org/jellyfin/sdk/model/api/ProfileConditionValue : java/lang/
 
 public final class org/jellyfin/sdk/model/api/ProfileConditionValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProfileConditionValue$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
@@ -7104,6 +7154,7 @@ public final class org/jellyfin/sdk/model/api/ProgramAudio : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/ProgramAudio$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ProgramAudio$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ProgramAudio;
@@ -7142,11 +7193,11 @@ public final class org/jellyfin/sdk/model/api/PublicSystemInfo {
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/PublicSystemInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/PublicSystemInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
@@ -7175,11 +7226,11 @@ public final class org/jellyfin/sdk/model/api/QueryFilters {
 	public final fun getTags ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueryFilters;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/QueryFilters$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueryFilters$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueryFilters;
@@ -7212,11 +7263,11 @@ public final class org/jellyfin/sdk/model/api/QueryFiltersLegacy {
 	public final fun getYears ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/QueryFiltersLegacy$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueryFiltersLegacy;
@@ -7244,11 +7295,11 @@ public final class org/jellyfin/sdk/model/api/QueueItem {
 	public final fun getPlaylistItemId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueueItem;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/QueueItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueueItem$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueueItem;
@@ -7276,11 +7327,11 @@ public final class org/jellyfin/sdk/model/api/QueueRequestDto {
 	public final fun getMode ()Lorg/jellyfin/sdk/model/api/GroupQueueMode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QueueRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/QueueRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QueueRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QueueRequestDto;
@@ -7305,11 +7356,11 @@ public final class org/jellyfin/sdk/model/api/QuickConnectDto {
 	public final fun getToken ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QuickConnectDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/QuickConnectDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QuickConnectDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QuickConnectDto;
@@ -7345,11 +7396,11 @@ public final class org/jellyfin/sdk/model/api/QuickConnectResult {
 	public final fun getSecret ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/QuickConnectResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/QuickConnectResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QuickConnectResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QuickConnectResult;
@@ -7374,6 +7425,7 @@ public final class org/jellyfin/sdk/model/api/QuickConnectState : java/lang/Enum
 
 public final class org/jellyfin/sdk/model/api/QuickConnectState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/QuickConnectState$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/QuickConnectState;
@@ -7397,6 +7449,7 @@ public final class org/jellyfin/sdk/model/api/RatingType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/RatingType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RatingType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RatingType;
@@ -7427,11 +7480,11 @@ public final class org/jellyfin/sdk/model/api/ReadyRequestDto {
 	public fun hashCode ()I
 	public final fun isPlaying ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ReadyRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ReadyRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ReadyRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ReadyRequestDto;
@@ -7463,11 +7516,11 @@ public final class org/jellyfin/sdk/model/api/RecommendationDto {
 	public final fun getRecommendationType ()Lorg/jellyfin/sdk/model/api/RecommendationType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RecommendationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/RecommendationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RecommendationDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RecommendationDto;
@@ -7495,6 +7548,7 @@ public final class org/jellyfin/sdk/model/api/RecommendationType : java/lang/Enu
 
 public final class org/jellyfin/sdk/model/api/RecommendationType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RecommendationType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RecommendationType;
@@ -7523,6 +7577,7 @@ public final class org/jellyfin/sdk/model/api/RecordingStatus : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/RecordingStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RecordingStatus$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RecordingStatus;
@@ -7566,11 +7621,11 @@ public final class org/jellyfin/sdk/model/api/RemoteImageInfo {
 	public final fun getWidth ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteImageInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/RemoteImageInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteImageInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteImageInfo;
@@ -7600,11 +7655,11 @@ public final class org/jellyfin/sdk/model/api/RemoteImageResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteImageResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/RemoteImageResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteImageResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteImageResult;
@@ -7653,11 +7708,11 @@ public final class org/jellyfin/sdk/model/api/RemoteSearchResult {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/RemoteSearchResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteSearchResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteSearchResult;
@@ -7704,11 +7759,11 @@ public final class org/jellyfin/sdk/model/api/RemoteSubtitleInfo {
 	public fun hashCode ()I
 	public final fun isHashMatch ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/RemoteSubtitleInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoteSubtitleInfo;
@@ -7735,11 +7790,11 @@ public final class org/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto {
 	public final fun getPlaylistItemIds ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto;
@@ -7764,6 +7819,7 @@ public final class org/jellyfin/sdk/model/api/RepeatMode : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/RepeatMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RepeatMode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RepeatMode;
@@ -7793,11 +7849,11 @@ public final class org/jellyfin/sdk/model/api/RepositoryInfo {
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/RepositoryInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/RepositoryInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/RepositoryInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/RepositoryInfo;
@@ -7835,11 +7891,11 @@ public final class org/jellyfin/sdk/model/api/ResponseProfile {
 	public final fun getVideoCodec ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ResponseProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ResponseProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ResponseProfile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ResponseProfile;
@@ -7863,6 +7919,7 @@ public final class org/jellyfin/sdk/model/api/ScrollDirection : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/ScrollDirection$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ScrollDirection$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ScrollDirection;
@@ -7944,11 +8001,11 @@ public final class org/jellyfin/sdk/model/api/SearchHint {
 	public fun hashCode ()I
 	public final fun isFolder ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SearchHint;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SearchHint$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SearchHint$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SearchHint;
@@ -7976,11 +8033,11 @@ public final class org/jellyfin/sdk/model/api/SearchHintResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SearchHintResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SearchHintResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SearchHintResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SearchHintResult;
@@ -8005,11 +8062,11 @@ public final class org/jellyfin/sdk/model/api/SeekRequestDto {
 	public final fun getPositionTicks ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeekRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SeekRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeekRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeekRequestDto;
@@ -8045,11 +8102,11 @@ public final class org/jellyfin/sdk/model/api/SendCommand {
 	public final fun getWhen ()Ljava/time/LocalDateTime;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SendCommand;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SendCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SendCommand$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SendCommand;
@@ -8075,6 +8132,7 @@ public final class org/jellyfin/sdk/model/api/SendCommandType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/SendCommandType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SendCommandType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SendCommandType;
@@ -8118,11 +8176,11 @@ public final class org/jellyfin/sdk/model/api/SeriesInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SeriesInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesInfo;
@@ -8154,11 +8212,11 @@ public final class org/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery;
@@ -8182,6 +8240,7 @@ public final class org/jellyfin/sdk/model/api/SeriesStatus : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/SeriesStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesStatus$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesStatus;
@@ -8275,11 +8334,11 @@ public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto {
 	public final fun isPostPaddingRequired ()Z
 	public final fun isPrePaddingRequired ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
@@ -8309,11 +8368,11 @@ public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult;
@@ -8503,11 +8562,11 @@ public final class org/jellyfin/sdk/model/api/ServerConfiguration {
 	public final fun isRemoteIpFilterBlacklist ()Z
 	public final fun isStartupWizardCompleted ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ServerConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ServerConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ServerConfiguration$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ServerConfiguration;
@@ -8540,11 +8599,11 @@ public final class org/jellyfin/sdk/model/api/ServerDiscoveryInfo {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ServerDiscoveryInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ServerDiscoveryInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ServerDiscoveryInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ServerDiscoveryInfo;
@@ -8624,11 +8683,11 @@ public final class org/jellyfin/sdk/model/api/SessionInfo {
 	public fun hashCode ()I
 	public final fun isActive ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SessionInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SessionInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SessionInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SessionInfo;
@@ -8684,6 +8743,7 @@ public final class org/jellyfin/sdk/model/api/SessionMessageType : java/lang/Enu
 
 public final class org/jellyfin/sdk/model/api/SessionMessageType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SessionMessageType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SessionMessageType;
@@ -8711,11 +8771,11 @@ public final class org/jellyfin/sdk/model/api/SessionUserInfo {
 	public final fun getUserName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SessionUserInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SessionUserInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SessionUserInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SessionUserInfo;
@@ -8744,11 +8804,11 @@ public final class org/jellyfin/sdk/model/api/SetChannelMappingDto {
 	public final fun getTunerChannelId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SetChannelMappingDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetChannelMappingDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetChannelMappingDto;
@@ -8773,11 +8833,11 @@ public final class org/jellyfin/sdk/model/api/SetPlaylistItemRequestDto {
 	public final fun getPlaylistItemId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SetPlaylistItemRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetPlaylistItemRequestDto;
@@ -8802,11 +8862,11 @@ public final class org/jellyfin/sdk/model/api/SetRepeatModeRequestDto {
 	public final fun getMode ()Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SetRepeatModeRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetRepeatModeRequestDto;
@@ -8831,11 +8891,11 @@ public final class org/jellyfin/sdk/model/api/SetShuffleModeRequestDto {
 	public final fun getMode ()Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SetShuffleModeRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SetShuffleModeRequestDto;
@@ -8885,11 +8945,11 @@ public final class org/jellyfin/sdk/model/api/SongInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SongInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SongInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SongInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SongInfo;
@@ -8913,6 +8973,7 @@ public final class org/jellyfin/sdk/model/api/SortOrder : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/SortOrder$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SortOrder$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SortOrder;
@@ -8941,11 +9002,11 @@ public final class org/jellyfin/sdk/model/api/SpecialViewOptionDto {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SpecialViewOptionDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SpecialViewOptionDto;
@@ -8976,11 +9037,11 @@ public final class org/jellyfin/sdk/model/api/StartupConfigurationDto {
 	public final fun getUiCulture ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/StartupConfigurationDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/StartupConfigurationDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/StartupConfigurationDto;
@@ -9007,11 +9068,11 @@ public final class org/jellyfin/sdk/model/api/StartupRemoteAccessDto {
 	public final fun getEnableRemoteAccess ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/StartupRemoteAccessDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/StartupRemoteAccessDto;
@@ -9040,11 +9101,11 @@ public final class org/jellyfin/sdk/model/api/StartupUserDto {
 	public final fun getPassword ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/StartupUserDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/StartupUserDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/StartupUserDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/StartupUserDto;
@@ -9070,6 +9131,7 @@ public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod : java/lang
 
 public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
@@ -9096,6 +9158,7 @@ public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode : java/lang/E
 
 public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
@@ -9129,11 +9192,11 @@ public final class org/jellyfin/sdk/model/api/SubtitleProfile {
 	public final fun getMethod ()Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SubtitleProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SubtitleProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SubtitleProfile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
@@ -9158,6 +9221,7 @@ public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType : java/lang
 
 public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
@@ -9233,11 +9297,11 @@ public final class org/jellyfin/sdk/model/api/SystemInfo {
 	public fun hashCode ()I
 	public final fun isShuttingDown ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/SystemInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/SystemInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/SystemInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/SystemInfo;
@@ -9263,6 +9327,7 @@ public final class org/jellyfin/sdk/model/api/TaskCompletionStatus : java/lang/E
 
 public final class org/jellyfin/sdk/model/api/TaskCompletionStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskCompletionStatus$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
@@ -9306,11 +9371,11 @@ public final class org/jellyfin/sdk/model/api/TaskInfo {
 	public fun hashCode ()I
 	public final fun isHidden ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TaskInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TaskInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskInfo;
@@ -9350,11 +9415,11 @@ public final class org/jellyfin/sdk/model/api/TaskResult {
 	public final fun getStatus ()Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TaskResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TaskResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskResult;
@@ -9379,6 +9444,7 @@ public final class org/jellyfin/sdk/model/api/TaskState : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/TaskState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskState$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskState;
@@ -9413,11 +9479,11 @@ public final class org/jellyfin/sdk/model/api/TaskTriggerInfo {
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TaskTriggerInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TaskTriggerInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TaskTriggerInfo;
@@ -9449,11 +9515,11 @@ public final class org/jellyfin/sdk/model/api/ThemeMediaResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ThemeMediaResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ThemeMediaResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ThemeMediaResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ThemeMediaResult;
@@ -9482,11 +9548,11 @@ public final class org/jellyfin/sdk/model/api/TimerEventInfo {
 	public final fun getProgramId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TimerEventInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TimerEventInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TimerEventInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TimerEventInfo;
@@ -9566,11 +9632,11 @@ public final class org/jellyfin/sdk/model/api/TimerInfoDto {
 	public final fun isPostPaddingRequired ()Z
 	public final fun isPrePaddingRequired ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TimerInfoDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TimerInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TimerInfoDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
@@ -9600,11 +9666,11 @@ public final class org/jellyfin/sdk/model/api/TimerInfoDtoQueryResult {
 	public final fun getTotalRecordCount ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TimerInfoDtoQueryResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TimerInfoDtoQueryResult;
@@ -9648,11 +9714,11 @@ public final class org/jellyfin/sdk/model/api/TrailerInfo {
 	public fun hashCode ()I
 	public final fun isAutomated ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TrailerInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TrailerInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TrailerInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TrailerInfo;
@@ -9684,11 +9750,11 @@ public final class org/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery {
 	public final fun getSearchProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery;
@@ -9733,6 +9799,7 @@ public final class org/jellyfin/sdk/model/api/TranscodeReason : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/TranscodeReason$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodeReason$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodeReason;
@@ -9756,6 +9823,7 @@ public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo : java/lang/Enum
 
 public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
@@ -9803,11 +9871,11 @@ public final class org/jellyfin/sdk/model/api/TranscodingInfo {
 	public final fun isAudioDirect ()Z
 	public final fun isVideoDirect ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TranscodingInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TranscodingInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodingInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodingInfo;
@@ -9861,11 +9929,11 @@ public final class org/jellyfin/sdk/model/api/TranscodingProfile {
 	public final fun getVideoCodec ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TranscodingProfile;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TranscodingProfile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TranscodingProfile$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TranscodingProfile;
@@ -9890,6 +9958,7 @@ public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp : java/la
 
 public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
@@ -9922,11 +9991,11 @@ public final class org/jellyfin/sdk/model/api/TunerChannelMapping {
 	public final fun getProviderChannelName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TunerChannelMapping;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TunerChannelMapping$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TunerChannelMapping$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TunerChannelMapping;
@@ -9972,11 +10041,11 @@ public final class org/jellyfin/sdk/model/api/TunerHostInfo {
 	public final fun getUserAgent ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TunerHostInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TunerHostInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TunerHostInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TunerHostInfo;
@@ -10013,11 +10082,11 @@ public final class org/jellyfin/sdk/model/api/TypeOptions {
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/TypeOptions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/TypeOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/TypeOptions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/TypeOptions;
@@ -10048,6 +10117,7 @@ public final class org/jellyfin/sdk/model/api/UnratedItem : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/UnratedItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UnratedItem$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UnratedItem;
@@ -10075,11 +10145,11 @@ public final class org/jellyfin/sdk/model/api/UpdateLibraryOptionsDto {
 	public final fun getLibraryOptions ()Lorg/jellyfin/sdk/model/api/LibraryOptions;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UpdateLibraryOptionsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateLibraryOptionsDto;
@@ -10106,11 +10176,11 @@ public final class org/jellyfin/sdk/model/api/UpdateMediaPathRequestDto {
 	public final fun getPathInfo ()Lorg/jellyfin/sdk/model/api/MediaPathInfo;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UpdateMediaPathRequestDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateMediaPathRequestDto;
@@ -10140,11 +10210,11 @@ public final class org/jellyfin/sdk/model/api/UpdateUserEasyPassword {
 	public final fun getResetPassword ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UpdateUserEasyPassword$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateUserEasyPassword;
@@ -10176,11 +10246,11 @@ public final class org/jellyfin/sdk/model/api/UpdateUserPassword {
 	public final fun getResetPassword ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UpdateUserPassword;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UpdateUserPassword$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UpdateUserPassword$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UpdateUserPassword;
@@ -10211,11 +10281,11 @@ public final class org/jellyfin/sdk/model/api/UploadSubtitleDto {
 	public fun hashCode ()I
 	public final fun isForced ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UploadSubtitleDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UploadSubtitleDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UploadSubtitleDto;
@@ -10269,11 +10339,11 @@ public final class org/jellyfin/sdk/model/api/UserConfiguration {
 	public final fun getSubtitleMode ()Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UserConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserConfiguration$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserConfiguration;
@@ -10325,11 +10395,11 @@ public final class org/jellyfin/sdk/model/api/UserDto {
 	public final fun getServerName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UserDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserDto;
@@ -10375,11 +10445,11 @@ public final class org/jellyfin/sdk/model/api/UserItemDataDto {
 	public fun hashCode ()I
 	public final fun isFavorite ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserItemDataDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UserItemDataDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserItemDataDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserItemDataDto;
@@ -10481,11 +10551,11 @@ public final class org/jellyfin/sdk/model/api/UserPolicy {
 	public final fun isDisabled ()Z
 	public final fun isHidden ()Z
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UserPolicy;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UserPolicy$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UserPolicy$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UserPolicy;
@@ -10512,11 +10582,11 @@ public final class org/jellyfin/sdk/model/api/UtcTimeResponse {
 	public final fun getResponseTransmissionTime ()Ljava/time/LocalDateTime;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/UtcTimeResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/UtcTimeResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/UtcTimeResponse$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/UtcTimeResponse;
@@ -10546,11 +10616,11 @@ public final class org/jellyfin/sdk/model/api/ValidatePathDto {
 	public fun hashCode ()I
 	public final fun isFile ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/ValidatePathDto;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/ValidatePathDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/ValidatePathDto$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/ValidatePathDto;
@@ -10585,11 +10655,11 @@ public final class org/jellyfin/sdk/model/api/Version {
 	public final fun getRevision ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/Version;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/Version$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/Version$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/Version;
@@ -10632,11 +10702,11 @@ public final class org/jellyfin/sdk/model/api/VersionInfo {
 	public final fun getVersionNumber ()Lorg/jellyfin/sdk/model/api/Version;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/VersionInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/VersionInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/VersionInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/VersionInfo;
@@ -10663,6 +10733,7 @@ public final class org/jellyfin/sdk/model/api/Video3dFormat : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/Video3dFormat$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/Video3dFormat$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/Video3dFormat;
@@ -10688,6 +10759,7 @@ public final class org/jellyfin/sdk/model/api/VideoType : java/lang/Enum {
 
 public final class org/jellyfin/sdk/model/api/VideoType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/VideoType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/VideoType;
@@ -10728,11 +10800,11 @@ public final class org/jellyfin/sdk/model/api/VirtualFolderInfo {
 	public final fun getRefreshStatus ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/VirtualFolderInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/VirtualFolderInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/VirtualFolderInfo;
@@ -10760,11 +10832,11 @@ public final class org/jellyfin/sdk/model/api/WakeOnLanInfo {
 	public final fun getPort ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/WakeOnLanInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/WakeOnLanInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/WakeOnLanInfo;
@@ -10793,11 +10865,11 @@ public final class org/jellyfin/sdk/model/api/XmlAttribute {
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/api/XmlAttribute;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/api/XmlAttribute$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/api/XmlAttribute$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/api/XmlAttribute;
@@ -10847,11 +10919,11 @@ public final class org/jellyfin/sdk/model/socket/ActivityLogEntryMessage : org/j
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ActivityLogEntryMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryMessage;
@@ -10878,11 +10950,11 @@ public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage : 
 	public final fun getPeriod ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStartMessage;
@@ -10900,11 +10972,11 @@ public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage : o
 	public static final field Companion Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage$Companion;
 	public fun <init> ()V
 	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ActivityLogEntryStopMessage;
@@ -10931,11 +11003,11 @@ public final class org/jellyfin/sdk/model/socket/ForceKeepAliveMessage : org/jel
 	public final fun getValue ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ForceKeepAliveMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ForceKeepAliveMessage;
@@ -10967,11 +11039,11 @@ public final class org/jellyfin/sdk/model/socket/GeneralCommandMessage : org/jel
 	public final fun getUserId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/GeneralCommandMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;
@@ -11030,6 +11102,7 @@ public final class org/jellyfin/sdk/model/socket/GeneralCommandType : java/lang/
 
 public final class org/jellyfin/sdk/model/socket/GeneralCommandType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/GeneralCommandType$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/GeneralCommandType;
@@ -11051,11 +11124,11 @@ public final class org/jellyfin/sdk/model/socket/KeepAliveMessage : org/jellyfin
 	public static final field Companion Lorg/jellyfin/sdk/model/socket/KeepAliveMessage$Companion;
 	public fun <init> ()V
 	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/KeepAliveMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/KeepAliveMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/KeepAliveMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/KeepAliveMessage;
@@ -11082,11 +11155,11 @@ public final class org/jellyfin/sdk/model/socket/LibraryChangedMessage : org/jel
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/LibraryChangedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/LibraryChangedMessage;
@@ -11116,11 +11189,11 @@ public final class org/jellyfin/sdk/model/socket/PackageInstallationCancelledMes
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCancelledMessage;
@@ -11147,11 +11220,11 @@ public final class org/jellyfin/sdk/model/socket/PackageInstallationCompletedMes
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallationCompletedMessage;
@@ -11178,11 +11251,11 @@ public final class org/jellyfin/sdk/model/socket/PackageInstallationFailedMessag
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/PackageInstallationFailedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallationFailedMessage;
@@ -11209,11 +11282,11 @@ public final class org/jellyfin/sdk/model/socket/PackageInstallingMessage : org/
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/PackageInstallingMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageInstallingMessage;
@@ -11240,11 +11313,11 @@ public final class org/jellyfin/sdk/model/socket/PackageUninstalledMessage : org
 	public final fun getPlugin ()Lorg/jellyfin/sdk/model/api/IPlugin;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/PackageUninstalledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PackageUninstalledMessage;
@@ -11301,11 +11374,11 @@ public final class org/jellyfin/sdk/model/socket/PlayMessage : org/jellyfin/sdk/
 	public final fun getRequest ()Lorg/jellyfin/sdk/model/api/PlayRequest;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PlayMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/PlayMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PlayMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PlayMessage;
@@ -11332,11 +11405,11 @@ public final class org/jellyfin/sdk/model/socket/PlayStateMessage : org/jellyfin
 	public final fun getRequest ()Lorg/jellyfin/sdk/model/api/PlaystateRequest;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/PlayStateMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/PlayStateMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/PlayStateMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/PlayStateMessage;
@@ -11363,11 +11436,11 @@ public final class org/jellyfin/sdk/model/socket/RefreshProgressMessage : org/je
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/RefreshProgressMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/RefreshProgressMessage;
@@ -11392,11 +11465,11 @@ public final class org/jellyfin/sdk/model/socket/RestartRequiredMessage : org/je
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/RestartRequiredMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/RestartRequiredMessage;
@@ -11423,11 +11496,11 @@ public final class org/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage : org
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTaskEndedMessage;
@@ -11454,11 +11527,11 @@ public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage : org
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoMessage;
@@ -11485,11 +11558,11 @@ public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage 
 	public final fun getPeriod ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStartMessage;
@@ -11507,11 +11580,11 @@ public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage :
 	public static final field Companion Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage$Companion;
 	public fun <init> ()V
 	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ScheduledTasksInfoStopMessage;
@@ -11538,11 +11611,11 @@ public final class org/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage : o
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCancelledMessage;
@@ -11569,11 +11642,11 @@ public final class org/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage : org
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SeriesTimerCreatedMessage;
@@ -11598,11 +11671,11 @@ public final class org/jellyfin/sdk/model/socket/ServerRestartingMessage : org/j
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ServerRestartingMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ServerRestartingMessage;
@@ -11627,11 +11700,11 @@ public final class org/jellyfin/sdk/model/socket/ServerShuttingDownMessage : org
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/ServerShuttingDownMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/ServerShuttingDownMessage;
@@ -11658,11 +11731,11 @@ public final class org/jellyfin/sdk/model/socket/SessionsMessage : org/jellyfin/
 	public final fun getSession ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SessionsMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/SessionsMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SessionsMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SessionsMessage;
@@ -11689,11 +11762,11 @@ public final class org/jellyfin/sdk/model/socket/SessionsStartMessage : org/jell
 	public final fun getPeriod ()Lorg/jellyfin/sdk/model/socket/PeriodicListenerPeriod;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/SessionsStartMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SessionsStartMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SessionsStartMessage;
@@ -11711,11 +11784,11 @@ public final class org/jellyfin/sdk/model/socket/SessionsStopMessage : org/jelly
 	public static final field Companion Lorg/jellyfin/sdk/model/socket/SessionsStopMessage$Companion;
 	public fun <init> ()V
 	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SessionsStopMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/SessionsStopMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SessionsStopMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SessionsStopMessage;
@@ -11745,11 +11818,11 @@ public final class org/jellyfin/sdk/model/socket/SyncPlayCommandMessage : org/je
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/SyncPlayCommandMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SyncPlayCommandMessage;
@@ -11776,11 +11849,11 @@ public final class org/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage : or
 	public final fun getUpdate ()Lorg/jellyfin/sdk/model/api/ObjectGroupUpdate;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/SyncPlayGroupUpdateMessage;
@@ -11807,11 +11880,11 @@ public final class org/jellyfin/sdk/model/socket/TimerCancelledMessage : org/jel
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/TimerCancelledMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/TimerCancelledMessage;
@@ -11838,11 +11911,11 @@ public final class org/jellyfin/sdk/model/socket/TimerCreatedMessage : org/jelly
 	public fun getMessageId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/TimerCreatedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/TimerCreatedMessage;
@@ -11871,11 +11944,11 @@ public final class org/jellyfin/sdk/model/socket/UserDataChangedMessage : org/je
 	public final fun getUserId ()Ljava/util/UUID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/UserDataChangedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/UserDataChangedMessage;
@@ -11902,11 +11975,11 @@ public final class org/jellyfin/sdk/model/socket/UserDeletedMessage : org/jellyf
 	public final fun getUserId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/UserDeletedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/UserDeletedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/UserDeletedMessage;
@@ -11933,11 +12006,11 @@ public final class org/jellyfin/sdk/model/socket/UserUpdatedMessage : org/jellyf
 	public final fun getUser ()Lorg/jellyfin/sdk/model/api/UserDto;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class org/jellyfin/sdk/model/socket/UserUpdatedMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/jellyfin/sdk/model/socket/UserUpdatedMessage;

--- a/jellyfin-platform-android/build.gradle.kts
+++ b/jellyfin-platform-android/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 	}
 
 	kotlinOptions {
-		jvmTarget = JavaVersion.VERSION_1_8.toString()
 		// The Android DSL doesn't support the explicitApi() function
 		// so we need to add it to the compiler arguments
 		freeCompilerArgs += "-Xexplicit-api=strict"

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -3,12 +3,11 @@ import de.undercouch.gradle.tasks.download.Download
 plugins {
 	kotlin("jvm")
 	id("application")
-
 	id("de.undercouch.download")
 }
 
 application {
-	mainClassName = "org.jellyfin.openapi.MainKt"
+	mainClass.set("org.jellyfin.openapi.MainKt")
 }
 
 dependencies {

--- a/samples/kotlin-cli/build.gradle.kts
+++ b/samples/kotlin-cli/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 application {
-	mainClassName = "org.jellyfin.sample.cli.MainKt"
+	mainClass.set("org.jellyfin.sample.cli.MainKt")
 }
 
 dependencies {


### PR DESCRIPTION
- Update Kotlin to version 1.5.0
- Updated mainClassName (deprecated) to new syntax
- Update .api file for jellyfin-model - changed due too kotlinx.serialization thingies in 1.5

JVM target is now 1.8 by default