### PR TITLE
Add workflow to maintain an openapi-unstable branch

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -1,0 +1,50 @@
+name: SDK Unstable Branch
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: unstable-branch
+  cancel-in-progress: true
+
+jobs:
+  unstable-branch-update:
+    runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'jellyfin/jellyfin-sdk-kotlin' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Setup Gradle cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run updateApiSpecUnstable and apiDump tasks
+        run: ./gradlew --build-cache --no-daemon --info updateApiSpecUnstable apiDump
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v7.2.0
+        with:
+          add: .
+          author_name: jellyfin-bot
+          author_email: team@jellyfin.org
+          branch: openapi-unstable
+          message: 'Update OpenAPI to unstable'
+          pull_strategy: NO-PULL
+          push: origin openapi-unstable --force


### PR DESCRIPTION
This new workflow will run for each change in the master branch for when the generator or other code changes and on a daily schedule to make sure the spec is up-to-date.

It will always start out with the code on the master branch and then regenerate the spec with the unstable version and force pushing it. This way the branch is always exactly one commit ahead. It can then be easily compared to see what kinds of magic is added to the API for the next release. It also helps find issues in the spec that need changes in the server or generator.

Example after I ran it on my fork: https://github.com/jellyfin/jellyfin-sdk-kotlin/compare/master...nielsvanvelzen:openapi-unstable