### PR TITLE
Replace commit action with git commands in unstable branch workflow

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -10,7 +10,6 @@ on:
 
 concurrency:
   group: unstable-branch
-  cancel-in-progress: true
 
 jobs:
   unstable-branch-update:
@@ -39,12 +38,10 @@ jobs:
       - name: Run updateApiSpecUnstable and apiDump tasks
         run: ./gradlew --build-cache --no-daemon --info updateApiSpecUnstable apiDump
       - name: Commit changes
-        uses: EndBug/add-and-commit@v7.2.0
-        with:
-          add: .
-          author_name: jellyfin-bot
-          author_email: team@jellyfin.org
-          branch: openapi-unstable
-          message: 'Update OpenAPI to unstable'
-          pull_strategy: NO-PULL
-          push: origin openapi-unstable --force
+        run: |
+          git config user.name jellyfin-bot
+          git config user.email team@jellyfin.org
+          git checkout -B openapi-unstable
+          git add .
+          git commit --allow-empty -m "Update OpenAPI to unstable"
+          git push --force origin openapi-unstable


### PR DESCRIPTION
- Removed "cancel in progress" from concurrency because a cancelled action shows as "failed" in the UI. Now it just waits before executing the next.
- Replaced the `EndBug/add-and-commit@v7.2.0` action with more simple git commands:
  - First set the author config (I tried `--author` on the commit but it wouldn't work so I just used git config)
  - Create or reset the unstable branch using `git checkout`
  - Add all fiels using `git add.`
  - Create commit, allowing empty commits for when there are no changes
  - Push to openapi-unstable branch, overwriting existing commits

Closes #248 