### PR TITLE
Update Dokka to version 1.4.32

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Plugins {
 		const val binaryCompatibilityValidatorVersion = "0.5.0"
 		const val detekt = "1.17.0-RC2"
 		const val nexusPublish = "1.0.0"
-		const val dokka = "1.4.30"
+		const val dokka = "1.4.32"
 		const val androidBuildTools = "4.2.0"
 	}
 


### PR DESCRIPTION
- Update Dokka to version 1.4.32

Updates the kotlinx.html dep so it won't fail.


https://github.com/Kotlin/dokka/releases/tag/v1.4.32