### PR TITLE
Catch all types of timeouts and rethrow as ApiClientException

### DIFF
--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -240,7 +240,7 @@ public open class KtorClient(
 			// Return custom response instance
 			return Response(body, response.status.value, response.headers.toMap())
 		} catch (err: HttpRequestTimeoutException) {
-			logger.debug("Http request timed out", err)
+			logger.debug("HTTP request timed out", err)
 			throw TimeoutException(err.message)
 		} catch (err: ConnectTimeoutException) {
 			logger.debug("Connection timed out", err)

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.network.sockets.*
 import io.ktor.util.*
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -239,7 +240,13 @@ public open class KtorClient(
 			// Return custom response instance
 			return Response(body, response.status.value, response.headers.toMap())
 		} catch (err: HttpRequestTimeoutException) {
+			logger.debug("Http request timed out", err)
+			throw TimeoutException(err.message)
+		} catch (err: ConnectTimeoutException) {
 			logger.debug("Connection timed out", err)
+			throw TimeoutException(err.message)
+		} catch (err: SocketTimeoutException) {
+			logger.debug("Socket timed out", err)
 			throw TimeoutException(err.message)
 		} catch (err: NoTransformationFoundException) {
 			logger.error("Requested model does not exist!?", err)


### PR DESCRIPTION
Fixes jellyfin/jellyfin-android#368.