### PR TITLE
Refactor discovery code with better rules

### DIFF
--- a/jellyfin-core/api/jellyfin-core.api
+++ b/jellyfin-core/api/jellyfin-core.api
@@ -47,16 +47,15 @@ public final class org/jellyfin/sdk/JellyfinOptions$Companion {
 
 public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
 	public static final field Companion Lorg/jellyfin/sdk/discovery/AddressCandidateHelper$Companion;
-	public static final field JF_BASE_URL Ljava/lang/String;
 	public static final field JF_HTTPS_PORT I
 	public static final field JF_HTTP_PORT I
+	public static final field PROTOCOL_HTTP Ljava/lang/String;
+	public static final field PROTOCOL_HTTPS Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun addBaseUrlCandidates ()V
 	public final fun addCommonCandidates ()V
 	public final fun addPortCandidates ()V
 	public final fun addProtocolCandidates ()V
 	public final fun getCandidates ()Ljava/util/List;
-	public final fun prioritize ()V
 }
 
 public final class org/jellyfin/sdk/discovery/AddressCandidateHelper$Companion {
@@ -71,12 +70,10 @@ public final class org/jellyfin/sdk/discovery/DiscoveryService {
 	public final fun discoverLocalServers (II)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun discoverLocalServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;IIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/List;
-	public final fun getRecommendedServer (Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getRecommendedServer$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getRecommendedServers (Ljava/lang/String;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRecommendedServers (Ljava/util/List;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/lang/String;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/List;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/JavaNetBroadcastAddressesProvider : org/jellyfin/sdk/discovery/DiscoveryBroadcastAddressesProvider {
@@ -103,33 +100,31 @@ public final class org/jellyfin/sdk/discovery/LocalServerDiscovery$Companion {
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerDiscovery {
 	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
-	public final fun discover (Ljava/util/List;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun discover (Lkotlinx/coroutines/flow/Flow;ZLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discover (Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discover (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerInfo {
-	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
 	public final fun component3 ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public final fun component4 ()Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Ljava/lang/String;
-	public final fun getParent ()Ljava/lang/String;
 	public final fun getResponseTime ()J
 	public final fun getScore ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public final fun getSystemInfo ()Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
 	public fun hashCode ()I
-	public final fun isAppended ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerInfoScore : java/lang/Enum {
 	public static final field BAD Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public static final field GOOD Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+	public static final field GREAT Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public static final field OK Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public static fun values ()[Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
@@ -1,24 +1,31 @@
 package org.jellyfin.sdk.discovery
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.Jellyfin
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.exception.InvalidContentException
+import org.jellyfin.sdk.api.client.exception.InvalidStatusException
+import org.jellyfin.sdk.api.client.exception.TimeoutException
 import org.jellyfin.sdk.api.operations.SystemApi
 import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.api.PublicSystemInfo
 import org.slf4j.LoggerFactory
-import java.net.ConnectException
+import kotlin.system.measureTimeMillis
 
 public class RecommendedServerDiscovery(
 	private val jellyfin: Jellyfin,
 ) {
-	private val logger = LoggerFactory.getLogger("RecommendedServerDiscovery")
-
 	private companion object {
 		private const val HTTP_OK = 200
-		private const val HTTPS_PREFIX = "https://"
 		private const val PRODUCT_NAME = "Jellyfin Server"
+		private const val SLOW_TIME_THRESHOLD = 3_000
+		private const val HTTP_TIMEOUT = 5_000L
 	}
 
 	private data class SystemInfoResult(
@@ -27,103 +34,100 @@ public class RecommendedServerDiscovery(
 		val responseTime: Long,
 	)
 
-	private suspend fun getSystemInfoResult(address: String): SystemInfoResult? {
+	private val logger = LoggerFactory.getLogger("RecommendedServerDiscovery")
+
+	@Suppress("MagicNumber")
+	private fun assignScore(result: SystemInfoResult): RecommendedServerInfo {
+		val version = result.systemInfo?.version?.let(ServerVersion::fromString)
+		val score = when {
+			// Did not reply with a valid system information
+			result.systemInfo == null -> RecommendedServerInfoScore.BAD
+			// Wrong product name - might be a different service on this connection
+			!result.systemInfo.productName.equals(PRODUCT_NAME) -> RecommendedServerInfoScore.BAD
+			// Version could not be parsed
+			version == null -> RecommendedServerInfoScore.BAD
+			// Server might be incompatible because it's below the minimum supported server version
+			version < Jellyfin.minimumVersion -> RecommendedServerInfoScore.OK
+			// API might differ slightly but at least above the minimum version
+			version < Jellyfin.apiVersion -> RecommendedServerInfoScore.GOOD
+			// Server is not too fast but should work
+			result.responseTime > SLOW_TIME_THRESHOLD -> RecommendedServerInfoScore.GOOD
+			// All other checks completed, server should have a great connection
+			else -> RecommendedServerInfoScore.GREAT
+		}
+
+		return RecommendedServerInfo(
+			result.address,
+			result.responseTime,
+			score,
+			result.systemInfo,
+		)
+	}
+
+	private suspend fun getSystemInfoResult(address: String): SystemInfoResult {
 		logger.info("Requesting public system info for $address")
 
-		val client = jellyfin.createApi(baseUrl = address)
+		val client = jellyfin.createApi(
+			baseUrl = address,
+			httpClientOptions = HttpClientOptions(
+				followRedirects = false,
+				timeout = HTTP_TIMEOUT,
+			),
+		)
 		val api = SystemApi(client)
 
-		val startTime = System.currentTimeMillis()
-
-		@Suppress("TooGenericExceptionCaught")
-		val info = try {
-			api.getPublicSystemInfo()
-		} catch (err: ConnectException) {
-			logger.debug("Could not connect to $address", err)
-			null
-		} catch (err: Exception) {
-			logger.error("Could not retrieve public system info for $address", err)
-			null
+		val info: Response<PublicSystemInfo>?
+		val responseTime = measureTimeMillis {
+			@Suppress("TooGenericExceptionCaught")
+			info = try {
+				api.getPublicSystemInfo()
+			} catch (err: TimeoutException) {
+				logger.debug("Could not connect to $address", err)
+				null
+			} catch (err: InvalidStatusException) {
+				logger.debug("Received unexpected status ${err.status} from $address", err)
+				null
+			} catch (err: InvalidContentException) {
+				logger.debug("Could not parse response from $address", err)
+				null
+			} catch (err: Throwable) {
+				logger.error("Could not retrieve public system info for $address", err)
+				null
+			}
 		}
-		val endTime = System.currentTimeMillis()
 
 		return SystemInfoResult(
 			address = address,
 			systemInfo = if (info != null && info.status == HTTP_OK) info.content else null,
-			responseTime = endTime - startTime,
+			responseTime = responseTime,
 		)
 	}
 
-	@Suppress("MagicNumber")
-	private fun assignScore(result: SystemInfoResult, parentResult: SystemInfoResult? = null): RecommendedServerInfo {
-		var points = 0
-
-		// Security
-		if (result.address.startsWith(HTTPS_PREFIX)) points += 3
-
-		// Speed
-		when {
-			result.responseTime < 500 -> points += 3
-			result.responseTime < 1500 -> points += 2
-			result.responseTime < 5000 -> points += 1
-		}
-
-		// Compatibility
-		val version = result.systemInfo?.version?.let(ServerVersion::fromString)
-		if (version != null) {
-			if (version >= Jellyfin.apiVersion) points += 1
-			if (version >= Jellyfin.minimumVersion) points += 1
-		}
-
-		val productName = result.systemInfo?.productName
-		if (productName != null && !productName.equals(PRODUCT_NAME, ignoreCase = true)) points = 0
-
-		// Minimum amount of points: 0
-		// Maximum amount of points: 8
-		val score = when {
-			points < 3 -> RecommendedServerInfoScore.BAD
-			points < 6 -> RecommendedServerInfoScore.OK
-			else -> RecommendedServerInfoScore.GOOD
-		}
-
-		return RecommendedServerInfo(result.address, result.responseTime, score, result.systemInfo, parentResult?.address)
+	/**
+	 * Discover all servers in the [servers] flow and retrieve the public system information to assign a score.
+	 * Returned servers are not ordered by score. Use [minimumScore] to automatically remove bad matches.
+	 */
+	public suspend fun discover(
+		servers: Flow<String>,
+		minimumScore: RecommendedServerInfoScore,
+	): Flow<RecommendedServerInfo> = withContext(Dispatchers.IO) {
+		servers
+			.map(::getSystemInfoResult)
+			.map(::assignScore)
+			.filter { serverInfo ->
+				// Use [minimumScore] to filter out bad score matches
+				serverInfo.score.score >= minimumScore.score
+			}
 	}
 
+	/**
+	 * Convert [servers] to a flow and calls [discover].
+	 */
 	public suspend fun discover(
 		servers: List<String>,
-		includeAppendedServers: Boolean,
 		minimumScore: RecommendedServerInfoScore,
 	): Flow<RecommendedServerInfo> = discover(
 		servers = servers.asFlow(),
-		includeAppendedServers = includeAppendedServers,
 		minimumScore = minimumScore
 	)
-
-	public suspend fun discover(
-		servers: Flow<String>,
-		includeAppendedServers: Boolean,
-		minimumScore: RecommendedServerInfoScore,
-	): Flow<RecommendedServerInfo> = withContext(Dispatchers.IO) {
-		flow {
-			servers.onEach parentEach@{ server ->
-				val info = getSystemInfoResult(server) ?: return@parentEach
-
-				if (includeAppendedServers) {
-					// Check for child server before emitting parent server
-					info.systemInfo?.localAddress?.let childLet@{ childServerAddress ->
-						val childInfo = getSystemInfoResult(childServerAddress) ?: return@childLet
-
-						// Emit info for child
-						emit(assignScore(childInfo, info))
-					}
-				}
-
-				// Emit info for server
-				emit(assignScore(info))
-			}.collect()
-		}.filter {
-			// Use [minimumScore] to filter out bad score matches
-			it.score.score >= minimumScore.score
-		}
-	}
 }

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfo.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfo.kt
@@ -7,10 +7,4 @@ public data class RecommendedServerInfo(
 	val responseTime: Long,
 	val score: RecommendedServerInfoScore,
 	val systemInfo: PublicSystemInfo?,
-	val parent: String?
-) {
-	/**
-	 * True when this server was not a part of the inputted addresses, false otherwise.
-	 */
-	val isAppended: Boolean = parent != null
-}
+)

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfoScore.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfoScore.kt
@@ -3,7 +3,26 @@ package org.jellyfin.sdk.discovery
 public enum class RecommendedServerInfoScore(
 	internal val score: Int
 ) {
+	/**
+	 * Same as [GOOD] but none of the scoring tests failed.
+	 */
+	GREAT(2),
+
+	/**
+	 * Server responds properly and appears to be compatible with the SDK. The server might be slower to respond or use
+	 * a slightly older api version.
+	 */
 	GOOD(1),
+
+	/**
+	 * The connection is not great (older server version, latency, not secure etc.) but the SDK should be able to
+	 * communicate just fine.
+	 */
 	OK(0),
+
+	/**
+	 * Indicates a server was unable to reply or the reply was not valid. Generally not recommended to proceed with a
+	 * connection.
+	 */
 	BAD(-1)
 }

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.sample.cli.command
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.default
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
@@ -9,12 +11,43 @@ import org.jellyfin.sdk.Jellyfin
 class Discover(
 	private val jellyfin: Jellyfin
 ) : CliktCommand("Discover servers on the local network") {
+	private val address by argument(
+		name = "address",
+		help = "Address to discover servers for. \"local\" to discovery servers in the local network."
+	).default("local")
+
 	override fun run() = runBlocking {
-		println("Starting discovery")
+		if (address == "local") runLocal()
+		else runAddress(address)
+	}
+
+	private suspend fun runLocal() {
+		println("Starting local network discovery")
 
 		jellyfin.discovery.discoverLocalServers().onEach {
 			println("Server ${it.name} was found at address ${it.address}:")
 			println("  $it")
 		}.collect()
+	}
+
+	private suspend fun runAddress(address: String) {
+		println("Starting discovery for $address")
+
+		val candidates = jellyfin.discovery.getAddressCandidates(address)
+		println("Found ${candidates.size} candidates")
+
+		jellyfin.discovery.getRecommendedServers(candidates).collect {
+			buildString {
+				append(it.address)
+				append(": ")
+				append(it.score.toString())
+				append(" (")
+				append("replied in ${it.responseTime}ms")
+				append(", ")
+				if (it.systemInfo == null) append("system information not found")
+				else append("system information found")
+				append(")")
+			}.let(::println)
+		}
 	}
 }

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Ping.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Ping.kt
@@ -24,7 +24,7 @@ class Ping(
 		else runSimple()
 	}
 
-	suspend fun runSimple() {
+	private suspend fun runSimple() {
 		val api = jellyfin.createApi(baseUrl = server)
 		val systemApi = SystemApi(api)
 
@@ -35,10 +35,10 @@ class Ping(
 		println("version: ${result.version}")
 	}
 
-	suspend fun runExtended() {
+	private suspend fun runExtended() {
 		val servers = jellyfin.discovery.getRecommendedServers(server)
 		servers.onEach {
-			println("${it.address}: score=${it.score} duration=${it.responseTime}ms parent(${it.isAppended})=${it.parent}")
+			println("${it.address}: score=${it.score} duration=${it.responseTime}ms")
 			println("info=${it.systemInfo}")
 			println()
 		}.collect()


### PR DESCRIPTION
# Changes
## Address Candidates

- Drop baseurl addition - too small of a user base to do this for. Each candidate adds to the amount of HTTP requests to make.
- Always prioritize candidates

## Recommendation discover

- Add new score type: GREAT
- Document all score types to summarize what they mean
- Remove `includeAppendedServers`: too complex, not worth the amount of additional requests
- Completely rewritten the scoring system. Doesn't use points anymore but strict rules instead.
  - Easier to maintain and see how it works
  - Checks if the server actually responded now
  - Uses the new GREAT type if all checks succeed
- Moved some code around, tweaked some calls

## Discovery Service

- Change the kdoc to reference the used functions instead 
  - To prevent outdated comments
- Remove `includeAppendedServers`
- Remove `getRecommendedServer`. Client should determine on it's own which server to use.

# </>

I'd love to have some feedback on the rules. Do they make sense? I think they do.