### PR TITLE
Update kotlinx.coroutines and fix warnings in WebSocketApi

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.5.0"
-kotlinx-coroutines = "1.4.3"
-kotlinx-serialization = "1.2.0"
+kotlinx-coroutines = "1.5.0"
+kotlinx-serialization = "1.2.1"
 ktor = "1.5.4"
 slf4j = "1.6.1"
 

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.sdk.discovery
 
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
@@ -13,6 +12,7 @@ import java.net.DatagramPacket
 import java.net.DatagramSocket
 import java.net.InetAddress
 import java.net.SocketTimeoutException
+import kotlin.coroutines.coroutineContext
 
 /**
  * Used to discover Jellyfin servers in the local network.
@@ -114,7 +114,7 @@ public class LocalServerDiscovery(
 
 		@Suppress("UnusedPrivateMember")
 		for (i in 0..maxServers) {
-			if (socket.isClosed || !GlobalScope.isActive) break
+			if (socket.isClosed || !coroutineContext.isActive) break
 
 			val info = receive(socket) ?: continue
 


### PR DESCRIPTION
I'm probably rewriting the WebSocketApi at some point, I'm not satisfied with the current implementation. The current changes are minimal just to fix the warnings after the update.