### PR TITLE
Fix enums not serialized in query parameters

### DIFF
--- a/jellyfin-api/src/test/kotlin/org/jellyfin/sdk/api/client/KtorClientTests.kt
+++ b/jellyfin-api/src/test/kotlin/org/jellyfin/sdk/api/client/KtorClientTests.kt
@@ -2,6 +2,7 @@ package org.jellyfin.sdk.api.client
 
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.api.ItemFields
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -98,5 +99,51 @@ public class KtorClientTests {
 		)
 
 		assertEquals("test/foo/baz", instance.createPath(path, parameters))
+	}
+
+	@Test
+	public fun `createUrl appends query parameters`() {
+		val instance = createClient()
+		val parameters = mapOf(
+			"a" to "b",
+			"c" to "2"
+		)
+
+		assertEquals(instance.baseUrl + "test?a=b&c=2", instance.createUrl("test", queryParameters = parameters))
+	}
+
+	@Test
+	public fun `createUrl removes null values`() {
+		val instance = createClient()
+		val parameters = mapOf(
+			"a" to "b",
+			"c" to null,
+			"d" to "2"
+		)
+
+		assertEquals(instance.baseUrl + "test?a=b&d=2", instance.createUrl("test", queryParameters = parameters))
+	}
+
+	@Test
+	public fun `createUrl stringifies values`() {
+		val instance = createClient()
+		val parameters = mapOf(
+			"one" to 1,
+			"bool" to true,
+			"str" to "str"
+		)
+
+		assertEquals(instance.baseUrl + "test?one=1&bool=true&str=str", instance.createUrl("test", queryParameters = parameters))
+	}
+
+	@Test
+	public fun `createUrl stringifies enum values`() {
+		val instance = createClient()
+		val parameters = mapOf(
+			"field1" to ItemFields.CHAPTERS,
+			"field2" to ItemFields.DATE_CREATED,
+		)
+
+		assertEquals(instance.baseUrl + "test?field1=Chapters&field2=DateCreated", instance.createUrl("test", queryParameters = parameters))
 	}
 }

--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -381,6 +381,8 @@ public final class org/jellyfin/sdk/model/api/Architecture : java/lang/Enum {
 	public static final field WASM Lorg/jellyfin/sdk/model/api/Architecture;
 	public static final field X64 Lorg/jellyfin/sdk/model/api/Architecture;
 	public static final field X86 Lorg/jellyfin/sdk/model/api/Architecture;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Architecture;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/Architecture;
 }
@@ -1420,6 +1422,8 @@ public final class org/jellyfin/sdk/model/api/ChannelItemSortField : java/lang/E
 	public static final field PLAY_COUNT Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
 	public static final field PREMIERE_DATE Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
 	public static final field RUNTIME Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
 }
@@ -1487,6 +1491,8 @@ public final class org/jellyfin/sdk/model/api/ChannelMediaContentType : java/lan
 	public static final field SONG Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
 	public static final field TRAILER Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
 	public static final field TV_EXTRA Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
 }
@@ -1512,6 +1518,8 @@ public final class org/jellyfin/sdk/model/api/ChannelMediaType : java/lang/Enum 
 	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelMediaType$Companion;
 	public static final field PHOTO Lorg/jellyfin/sdk/model/api/ChannelMediaType;
 	public static final field VIDEO Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelMediaType;
 }
@@ -1536,6 +1544,8 @@ public final class org/jellyfin/sdk/model/api/ChannelType : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/ChannelType$Companion;
 	public static final field RADIO Lorg/jellyfin/sdk/model/api/ChannelType;
 	public static final field TV Lorg/jellyfin/sdk/model/api/ChannelType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ChannelType;
 }
@@ -1733,6 +1743,8 @@ public final class org/jellyfin/sdk/model/api/CodecType : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/CodecType$Companion;
 	public static final field VIDEO Lorg/jellyfin/sdk/model/api/CodecType;
 	public static final field VIDEO_AUDIO Lorg/jellyfin/sdk/model/api/CodecType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CodecType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/CodecType;
 }
@@ -1792,6 +1804,8 @@ public final class org/jellyfin/sdk/model/api/CollectionTypeOptions : java/lang/
 	public static final field MUSIC Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
 	public static final field MUSIC_VIDEOS Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
 	public static final field TV_SHOWS Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
 }
@@ -1858,6 +1872,8 @@ public final class org/jellyfin/sdk/model/api/ConfigurationPageType : java/lang/
 	public static final field Companion Lorg/jellyfin/sdk/model/api/ConfigurationPageType$Companion;
 	public static final field NONE Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
 	public static final field PLUGIN_CONFIGURATION Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ConfigurationPageType;
 }
@@ -2101,6 +2117,8 @@ public final class org/jellyfin/sdk/model/api/DayOfWeek : java/lang/Enum {
 	public static final field THURSDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
 	public static final field TUESDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
 	public static final field WEDNESDAY Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayOfWeek;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/DayOfWeek;
 }
@@ -2126,6 +2144,8 @@ public final class org/jellyfin/sdk/model/api/DayPattern : java/lang/Enum {
 	public static final field DAILY Lorg/jellyfin/sdk/model/api/DayPattern;
 	public static final field WEEKDAYS Lorg/jellyfin/sdk/model/api/DayPattern;
 	public static final field WEEKENDS Lorg/jellyfin/sdk/model/api/DayPattern;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayPattern;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/DayPattern;
 }
@@ -2479,6 +2499,8 @@ public final class org/jellyfin/sdk/model/api/DeviceProfileType : java/lang/Enum
 	public static final field Companion Lorg/jellyfin/sdk/model/api/DeviceProfileType$Companion;
 	public static final field SYSTEM Lorg/jellyfin/sdk/model/api/DeviceProfileType;
 	public static final field USER Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DeviceProfileType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/DeviceProfileType;
 }
@@ -2596,6 +2618,8 @@ public final class org/jellyfin/sdk/model/api/DlnaProfileType : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/DlnaProfileType$Companion;
 	public static final field PHOTO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public static final field VIDEO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 }
@@ -2628,6 +2652,8 @@ public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek : java/lang/Enum 
 	public static final field WEDNESDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
 	public static final field WEEKDAY Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
 	public static final field WEEKEND Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
 }
@@ -2652,6 +2678,8 @@ public final class org/jellyfin/sdk/model/api/EncodingContext : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/EncodingContext$Companion;
 	public static final field STATIC Lorg/jellyfin/sdk/model/api/EncodingContext;
 	public static final field STREAMING Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/EncodingContext;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/EncodingContext;
 }
@@ -2754,6 +2782,8 @@ public final class org/jellyfin/sdk/model/api/ExternalIdMediaType : java/lang/En
 	public static final field SEASON Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public static final field SERIES Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public static final field TRACK Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 }
@@ -2813,6 +2843,8 @@ public final class org/jellyfin/sdk/model/api/FFmpegLocation : java/lang/Enum {
 	public static final field NOT_FOUND Lorg/jellyfin/sdk/model/api/FFmpegLocation;
 	public static final field SET_BY_ARGUMENT Lorg/jellyfin/sdk/model/api/FFmpegLocation;
 	public static final field SYSTEM Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FFmpegLocation;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/FFmpegLocation;
 }
@@ -2873,6 +2905,8 @@ public final class org/jellyfin/sdk/model/api/FileSystemEntryType : java/lang/En
 	public static final field FILE Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
 	public static final field NETWORK_COMPUTER Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
 	public static final field NETWORK_SHARE Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
 }
@@ -2934,6 +2968,8 @@ public final class org/jellyfin/sdk/model/api/ForgotPasswordAction : java/lang/E
 	public static final field Companion Lorg/jellyfin/sdk/model/api/ForgotPasswordAction$Companion;
 	public static final field IN_NETWORK_REQUIRED Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
 	public static final field PIN_CODE Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
 }
@@ -3123,6 +3159,8 @@ public final class org/jellyfin/sdk/model/api/GeneralCommandType : java/lang/Enu
 	public static final field UNMUTE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static final field VOLUME_DOWN Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static final field VOLUME_UP Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 }
@@ -3267,6 +3305,8 @@ public final class org/jellyfin/sdk/model/api/GroupQueueMode : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupQueueMode$Companion;
 	public static final field QUEUE Lorg/jellyfin/sdk/model/api/GroupQueueMode;
 	public static final field QUEUE_NEXT Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupQueueMode;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupQueueMode;
 }
@@ -3292,6 +3332,8 @@ public final class org/jellyfin/sdk/model/api/GroupRepeatMode : java/lang/Enum {
 	public static final field REPEAT_ALL Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
 	public static final field REPEAT_NONE Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
 	public static final field REPEAT_ONE Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
 }
@@ -3316,6 +3358,8 @@ public final class org/jellyfin/sdk/model/api/GroupShuffleMode : java/lang/Enum 
 	public static final field Companion Lorg/jellyfin/sdk/model/api/GroupShuffleMode$Companion;
 	public static final field SHUFFLE Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
 	public static final field SORTED Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
 }
@@ -3342,6 +3386,8 @@ public final class org/jellyfin/sdk/model/api/GroupStateType : java/lang/Enum {
 	public static final field PAUSED Lorg/jellyfin/sdk/model/api/GroupStateType;
 	public static final field PLAYING Lorg/jellyfin/sdk/model/api/GroupStateType;
 	public static final field WAITING Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupStateType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupStateType;
 }
@@ -3375,6 +3421,8 @@ public final class org/jellyfin/sdk/model/api/GroupUpdateType : java/lang/Enum {
 	public static final field STATE_UPDATE Lorg/jellyfin/sdk/model/api/GroupUpdateType;
 	public static final field USER_JOINED Lorg/jellyfin/sdk/model/api/GroupUpdateType;
 	public static final field USER_LEFT Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupUpdateType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/GroupUpdateType;
 }
@@ -3431,6 +3479,8 @@ public final class org/jellyfin/sdk/model/api/HeaderMatchType : java/lang/Enum {
 	public static final field EQUALS Lorg/jellyfin/sdk/model/api/HeaderMatchType;
 	public static final field REGEX Lorg/jellyfin/sdk/model/api/HeaderMatchType;
 	public static final field SUBSTRING Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/HeaderMatchType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/HeaderMatchType;
 }
@@ -3601,6 +3651,8 @@ public final class org/jellyfin/sdk/model/api/ImageFormat : java/lang/Enum {
 	public static final field JPG Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public static final field PNG Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public static final field WEBP Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageFormat;
 }
@@ -3708,6 +3760,8 @@ public final class org/jellyfin/sdk/model/api/ImageOrientation : java/lang/Enum 
 	public static final field RIGHT_TOP Lorg/jellyfin/sdk/model/api/ImageOrientation;
 	public static final field TOP_LEFT Lorg/jellyfin/sdk/model/api/ImageOrientation;
 	public static final field TOP_RIGHT Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageOrientation;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageOrientation;
 }
@@ -3765,6 +3819,8 @@ public final class org/jellyfin/sdk/model/api/ImageSavingConvention : java/lang/
 	public static final field COMPATIBLE Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/ImageSavingConvention$Companion;
 	public static final field LEGACY Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
 }
@@ -3800,6 +3856,8 @@ public final class org/jellyfin/sdk/model/api/ImageType : java/lang/Enum {
 	public static final field PROFILE Lorg/jellyfin/sdk/model/api/ImageType;
 	public static final field SCREENSHOT Lorg/jellyfin/sdk/model/api/ImageType;
 	public static final field THUMB Lorg/jellyfin/sdk/model/api/ImageType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ImageType;
 }
@@ -3866,6 +3924,8 @@ public final class org/jellyfin/sdk/model/api/IsoType : java/lang/Enum {
 	public static final field BLU_RAY Lorg/jellyfin/sdk/model/api/IsoType;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/IsoType$Companion;
 	public static final field DVD Lorg/jellyfin/sdk/model/api/IsoType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/IsoType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/IsoType;
 }
@@ -4000,6 +4060,8 @@ public final class org/jellyfin/sdk/model/api/ItemFields : java/lang/Enum {
 	public static final field THEME_SONG_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
 	public static final field THEME_VIDEO_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
 	public static final field WIDTH Lorg/jellyfin/sdk/model/api/ItemFields;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFields;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ItemFields;
 }
@@ -4031,6 +4093,8 @@ public final class org/jellyfin/sdk/model/api/ItemFilter : java/lang/Enum {
 	public static final field IS_RESUMABLE Lorg/jellyfin/sdk/model/api/ItemFilter;
 	public static final field IS_UNPLAYED Lorg/jellyfin/sdk/model/api/ItemFilter;
 	public static final field LIKES Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFilter;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ItemFilter;
 }
@@ -4086,6 +4150,8 @@ public final class org/jellyfin/sdk/model/api/KeepUntil : java/lang/Enum {
 	public static final field UNTIL_DELETED Lorg/jellyfin/sdk/model/api/KeepUntil;
 	public static final field UNTIL_SPACE_NEEDED Lorg/jellyfin/sdk/model/api/KeepUntil;
 	public static final field UNTIL_WATCHED Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/KeepUntil;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/KeepUntil;
 }
@@ -4511,6 +4577,8 @@ public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus : java/lang/En
 	public static final field Companion Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus$Companion;
 	public static final field OK Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
 	public static final field UNAVAILABLE Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
 }
@@ -4570,6 +4638,8 @@ public final class org/jellyfin/sdk/model/api/LocationType : java/lang/Enum {
 	public static final field OFFLINE Lorg/jellyfin/sdk/model/api/LocationType;
 	public static final field REMOTE Lorg/jellyfin/sdk/model/api/LocationType;
 	public static final field VIRTUAL Lorg/jellyfin/sdk/model/api/LocationType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LocationType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/LocationType;
 }
@@ -4635,6 +4705,8 @@ public final class org/jellyfin/sdk/model/api/LogLevel : java/lang/Enum {
 	public static final field NONE Lorg/jellyfin/sdk/model/api/LogLevel;
 	public static final field TRACE Lorg/jellyfin/sdk/model/api/LogLevel;
 	public static final field WARNING Lorg/jellyfin/sdk/model/api/LogLevel;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LogLevel;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/LogLevel;
 }
@@ -4806,6 +4878,8 @@ public final class org/jellyfin/sdk/model/api/MediaProtocol : java/lang/Enum {
 	public static final field RTP Lorg/jellyfin/sdk/model/api/MediaProtocol;
 	public static final field RTSP Lorg/jellyfin/sdk/model/api/MediaProtocol;
 	public static final field UDP Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaProtocol;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/MediaProtocol;
 }
@@ -4943,6 +5017,8 @@ public final class org/jellyfin/sdk/model/api/MediaSourceType : java/lang/Enum {
 	public static final field DEFAULT Lorg/jellyfin/sdk/model/api/MediaSourceType;
 	public static final field GROUPING Lorg/jellyfin/sdk/model/api/MediaSourceType;
 	public static final field PLACEHOLDER Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaSourceType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/MediaSourceType;
 }
@@ -5091,6 +5167,8 @@ public final class org/jellyfin/sdk/model/api/MediaStreamType : java/lang/Enum {
 	public static final field EMBEDDED_IMAGE Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public static final field SUBTITLE Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public static final field VIDEO Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/MediaStreamType;
 }
@@ -5294,6 +5372,8 @@ public final class org/jellyfin/sdk/model/api/MetadataField : java/lang/Enum {
 	public static final field RUNTIME Lorg/jellyfin/sdk/model/api/MetadataField;
 	public static final field STUDIOS Lorg/jellyfin/sdk/model/api/MetadataField;
 	public static final field TAGS Lorg/jellyfin/sdk/model/api/MetadataField;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataField;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/MetadataField;
 }
@@ -5363,6 +5443,8 @@ public final class org/jellyfin/sdk/model/api/MetadataRefreshMode : java/lang/En
 	public static final field FULL_REFRESH Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
 	public static final field NONE Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
 	public static final field VALIDATION_ONLY Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
 }
@@ -5791,6 +5873,8 @@ public final class org/jellyfin/sdk/model/api/NotificationLevel : java/lang/Enum
 	public static final field ERROR Lorg/jellyfin/sdk/model/api/NotificationLevel;
 	public static final field NORMAL Lorg/jellyfin/sdk/model/api/NotificationLevel;
 	public static final field WARNING Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/NotificationLevel;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/NotificationLevel;
 }
@@ -6260,6 +6344,8 @@ public final class org/jellyfin/sdk/model/api/PlayAccess : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/PlayAccess$Companion;
 	public static final field FULL Lorg/jellyfin/sdk/model/api/PlayAccess;
 	public static final field NONE Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayAccess;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlayAccess;
 }
@@ -6287,6 +6373,8 @@ public final class org/jellyfin/sdk/model/api/PlayCommand : java/lang/Enum {
 	public static final field PLAY_NEXT Lorg/jellyfin/sdk/model/api/PlayCommand;
 	public static final field PLAY_NOW Lorg/jellyfin/sdk/model/api/PlayCommand;
 	public static final field PLAY_SHUFFLE Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayCommand;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlayCommand;
 }
@@ -6312,6 +6400,8 @@ public final class org/jellyfin/sdk/model/api/PlayMethod : java/lang/Enum {
 	public static final field DIRECT_PLAY Lorg/jellyfin/sdk/model/api/PlayMethod;
 	public static final field DIRECT_STREAM Lorg/jellyfin/sdk/model/api/PlayMethod;
 	public static final field TRANSCODE Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayMethod;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlayMethod;
 }
@@ -6415,6 +6505,8 @@ public final class org/jellyfin/sdk/model/api/PlaybackErrorCode : java/lang/Enum
 	public static final field NOT_ALLOWED Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
 	public static final field NO_COMPATIBLE_STREAM Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
 	public static final field RATE_LIMIT_EXCEEDED Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
 }
@@ -6805,6 +6897,8 @@ public final class org/jellyfin/sdk/model/api/PlaystateCommand : java/lang/Enum 
 	public static final field SEEK Lorg/jellyfin/sdk/model/api/PlaystateCommand;
 	public static final field STOP Lorg/jellyfin/sdk/model/api/PlaystateCommand;
 	public static final field UNPAUSE Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaystateCommand;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/PlaystateCommand;
 }
@@ -6944,6 +7038,8 @@ public final class org/jellyfin/sdk/model/api/PluginStatus : java/lang/Enum {
 	public static final field NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/PluginStatus;
 	public static final field RESTART Lorg/jellyfin/sdk/model/api/PluginStatus;
 	public static final field SUPERCEDED Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PluginStatus;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/PluginStatus;
 }
@@ -7075,6 +7171,8 @@ public final class org/jellyfin/sdk/model/api/ProfileConditionType : java/lang/E
 	public static final field GREATER_THAN_EQUAL Lorg/jellyfin/sdk/model/api/ProfileConditionType;
 	public static final field LESS_THAN_EQUAL Lorg/jellyfin/sdk/model/api/ProfileConditionType;
 	public static final field NOT_EQUALS Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ProfileConditionType;
 }
@@ -7120,6 +7218,8 @@ public final class org/jellyfin/sdk/model/api/ProfileConditionValue : java/lang/
 	public static final field VIDEO_PROFILE Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
 	public static final field VIDEO_TIMESTAMP Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
 	public static final field WIDTH Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
 }
@@ -7148,6 +7248,8 @@ public final class org/jellyfin/sdk/model/api/ProgramAudio : java/lang/Enum {
 	public static final field MONO Lorg/jellyfin/sdk/model/api/ProgramAudio;
 	public static final field STEREO Lorg/jellyfin/sdk/model/api/ProgramAudio;
 	public static final field THX Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProgramAudio;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ProgramAudio;
 }
@@ -7419,6 +7521,8 @@ public final class org/jellyfin/sdk/model/api/QuickConnectState : java/lang/Enum
 	public static final field AVAILABLE Lorg/jellyfin/sdk/model/api/QuickConnectState;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/QuickConnectState$Companion;
 	public static final field UNAVAILABLE Lorg/jellyfin/sdk/model/api/QuickConnectState;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/QuickConnectState;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/QuickConnectState;
 }
@@ -7443,6 +7547,8 @@ public final class org/jellyfin/sdk/model/api/RatingType : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/RatingType$Companion;
 	public static final field LIKES Lorg/jellyfin/sdk/model/api/RatingType;
 	public static final field SCORE Lorg/jellyfin/sdk/model/api/RatingType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RatingType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/RatingType;
 }
@@ -7542,6 +7648,8 @@ public final class org/jellyfin/sdk/model/api/RecommendationType : java/lang/Enu
 	public static final field HAS_LIKED_DIRECTOR Lorg/jellyfin/sdk/model/api/RecommendationType;
 	public static final field SIMILAR_TO_LIKED_ITEM Lorg/jellyfin/sdk/model/api/RecommendationType;
 	public static final field SIMILAR_TO_RECENTLY_PLAYED Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecommendationType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/RecommendationType;
 }
@@ -7571,6 +7679,8 @@ public final class org/jellyfin/sdk/model/api/RecordingStatus : java/lang/Enum {
 	public static final field ERROR Lorg/jellyfin/sdk/model/api/RecordingStatus;
 	public static final field IN_PROGRESS Lorg/jellyfin/sdk/model/api/RecordingStatus;
 	public static final field NEW Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecordingStatus;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/RecordingStatus;
 }
@@ -7813,6 +7923,8 @@ public final class org/jellyfin/sdk/model/api/RepeatMode : java/lang/Enum {
 	public static final field REPEAT_ALL Lorg/jellyfin/sdk/model/api/RepeatMode;
 	public static final field REPEAT_NONE Lorg/jellyfin/sdk/model/api/RepeatMode;
 	public static final field REPEAT_ONE Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RepeatMode;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/RepeatMode;
 }
@@ -7913,6 +8025,8 @@ public final class org/jellyfin/sdk/model/api/ScrollDirection : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/ScrollDirection$Companion;
 	public static final field HORIZONTAL Lorg/jellyfin/sdk/model/api/ScrollDirection;
 	public static final field VERTICAL Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ScrollDirection;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/ScrollDirection;
 }
@@ -8126,6 +8240,8 @@ public final class org/jellyfin/sdk/model/api/SendCommandType : java/lang/Enum {
 	public static final field SEEK Lorg/jellyfin/sdk/model/api/SendCommandType;
 	public static final field STOP Lorg/jellyfin/sdk/model/api/SendCommandType;
 	public static final field UNPAUSE Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SendCommandType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/SendCommandType;
 }
@@ -8234,6 +8350,8 @@ public final class org/jellyfin/sdk/model/api/SeriesStatus : java/lang/Enum {
 	public static final field CONTINUING Lorg/jellyfin/sdk/model/api/SeriesStatus;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesStatus$Companion;
 	public static final field ENDED Lorg/jellyfin/sdk/model/api/SeriesStatus;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesStatus;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/SeriesStatus;
 }
@@ -8737,6 +8855,8 @@ public final class org/jellyfin/sdk/model/api/SessionMessageType : java/lang/Enu
 	public static final field USER_DATA_CHANGED Lorg/jellyfin/sdk/model/api/SessionMessageType;
 	public static final field USER_DELETED Lorg/jellyfin/sdk/model/api/SessionMessageType;
 	public static final field USER_UPDATED Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SessionMessageType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/SessionMessageType;
 }
@@ -8967,6 +9087,8 @@ public final class org/jellyfin/sdk/model/api/SortOrder : java/lang/Enum {
 	public static final field ASCENDING Lorg/jellyfin/sdk/model/api/SortOrder;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/SortOrder$Companion;
 	public static final field DESCENDING Lorg/jellyfin/sdk/model/api/SortOrder;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SortOrder;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/SortOrder;
 }
@@ -9125,6 +9247,8 @@ public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod : java/lang
 	public static final field ENCODE Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
 	public static final field EXTERNAL Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
 	public static final field HLS Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
 }
@@ -9152,6 +9276,8 @@ public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode : java/lang/E
 	public static final field NONE Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
 	public static final field ONLY_FORCED Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
 	public static final field SMART Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
 }
@@ -9215,6 +9341,8 @@ public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType : java/lang
 	public static final field Companion Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType$Companion;
 	public static final field JOIN_GROUPS Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
 	public static final field NONE Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
 }
@@ -9321,6 +9449,8 @@ public final class org/jellyfin/sdk/model/api/TaskCompletionStatus : java/lang/E
 	public static final field COMPLETED Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/TaskCompletionStatus$Companion;
 	public static final field FAILED Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
 }
@@ -9438,6 +9568,8 @@ public final class org/jellyfin/sdk/model/api/TaskState : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/TaskState$Companion;
 	public static final field IDLE Lorg/jellyfin/sdk/model/api/TaskState;
 	public static final field RUNNING Lorg/jellyfin/sdk/model/api/TaskState;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskState;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/TaskState;
 }
@@ -9793,6 +9925,8 @@ public final class org/jellyfin/sdk/model/api/TranscodeReason : java/lang/Enum {
 	public static final field VIDEO_LEVEL_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
 	public static final field VIDEO_PROFILE_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
 	public static final field VIDEO_RESOLUTION_NOT_SUPPORTED Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeReason;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/TranscodeReason;
 }
@@ -9817,6 +9951,8 @@ public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo : java/lang/Enum
 	public static final field AUTO Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
 	public static final field BYTES Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo$Companion;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
 }
@@ -9952,6 +10088,8 @@ public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp : java/la
 	public static final field NONE Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
 	public static final field VALID Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
 	public static final field ZERO Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
 }
@@ -10111,6 +10249,8 @@ public final class org/jellyfin/sdk/model/api/UnratedItem : java/lang/Enum {
 	public static final field OTHER Lorg/jellyfin/sdk/model/api/UnratedItem;
 	public static final field SERIES Lorg/jellyfin/sdk/model/api/UnratedItem;
 	public static final field TRAILER Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/UnratedItem;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/UnratedItem;
 }
@@ -10727,6 +10867,8 @@ public final class org/jellyfin/sdk/model/api/Video3dFormat : java/lang/Enum {
 	public static final field HALF_SIDE_BY_SIDE Lorg/jellyfin/sdk/model/api/Video3dFormat;
 	public static final field HALF_TOP_AND_BOTTOM Lorg/jellyfin/sdk/model/api/Video3dFormat;
 	public static final field MVC Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Video3dFormat;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/Video3dFormat;
 }
@@ -10753,6 +10895,8 @@ public final class org/jellyfin/sdk/model/api/VideoType : java/lang/Enum {
 	public static final field DVD Lorg/jellyfin/sdk/model/api/VideoType;
 	public static final field ISO Lorg/jellyfin/sdk/model/api/VideoType;
 	public static final field VIDEO_FILE Lorg/jellyfin/sdk/model/api/VideoType;
+	public final fun getSerialName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/VideoType;
 	public static fun values ()[Lorg/jellyfin/sdk/model/api/VideoType;
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/Architecture.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/Architecture.kt
@@ -5,19 +5,25 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class Architecture {
+public enum class Architecture(
+	public val serialName: String
+) {
 	@SerialName("X86")
-	X86,
+	X86("X86"),
 	@SerialName("X64")
-	X64,
+	X64("X64"),
 	@SerialName("Arm")
-	ARM,
+	ARM("Arm"),
 	@SerialName("Arm64")
-	ARM_64,
+	ARM_64("Arm64"),
 	@SerialName("Wasm")
-	WASM,
+	WASM("Wasm"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelItemSortField.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelItemSortField.kt
@@ -5,23 +5,29 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ChannelItemSortField {
+public enum class ChannelItemSortField(
+	public val serialName: String
+) {
 	@SerialName("Name")
-	NAME,
+	NAME("Name"),
 	@SerialName("CommunityRating")
-	COMMUNITY_RATING,
+	COMMUNITY_RATING("CommunityRating"),
 	@SerialName("PremiereDate")
-	PREMIERE_DATE,
+	PREMIERE_DATE("PremiereDate"),
 	@SerialName("DateCreated")
-	DATE_CREATED,
+	DATE_CREATED("DateCreated"),
 	@SerialName("Runtime")
-	RUNTIME,
+	RUNTIME("Runtime"),
 	@SerialName("PlayCount")
-	PLAY_COUNT,
+	PLAY_COUNT("PlayCount"),
 	@SerialName("CommunityPlayCount")
-	COMMUNITY_PLAY_COUNT,
+	COMMUNITY_PLAY_COUNT("CommunityPlayCount"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaContentType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaContentType.kt
@@ -5,25 +5,31 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ChannelMediaContentType {
+public enum class ChannelMediaContentType(
+	public val serialName: String
+) {
 	@SerialName("Clip")
-	CLIP,
+	CLIP("Clip"),
 	@SerialName("Podcast")
-	PODCAST,
+	PODCAST("Podcast"),
 	@SerialName("Trailer")
-	TRAILER,
+	TRAILER("Trailer"),
 	@SerialName("Movie")
-	MOVIE,
+	MOVIE("Movie"),
 	@SerialName("Episode")
-	EPISODE,
+	EPISODE("Episode"),
 	@SerialName("Song")
-	SONG,
+	SONG("Song"),
 	@SerialName("MovieExtra")
-	MOVIE_EXTRA,
+	MOVIE_EXTRA("MovieExtra"),
 	@SerialName("TvExtra")
-	TV_EXTRA,
+	TV_EXTRA("TvExtra"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaType.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ChannelMediaType {
+public enum class ChannelMediaType(
+	public val serialName: String
+) {
 	@SerialName("Audio")
-	AUDIO,
+	AUDIO("Audio"),
 	@SerialName("Video")
-	VIDEO,
+	VIDEO("Video"),
 	@SerialName("Photo")
-	PHOTO,
+	PHOTO("Photo"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ChannelType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * Enum ChannelType.
  */
 @Serializable
-public enum class ChannelType {
+public enum class ChannelType(
+	public val serialName: String
+) {
 	@SerialName("TV")
-	TV,
+	TV("TV"),
 	@SerialName("Radio")
-	RADIO,
+	RADIO("Radio"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/CodecType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/CodecType.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class CodecType {
+public enum class CodecType(
+	public val serialName: String
+) {
 	@SerialName("Video")
-	VIDEO,
+	VIDEO("Video"),
 	@SerialName("VideoAudio")
-	VIDEO_AUDIO,
+	VIDEO_AUDIO("VideoAudio"),
 	@SerialName("Audio")
-	AUDIO,
+	AUDIO("Audio"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/CollectionTypeOptions.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/CollectionTypeOptions.kt
@@ -5,25 +5,31 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class CollectionTypeOptions {
+public enum class CollectionTypeOptions(
+	public val serialName: String
+) {
 	@SerialName("Movies")
-	MOVIES,
+	MOVIES("Movies"),
 	@SerialName("TvShows")
-	TV_SHOWS,
+	TV_SHOWS("TvShows"),
 	@SerialName("Music")
-	MUSIC,
+	MUSIC("Music"),
 	@SerialName("MusicVideos")
-	MUSIC_VIDEOS,
+	MUSIC_VIDEOS("MusicVideos"),
 	@SerialName("HomeVideos")
-	HOME_VIDEOS,
+	HOME_VIDEOS("HomeVideos"),
 	@SerialName("BoxSets")
-	BOX_SETS,
+	BOX_SETS("BoxSets"),
 	@SerialName("Books")
-	BOOKS,
+	BOOKS("Books"),
 	@SerialName("Mixed")
-	MIXED,
+	MIXED("Mixed"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ConfigurationPageType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ConfigurationPageType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * Enum ConfigurationPageType.
  */
 @Serializable
-public enum class ConfigurationPageType {
+public enum class ConfigurationPageType(
+	public val serialName: String
+) {
 	@SerialName("PluginConfiguration")
-	PLUGIN_CONFIGURATION,
+	PLUGIN_CONFIGURATION("PluginConfiguration"),
 	@SerialName("None")
-	NONE,
+	NONE("None"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DayOfWeek.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DayOfWeek.kt
@@ -5,23 +5,29 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class DayOfWeek {
+public enum class DayOfWeek(
+	public val serialName: String
+) {
 	@SerialName("Sunday")
-	SUNDAY,
+	SUNDAY("Sunday"),
 	@SerialName("Monday")
-	MONDAY,
+	MONDAY("Monday"),
 	@SerialName("Tuesday")
-	TUESDAY,
+	TUESDAY("Tuesday"),
 	@SerialName("Wednesday")
-	WEDNESDAY,
+	WEDNESDAY("Wednesday"),
 	@SerialName("Thursday")
-	THURSDAY,
+	THURSDAY("Thursday"),
 	@SerialName("Friday")
-	FRIDAY,
+	FRIDAY("Friday"),
 	@SerialName("Saturday")
-	SATURDAY,
+	SATURDAY("Saturday"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DayPattern.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DayPattern.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class DayPattern {
+public enum class DayPattern(
+	public val serialName: String
+) {
 	@SerialName("Daily")
-	DAILY,
+	DAILY("Daily"),
 	@SerialName("Weekdays")
-	WEEKDAYS,
+	WEEKDAYS("Weekdays"),
 	@SerialName("Weekends")
-	WEEKENDS,
+	WEEKENDS("Weekends"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfileType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfileType.kt
@@ -5,13 +5,19 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class DeviceProfileType {
+public enum class DeviceProfileType(
+	public val serialName: String
+) {
 	@SerialName("System")
-	SYSTEM,
+	SYSTEM("System"),
 	@SerialName("User")
-	USER,
+	USER("User"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DlnaProfileType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DlnaProfileType.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class DlnaProfileType {
+public enum class DlnaProfileType(
+	public val serialName: String
+) {
 	@SerialName("Audio")
-	AUDIO,
+	AUDIO("Audio"),
 	@SerialName("Video")
-	VIDEO,
+	VIDEO("Video"),
 	@SerialName("Photo")
-	PHOTO,
+	PHOTO("Photo"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DynamicDayOfWeek.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/DynamicDayOfWeek.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,25 +13,30 @@ import kotlinx.serialization.Serializable
  * An enum that represents a day of the week, weekdays, weekends, or all days.
  */
 @Serializable
-public enum class DynamicDayOfWeek {
+public enum class DynamicDayOfWeek(
+	public val serialName: String
+) {
 	@SerialName("Sunday")
-	SUNDAY,
+	SUNDAY("Sunday"),
 	@SerialName("Monday")
-	MONDAY,
+	MONDAY("Monday"),
 	@SerialName("Tuesday")
-	TUESDAY,
+	TUESDAY("Tuesday"),
 	@SerialName("Wednesday")
-	WEDNESDAY,
+	WEDNESDAY("Wednesday"),
 	@SerialName("Thursday")
-	THURSDAY,
+	THURSDAY("Thursday"),
 	@SerialName("Friday")
-	FRIDAY,
+	FRIDAY("Friday"),
 	@SerialName("Saturday")
-	SATURDAY,
+	SATURDAY("Saturday"),
 	@SerialName("Everyday")
-	EVERYDAY,
+	EVERYDAY("Everyday"),
 	@SerialName("Weekday")
-	WEEKDAY,
+	WEEKDAY("Weekday"),
 	@SerialName("Weekend")
-	WEEKEND,
+	WEEKEND("Weekend"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/EncodingContext.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/EncodingContext.kt
@@ -5,13 +5,19 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class EncodingContext {
+public enum class EncodingContext(
+	public val serialName: String
+) {
 	@SerialName("Streaming")
-	STREAMING,
+	STREAMING("Streaming"),
 	@SerialName("Static")
-	STATIC,
+	STATIC("Static"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdMediaType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdMediaType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,29 +13,34 @@ import kotlinx.serialization.Serializable
  * The specific media type of an MediaBrowser.Model.Providers.ExternalIdInfo.
  */
 @Serializable
-public enum class ExternalIdMediaType {
+public enum class ExternalIdMediaType(
+	public val serialName: String
+) {
 	@SerialName("Album")
-	ALBUM,
+	ALBUM("Album"),
 	@SerialName("AlbumArtist")
-	ALBUM_ARTIST,
+	ALBUM_ARTIST("AlbumArtist"),
 	@SerialName("Artist")
-	ARTIST,
+	ARTIST("Artist"),
 	@SerialName("BoxSet")
-	BOX_SET,
+	BOX_SET("BoxSet"),
 	@SerialName("Episode")
-	EPISODE,
+	EPISODE("Episode"),
 	@SerialName("Movie")
-	MOVIE,
+	MOVIE("Movie"),
 	@SerialName("OtherArtist")
-	OTHER_ARTIST,
+	OTHER_ARTIST("OtherArtist"),
 	@SerialName("Person")
-	PERSON,
+	PERSON("Person"),
 	@SerialName("ReleaseGroup")
-	RELEASE_GROUP,
+	RELEASE_GROUP("ReleaseGroup"),
 	@SerialName("Season")
-	SEASON,
+	SEASON("Season"),
 	@SerialName("Series")
-	SERIES,
+	SERIES("Series"),
 	@SerialName("Track")
-	TRACK,
+	TRACK("Track"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/FFmpegLocation.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/FFmpegLocation.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum describing the location of the FFmpeg tool.
  */
 @Serializable
-public enum class FFmpegLocation {
+public enum class FFmpegLocation(
+	public val serialName: String
+) {
 	@SerialName("NotFound")
-	NOT_FOUND,
+	NOT_FOUND("NotFound"),
 	@SerialName("SetByArgument")
-	SET_BY_ARGUMENT,
+	SET_BY_ARGUMENT("SetByArgument"),
 	@SerialName("Custom")
-	CUSTOM,
+	CUSTOM("Custom"),
 	@SerialName("System")
-	SYSTEM,
+	SYSTEM("System"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/FileSystemEntryType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/FileSystemEntryType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum FileSystemEntryType.
  */
 @Serializable
-public enum class FileSystemEntryType {
+public enum class FileSystemEntryType(
+	public val serialName: String
+) {
 	@SerialName("File")
-	FILE,
+	FILE("File"),
 	@SerialName("Directory")
-	DIRECTORY,
+	DIRECTORY("Directory"),
 	@SerialName("NetworkComputer")
-	NETWORK_COMPUTER,
+	NETWORK_COMPUTER("NetworkComputer"),
 	@SerialName("NetworkShare")
-	NETWORK_SHARE,
+	NETWORK_SHARE("NetworkShare"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordAction.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordAction.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ForgotPasswordAction {
+public enum class ForgotPasswordAction(
+	public val serialName: String
+) {
 	@SerialName("ContactAdmin")
-	CONTACT_ADMIN,
+	CONTACT_ADMIN("ContactAdmin"),
 	@SerialName("PinCode")
-	PIN_CODE,
+	PIN_CODE("PinCode"),
 	@SerialName("InNetworkRequired")
-	IN_NETWORK_REQUIRED,
+	IN_NETWORK_REQUIRED("InNetworkRequired"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GeneralCommandType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GeneralCommandType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,87 +13,92 @@ import kotlinx.serialization.Serializable
  * This exists simply to identify a set of known commands.
  */
 @Serializable
-public enum class GeneralCommandType {
+public enum class GeneralCommandType(
+	public val serialName: String
+) {
 	@SerialName("MoveUp")
-	MOVE_UP,
+	MOVE_UP("MoveUp"),
 	@SerialName("MoveDown")
-	MOVE_DOWN,
+	MOVE_DOWN("MoveDown"),
 	@SerialName("MoveLeft")
-	MOVE_LEFT,
+	MOVE_LEFT("MoveLeft"),
 	@SerialName("MoveRight")
-	MOVE_RIGHT,
+	MOVE_RIGHT("MoveRight"),
 	@SerialName("PageUp")
-	PAGE_UP,
+	PAGE_UP("PageUp"),
 	@SerialName("PageDown")
-	PAGE_DOWN,
+	PAGE_DOWN("PageDown"),
 	@SerialName("PreviousLetter")
-	PREVIOUS_LETTER,
+	PREVIOUS_LETTER("PreviousLetter"),
 	@SerialName("NextLetter")
-	NEXT_LETTER,
+	NEXT_LETTER("NextLetter"),
 	@SerialName("ToggleOsd")
-	TOGGLE_OSD,
+	TOGGLE_OSD("ToggleOsd"),
 	@SerialName("ToggleContextMenu")
-	TOGGLE_CONTEXT_MENU,
+	TOGGLE_CONTEXT_MENU("ToggleContextMenu"),
 	@SerialName("Select")
-	SELECT,
+	SELECT("Select"),
 	@SerialName("Back")
-	BACK,
+	BACK("Back"),
 	@SerialName("TakeScreenshot")
-	TAKE_SCREENSHOT,
+	TAKE_SCREENSHOT("TakeScreenshot"),
 	@SerialName("SendKey")
-	SEND_KEY,
+	SEND_KEY("SendKey"),
 	@SerialName("SendString")
-	SEND_STRING,
+	SEND_STRING("SendString"),
 	@SerialName("GoHome")
-	GO_HOME,
+	GO_HOME("GoHome"),
 	@SerialName("GoToSettings")
-	GO_TO_SETTINGS,
+	GO_TO_SETTINGS("GoToSettings"),
 	@SerialName("VolumeUp")
-	VOLUME_UP,
+	VOLUME_UP("VolumeUp"),
 	@SerialName("VolumeDown")
-	VOLUME_DOWN,
+	VOLUME_DOWN("VolumeDown"),
 	@SerialName("Mute")
-	MUTE,
+	MUTE("Mute"),
 	@SerialName("Unmute")
-	UNMUTE,
+	UNMUTE("Unmute"),
 	@SerialName("ToggleMute")
-	TOGGLE_MUTE,
+	TOGGLE_MUTE("ToggleMute"),
 	@SerialName("SetVolume")
-	SET_VOLUME,
+	SET_VOLUME("SetVolume"),
 	@SerialName("SetAudioStreamIndex")
-	SET_AUDIO_STREAM_INDEX,
+	SET_AUDIO_STREAM_INDEX("SetAudioStreamIndex"),
 	@SerialName("SetSubtitleStreamIndex")
-	SET_SUBTITLE_STREAM_INDEX,
+	SET_SUBTITLE_STREAM_INDEX("SetSubtitleStreamIndex"),
 	@SerialName("ToggleFullscreen")
-	TOGGLE_FULLSCREEN,
+	TOGGLE_FULLSCREEN("ToggleFullscreen"),
 	@SerialName("DisplayContent")
-	DISPLAY_CONTENT,
+	DISPLAY_CONTENT("DisplayContent"),
 	@SerialName("GoToSearch")
-	GO_TO_SEARCH,
+	GO_TO_SEARCH("GoToSearch"),
 	@SerialName("DisplayMessage")
-	DISPLAY_MESSAGE,
+	DISPLAY_MESSAGE("DisplayMessage"),
 	@SerialName("SetRepeatMode")
-	SET_REPEAT_MODE,
+	SET_REPEAT_MODE("SetRepeatMode"),
 	@SerialName("ChannelUp")
-	CHANNEL_UP,
+	CHANNEL_UP("ChannelUp"),
 	@SerialName("ChannelDown")
-	CHANNEL_DOWN,
+	CHANNEL_DOWN("ChannelDown"),
 	@SerialName("Guide")
-	GUIDE,
+	GUIDE("Guide"),
 	@SerialName("ToggleStats")
-	TOGGLE_STATS,
+	TOGGLE_STATS("ToggleStats"),
 	@SerialName("PlayMediaSource")
-	PLAY_MEDIA_SOURCE,
+	PLAY_MEDIA_SOURCE("PlayMediaSource"),
 	@SerialName("PlayTrailers")
-	PLAY_TRAILERS,
+	PLAY_TRAILERS("PlayTrailers"),
 	@SerialName("SetShuffleQueue")
-	SET_SHUFFLE_QUEUE,
+	SET_SHUFFLE_QUEUE("SetShuffleQueue"),
 	@SerialName("PlayState")
-	PLAY_STATE,
+	PLAY_STATE("PlayState"),
 	@SerialName("PlayNext")
-	PLAY_NEXT,
+	PLAY_NEXT("PlayNext"),
 	@SerialName("ToggleOsdMenu")
-	TOGGLE_OSD_MENU,
+	TOGGLE_OSD_MENU("ToggleOsdMenu"),
 	@SerialName("Play")
-	PLAY,
+	PLAY("Play"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupQueueMode.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupQueueMode.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * Enum GroupQueueMode.
  */
 @Serializable
-public enum class GroupQueueMode {
+public enum class GroupQueueMode(
+	public val serialName: String
+) {
 	@SerialName("Queue")
-	QUEUE,
+	QUEUE("Queue"),
 	@SerialName("QueueNext")
-	QUEUE_NEXT,
+	QUEUE_NEXT("QueueNext"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupRepeatMode.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupRepeatMode.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,11 +13,16 @@ import kotlinx.serialization.Serializable
  * Enum GroupRepeatMode.
  */
 @Serializable
-public enum class GroupRepeatMode {
+public enum class GroupRepeatMode(
+	public val serialName: String
+) {
 	@SerialName("RepeatOne")
-	REPEAT_ONE,
+	REPEAT_ONE("RepeatOne"),
 	@SerialName("RepeatAll")
-	REPEAT_ALL,
+	REPEAT_ALL("RepeatAll"),
 	@SerialName("RepeatNone")
-	REPEAT_NONE,
+	REPEAT_NONE("RepeatNone"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupShuffleMode.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupShuffleMode.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * Enum GroupShuffleMode.
  */
 @Serializable
-public enum class GroupShuffleMode {
+public enum class GroupShuffleMode(
+	public val serialName: String
+) {
 	@SerialName("Sorted")
-	SORTED,
+	SORTED("Sorted"),
 	@SerialName("Shuffle")
-	SHUFFLE,
+	SHUFFLE("Shuffle"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupStateType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupStateType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum GroupState.
  */
 @Serializable
-public enum class GroupStateType {
+public enum class GroupStateType(
+	public val serialName: String
+) {
 	@SerialName("Idle")
-	IDLE,
+	IDLE("Idle"),
 	@SerialName("Waiting")
-	WAITING,
+	WAITING("Waiting"),
 	@SerialName("Paused")
-	PAUSED,
+	PAUSED("Paused"),
 	@SerialName("Playing")
-	PLAYING,
+	PLAYING("Playing"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupUpdateType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/GroupUpdateType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,27 +13,32 @@ import kotlinx.serialization.Serializable
  * Enum GroupUpdateType.
  */
 @Serializable
-public enum class GroupUpdateType {
+public enum class GroupUpdateType(
+	public val serialName: String
+) {
 	@SerialName("UserJoined")
-	USER_JOINED,
+	USER_JOINED("UserJoined"),
 	@SerialName("UserLeft")
-	USER_LEFT,
+	USER_LEFT("UserLeft"),
 	@SerialName("GroupJoined")
-	GROUP_JOINED,
+	GROUP_JOINED("GroupJoined"),
 	@SerialName("GroupLeft")
-	GROUP_LEFT,
+	GROUP_LEFT("GroupLeft"),
 	@SerialName("StateUpdate")
-	STATE_UPDATE,
+	STATE_UPDATE("StateUpdate"),
 	@SerialName("PlayQueue")
-	PLAY_QUEUE,
+	PLAY_QUEUE("PlayQueue"),
 	@SerialName("NotInGroup")
-	NOT_IN_GROUP,
+	NOT_IN_GROUP("NotInGroup"),
 	@SerialName("GroupDoesNotExist")
-	GROUP_DOES_NOT_EXIST,
+	GROUP_DOES_NOT_EXIST("GroupDoesNotExist"),
 	@SerialName("CreateGroupDenied")
-	CREATE_GROUP_DENIED,
+	CREATE_GROUP_DENIED("CreateGroupDenied"),
 	@SerialName("JoinGroupDenied")
-	JOIN_GROUP_DENIED,
+	JOIN_GROUP_DENIED("JoinGroupDenied"),
 	@SerialName("LibraryAccessDenied")
-	LIBRARY_ACCESS_DENIED,
+	LIBRARY_ACCESS_DENIED("LibraryAccessDenied"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/HeaderMatchType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/HeaderMatchType.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class HeaderMatchType {
+public enum class HeaderMatchType(
+	public val serialName: String
+) {
 	@SerialName("Equals")
-	EQUALS,
+	EQUALS("Equals"),
 	@SerialName("Regex")
-	REGEX,
+	REGEX("Regex"),
 	@SerialName("Substring")
-	SUBSTRING,
+	SUBSTRING("Substring"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageFormat.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageFormat.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,15 +13,20 @@ import kotlinx.serialization.Serializable
  * Enum ImageOutputFormat.
  */
 @Serializable
-public enum class ImageFormat {
+public enum class ImageFormat(
+	public val serialName: String
+) {
 	@SerialName("Bmp")
-	BMP,
+	BMP("Bmp"),
 	@SerialName("Gif")
-	GIF,
+	GIF("Gif"),
 	@SerialName("Jpg")
-	JPG,
+	JPG("Jpg"),
 	@SerialName("Png")
-	PNG,
+	PNG("Png"),
 	@SerialName("Webp")
-	WEBP,
+	WEBP("Webp"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageOrientation.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageOrientation.kt
@@ -5,25 +5,31 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ImageOrientation {
+public enum class ImageOrientation(
+	public val serialName: String
+) {
 	@SerialName("TopLeft")
-	TOP_LEFT,
+	TOP_LEFT("TopLeft"),
 	@SerialName("TopRight")
-	TOP_RIGHT,
+	TOP_RIGHT("TopRight"),
 	@SerialName("BottomRight")
-	BOTTOM_RIGHT,
+	BOTTOM_RIGHT("BottomRight"),
 	@SerialName("BottomLeft")
-	BOTTOM_LEFT,
+	BOTTOM_LEFT("BottomLeft"),
 	@SerialName("LeftTop")
-	LEFT_TOP,
+	LEFT_TOP("LeftTop"),
 	@SerialName("RightTop")
-	RIGHT_TOP,
+	RIGHT_TOP("RightTop"),
 	@SerialName("RightBottom")
-	RIGHT_BOTTOM,
+	RIGHT_BOTTOM("RightBottom"),
 	@SerialName("LeftBottom")
-	LEFT_BOTTOM,
+	LEFT_BOTTOM("LeftBottom"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageSavingConvention.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageSavingConvention.kt
@@ -5,13 +5,19 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ImageSavingConvention {
+public enum class ImageSavingConvention(
+	public val serialName: String
+) {
 	@SerialName("Legacy")
-	LEGACY,
+	LEGACY("Legacy"),
 	@SerialName("Compatible")
-	COMPATIBLE,
+	COMPATIBLE("Compatible"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ImageType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,31 +13,36 @@ import kotlinx.serialization.Serializable
  * Enum ImageType.
  */
 @Serializable
-public enum class ImageType {
+public enum class ImageType(
+	public val serialName: String
+) {
 	@SerialName("Primary")
-	PRIMARY,
+	PRIMARY("Primary"),
 	@SerialName("Art")
-	ART,
+	ART("Art"),
 	@SerialName("Backdrop")
-	BACKDROP,
+	BACKDROP("Backdrop"),
 	@SerialName("Banner")
-	BANNER,
+	BANNER("Banner"),
 	@SerialName("Logo")
-	LOGO,
+	LOGO("Logo"),
 	@SerialName("Thumb")
-	THUMB,
+	THUMB("Thumb"),
 	@SerialName("Disc")
-	DISC,
+	DISC("Disc"),
 	@SerialName("Box")
-	BOX,
+	BOX("Box"),
 	@SerialName("Screenshot")
-	SCREENSHOT,
+	SCREENSHOT("Screenshot"),
 	@SerialName("Menu")
-	MENU,
+	MENU("Menu"),
 	@SerialName("Chapter")
-	CHAPTER,
+	CHAPTER("Chapter"),
 	@SerialName("BoxRear")
-	BOX_REAR,
+	BOX_REAR("BoxRear"),
 	@SerialName("Profile")
-	PROFILE,
+	PROFILE("Profile"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/IsoType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/IsoType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * Enum IsoType.
  */
 @Serializable
-public enum class IsoType {
+public enum class IsoType(
+	public val serialName: String
+) {
 	@SerialName("Dvd")
-	DVD,
+	DVD("Dvd"),
 	@SerialName("BluRay")
-	BLU_RAY,
+	BLU_RAY("BluRay"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ItemFields.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ItemFields.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,127 +13,132 @@ import kotlinx.serialization.Serializable
  * Used to control the data that gets attached to DtoBaseItems.
  */
 @Serializable
-public enum class ItemFields {
+public enum class ItemFields(
+	public val serialName: String
+) {
 	@SerialName("AirTime")
-	AIR_TIME,
+	AIR_TIME("AirTime"),
 	@SerialName("CanDelete")
-	CAN_DELETE,
+	CAN_DELETE("CanDelete"),
 	@SerialName("CanDownload")
-	CAN_DOWNLOAD,
+	CAN_DOWNLOAD("CanDownload"),
 	@SerialName("ChannelInfo")
-	CHANNEL_INFO,
+	CHANNEL_INFO("ChannelInfo"),
 	@SerialName("Chapters")
-	CHAPTERS,
+	CHAPTERS("Chapters"),
 	@SerialName("ChildCount")
-	CHILD_COUNT,
+	CHILD_COUNT("ChildCount"),
 	@SerialName("CumulativeRunTimeTicks")
-	CUMULATIVE_RUN_TIME_TICKS,
+	CUMULATIVE_RUN_TIME_TICKS("CumulativeRunTimeTicks"),
 	@SerialName("CustomRating")
-	CUSTOM_RATING,
+	CUSTOM_RATING("CustomRating"),
 	@SerialName("DateCreated")
-	DATE_CREATED,
+	DATE_CREATED("DateCreated"),
 	@SerialName("DateLastMediaAdded")
-	DATE_LAST_MEDIA_ADDED,
+	DATE_LAST_MEDIA_ADDED("DateLastMediaAdded"),
 	@SerialName("DisplayPreferencesId")
-	DISPLAY_PREFERENCES_ID,
+	DISPLAY_PREFERENCES_ID("DisplayPreferencesId"),
 	@SerialName("Etag")
-	ETAG,
+	ETAG("Etag"),
 	@SerialName("ExternalUrls")
-	EXTERNAL_URLS,
+	EXTERNAL_URLS("ExternalUrls"),
 	@SerialName("Genres")
-	GENRES,
+	GENRES("Genres"),
 	@SerialName("HomePageUrl")
-	HOME_PAGE_URL,
+	HOME_PAGE_URL("HomePageUrl"),
 	@SerialName("ItemCounts")
-	ITEM_COUNTS,
+	ITEM_COUNTS("ItemCounts"),
 	@SerialName("MediaSourceCount")
-	MEDIA_SOURCE_COUNT,
+	MEDIA_SOURCE_COUNT("MediaSourceCount"),
 	@SerialName("MediaSources")
-	MEDIA_SOURCES,
+	MEDIA_SOURCES("MediaSources"),
 	@SerialName("OriginalTitle")
-	ORIGINAL_TITLE,
+	ORIGINAL_TITLE("OriginalTitle"),
 	@SerialName("Overview")
-	OVERVIEW,
+	OVERVIEW("Overview"),
 	@SerialName("ParentId")
-	PARENT_ID,
+	PARENT_ID("ParentId"),
 	@SerialName("Path")
-	PATH,
+	PATH("Path"),
 	@SerialName("People")
-	PEOPLE,
+	PEOPLE("People"),
 	@SerialName("PlayAccess")
-	PLAY_ACCESS,
+	PLAY_ACCESS("PlayAccess"),
 	@SerialName("ProductionLocations")
-	PRODUCTION_LOCATIONS,
+	PRODUCTION_LOCATIONS("ProductionLocations"),
 	@SerialName("ProviderIds")
-	PROVIDER_IDS,
+	PROVIDER_IDS("ProviderIds"),
 	@SerialName("PrimaryImageAspectRatio")
-	PRIMARY_IMAGE_ASPECT_RATIO,
+	PRIMARY_IMAGE_ASPECT_RATIO("PrimaryImageAspectRatio"),
 	@SerialName("RecursiveItemCount")
-	RECURSIVE_ITEM_COUNT,
+	RECURSIVE_ITEM_COUNT("RecursiveItemCount"),
 	@SerialName("Settings")
-	SETTINGS,
+	SETTINGS("Settings"),
 	@SerialName("ScreenshotImageTags")
-	SCREENSHOT_IMAGE_TAGS,
+	SCREENSHOT_IMAGE_TAGS("ScreenshotImageTags"),
 	@SerialName("SeriesPrimaryImage")
-	SERIES_PRIMARY_IMAGE,
+	SERIES_PRIMARY_IMAGE("SeriesPrimaryImage"),
 	@SerialName("SeriesStudio")
-	SERIES_STUDIO,
+	SERIES_STUDIO("SeriesStudio"),
 	@SerialName("SortName")
-	SORT_NAME,
+	SORT_NAME("SortName"),
 	@SerialName("SpecialEpisodeNumbers")
-	SPECIAL_EPISODE_NUMBERS,
+	SPECIAL_EPISODE_NUMBERS("SpecialEpisodeNumbers"),
 	@SerialName("Studios")
-	STUDIOS,
+	STUDIOS("Studios"),
 	@SerialName("BasicSyncInfo")
-	BASIC_SYNC_INFO,
+	BASIC_SYNC_INFO("BasicSyncInfo"),
 	@SerialName("SyncInfo")
-	SYNC_INFO,
+	SYNC_INFO("SyncInfo"),
 	@SerialName("Taglines")
-	TAGLINES,
+	TAGLINES("Taglines"),
 	@SerialName("Tags")
-	TAGS,
+	TAGS("Tags"),
 	@SerialName("RemoteTrailers")
-	REMOTE_TRAILERS,
+	REMOTE_TRAILERS("RemoteTrailers"),
 	@SerialName("MediaStreams")
-	MEDIA_STREAMS,
+	MEDIA_STREAMS("MediaStreams"),
 	@SerialName("SeasonUserData")
-	SEASON_USER_DATA,
+	SEASON_USER_DATA("SeasonUserData"),
 	@SerialName("ServiceName")
-	SERVICE_NAME,
+	SERVICE_NAME("ServiceName"),
 	@SerialName("ThemeSongIds")
-	THEME_SONG_IDS,
+	THEME_SONG_IDS("ThemeSongIds"),
 	@SerialName("ThemeVideoIds")
-	THEME_VIDEO_IDS,
+	THEME_VIDEO_IDS("ThemeVideoIds"),
 	@SerialName("ExternalEtag")
-	EXTERNAL_ETAG,
+	EXTERNAL_ETAG("ExternalEtag"),
 	@SerialName("PresentationUniqueKey")
-	PRESENTATION_UNIQUE_KEY,
+	PRESENTATION_UNIQUE_KEY("PresentationUniqueKey"),
 	@SerialName("InheritedParentalRatingValue")
-	INHERITED_PARENTAL_RATING_VALUE,
+	INHERITED_PARENTAL_RATING_VALUE("InheritedParentalRatingValue"),
 	@SerialName("ExternalSeriesId")
-	EXTERNAL_SERIES_ID,
+	EXTERNAL_SERIES_ID("ExternalSeriesId"),
 	@SerialName("SeriesPresentationUniqueKey")
-	SERIES_PRESENTATION_UNIQUE_KEY,
+	SERIES_PRESENTATION_UNIQUE_KEY("SeriesPresentationUniqueKey"),
 	@SerialName("DateLastRefreshed")
-	DATE_LAST_REFRESHED,
+	DATE_LAST_REFRESHED("DateLastRefreshed"),
 	@SerialName("DateLastSaved")
-	DATE_LAST_SAVED,
+	DATE_LAST_SAVED("DateLastSaved"),
 	@SerialName("RefreshState")
-	REFRESH_STATE,
+	REFRESH_STATE("RefreshState"),
 	@SerialName("ChannelImage")
-	CHANNEL_IMAGE,
+	CHANNEL_IMAGE("ChannelImage"),
 	@SerialName("EnableMediaSourceDisplay")
-	ENABLE_MEDIA_SOURCE_DISPLAY,
+	ENABLE_MEDIA_SOURCE_DISPLAY("EnableMediaSourceDisplay"),
 	@SerialName("Width")
-	WIDTH,
+	WIDTH("Width"),
 	@SerialName("Height")
-	HEIGHT,
+	HEIGHT("Height"),
 	@SerialName("ExtraIds")
-	EXTRA_IDS,
+	EXTRA_IDS("ExtraIds"),
 	@SerialName("LocalTrailerCount")
-	LOCAL_TRAILER_COUNT,
+	LOCAL_TRAILER_COUNT("LocalTrailerCount"),
 	@SerialName("IsHD")
-	IS_HD,
+	IS_HD("IsHD"),
 	@SerialName("SpecialFeatureCount")
-	SPECIAL_FEATURE_COUNT,
+	SPECIAL_FEATURE_COUNT("SpecialFeatureCount"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ItemFilter.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ItemFilter.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,23 +13,28 @@ import kotlinx.serialization.Serializable
  * Enum ItemFilter.
  */
 @Serializable
-public enum class ItemFilter {
+public enum class ItemFilter(
+	public val serialName: String
+) {
 	@SerialName("IsFolder")
-	IS_FOLDER,
+	IS_FOLDER("IsFolder"),
 	@SerialName("IsNotFolder")
-	IS_NOT_FOLDER,
+	IS_NOT_FOLDER("IsNotFolder"),
 	@SerialName("IsUnplayed")
-	IS_UNPLAYED,
+	IS_UNPLAYED("IsUnplayed"),
 	@SerialName("IsPlayed")
-	IS_PLAYED,
+	IS_PLAYED("IsPlayed"),
 	@SerialName("IsFavorite")
-	IS_FAVORITE,
+	IS_FAVORITE("IsFavorite"),
 	@SerialName("IsResumable")
-	IS_RESUMABLE,
+	IS_RESUMABLE("IsResumable"),
 	@SerialName("Likes")
-	LIKES,
+	LIKES("Likes"),
 	@SerialName("Dislikes")
-	DISLIKES,
+	DISLIKES("Dislikes"),
 	@SerialName("IsFavoriteOrLikes")
-	IS_FAVORITE_OR_LIKES,
+	IS_FAVORITE_OR_LIKES("IsFavoriteOrLikes"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/KeepUntil.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/KeepUntil.kt
@@ -5,17 +5,23 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class KeepUntil {
+public enum class KeepUntil(
+	public val serialName: String
+) {
 	@SerialName("UntilDeleted")
-	UNTIL_DELETED,
+	UNTIL_DELETED("UntilDeleted"),
 	@SerialName("UntilSpaceNeeded")
-	UNTIL_SPACE_NEEDED,
+	UNTIL_SPACE_NEEDED("UntilSpaceNeeded"),
 	@SerialName("UntilWatched")
-	UNTIL_WATCHED,
+	UNTIL_WATCHED("UntilWatched"),
 	@SerialName("UntilDate")
-	UNTIL_DATE,
+	UNTIL_DATE("UntilDate"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvServiceStatus.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvServiceStatus.kt
@@ -5,13 +5,19 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class LiveTvServiceStatus {
+public enum class LiveTvServiceStatus(
+	public val serialName: String
+) {
 	@SerialName("Ok")
-	OK,
+	OK("Ok"),
 	@SerialName("Unavailable")
-	UNAVAILABLE,
+	UNAVAILABLE("Unavailable"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/LocationType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/LocationType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum LocationType.
  */
 @Serializable
-public enum class LocationType {
+public enum class LocationType(
+	public val serialName: String
+) {
 	@SerialName("FileSystem")
-	FILE_SYSTEM,
+	FILE_SYSTEM("FileSystem"),
 	@SerialName("Remote")
-	REMOTE,
+	REMOTE("Remote"),
 	@SerialName("Virtual")
-	VIRTUAL,
+	VIRTUAL("Virtual"),
 	@SerialName("Offline")
-	OFFLINE,
+	OFFLINE("Offline"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/LogLevel.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/LogLevel.kt
@@ -5,23 +5,29 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class LogLevel {
+public enum class LogLevel(
+	public val serialName: String
+) {
 	@SerialName("Trace")
-	TRACE,
+	TRACE("Trace"),
 	@SerialName("Debug")
-	DEBUG,
+	DEBUG("Debug"),
 	@SerialName("Information")
-	INFORMATION,
+	INFORMATION("Information"),
 	@SerialName("Warning")
-	WARNING,
+	WARNING("Warning"),
 	@SerialName("Error")
-	ERROR,
+	ERROR("Error"),
 	@SerialName("Critical")
-	CRITICAL,
+	CRITICAL("Critical"),
 	@SerialName("None")
-	NONE,
+	NONE("None"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MediaProtocol.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MediaProtocol.kt
@@ -5,23 +5,29 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class MediaProtocol {
+public enum class MediaProtocol(
+	public val serialName: String
+) {
 	@SerialName("File")
-	FILE,
+	FILE("File"),
 	@SerialName("Http")
-	HTTP,
+	HTTP("Http"),
 	@SerialName("Rtmp")
-	RTMP,
+	RTMP("Rtmp"),
 	@SerialName("Rtsp")
-	RTSP,
+	RTSP("Rtsp"),
 	@SerialName("Udp")
-	UDP,
+	UDP("Udp"),
 	@SerialName("Rtp")
-	RTP,
+	RTP("Rtp"),
 	@SerialName("Ftp")
-	FTP,
+	FTP("Ftp"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MediaSourceType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MediaSourceType.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class MediaSourceType {
+public enum class MediaSourceType(
+	public val serialName: String
+) {
 	@SerialName("Default")
-	DEFAULT,
+	DEFAULT("Default"),
 	@SerialName("Grouping")
-	GROUPING,
+	GROUPING("Grouping"),
 	@SerialName("Placeholder")
-	PLACEHOLDER,
+	PLACEHOLDER("Placeholder"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MediaStreamType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MediaStreamType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum MediaStreamType.
  */
 @Serializable
-public enum class MediaStreamType {
+public enum class MediaStreamType(
+	public val serialName: String
+) {
 	@SerialName("Audio")
-	AUDIO,
+	AUDIO("Audio"),
 	@SerialName("Video")
-	VIDEO,
+	VIDEO("Video"),
 	@SerialName("Subtitle")
-	SUBTITLE,
+	SUBTITLE("Subtitle"),
 	@SerialName("EmbeddedImage")
-	EMBEDDED_IMAGE,
+	EMBEDDED_IMAGE("EmbeddedImage"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MetadataField.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MetadataField.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,23 +13,28 @@ import kotlinx.serialization.Serializable
  * Enum MetadataFields.
  */
 @Serializable
-public enum class MetadataField {
+public enum class MetadataField(
+	public val serialName: String
+) {
 	@SerialName("Cast")
-	CAST,
+	CAST("Cast"),
 	@SerialName("Genres")
-	GENRES,
+	GENRES("Genres"),
 	@SerialName("ProductionLocations")
-	PRODUCTION_LOCATIONS,
+	PRODUCTION_LOCATIONS("ProductionLocations"),
 	@SerialName("Studios")
-	STUDIOS,
+	STUDIOS("Studios"),
 	@SerialName("Tags")
-	TAGS,
+	TAGS("Tags"),
 	@SerialName("Name")
-	NAME,
+	NAME("Name"),
 	@SerialName("Overview")
-	OVERVIEW,
+	OVERVIEW("Overview"),
 	@SerialName("Runtime")
-	RUNTIME,
+	RUNTIME("Runtime"),
 	@SerialName("OfficialRating")
-	OFFICIAL_RATING,
+	OFFICIAL_RATING("OfficialRating"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MetadataRefreshMode.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/MetadataRefreshMode.kt
@@ -5,17 +5,23 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class MetadataRefreshMode {
+public enum class MetadataRefreshMode(
+	public val serialName: String
+) {
 	@SerialName("None")
-	NONE,
+	NONE("None"),
 	@SerialName("ValidationOnly")
-	VALIDATION_ONLY,
+	VALIDATION_ONLY("ValidationOnly"),
 	@SerialName("Default")
-	DEFAULT,
+	DEFAULT("Default"),
 	@SerialName("FullRefresh")
-	FULL_REFRESH,
+	FULL_REFRESH("FullRefresh"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/NotificationLevel.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/NotificationLevel.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class NotificationLevel {
+public enum class NotificationLevel(
+	public val serialName: String
+) {
 	@SerialName("Normal")
-	NORMAL,
+	NORMAL("Normal"),
 	@SerialName("Warning")
-	WARNING,
+	WARNING("Warning"),
 	@SerialName("Error")
-	ERROR,
+	ERROR("Error"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlayAccess.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlayAccess.kt
@@ -5,13 +5,19 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class PlayAccess {
+public enum class PlayAccess(
+	public val serialName: String
+) {
 	@SerialName("Full")
-	FULL,
+	FULL("Full"),
 	@SerialName("None")
-	NONE,
+	NONE("None"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlayCommand.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlayCommand.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,15 +13,20 @@ import kotlinx.serialization.Serializable
  * Enum PlayCommand.
  */
 @Serializable
-public enum class PlayCommand {
+public enum class PlayCommand(
+	public val serialName: String
+) {
 	@SerialName("PlayNow")
-	PLAY_NOW,
+	PLAY_NOW("PlayNow"),
 	@SerialName("PlayNext")
-	PLAY_NEXT,
+	PLAY_NEXT("PlayNext"),
 	@SerialName("PlayLast")
-	PLAY_LAST,
+	PLAY_LAST("PlayLast"),
 	@SerialName("PlayInstantMix")
-	PLAY_INSTANT_MIX,
+	PLAY_INSTANT_MIX("PlayInstantMix"),
 	@SerialName("PlayShuffle")
-	PLAY_SHUFFLE,
+	PLAY_SHUFFLE("PlayShuffle"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlayMethod.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlayMethod.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class PlayMethod {
+public enum class PlayMethod(
+	public val serialName: String
+) {
 	@SerialName("Transcode")
-	TRANSCODE,
+	TRANSCODE("Transcode"),
 	@SerialName("DirectStream")
-	DIRECT_STREAM,
+	DIRECT_STREAM("DirectStream"),
 	@SerialName("DirectPlay")
-	DIRECT_PLAY,
+	DIRECT_PLAY("DirectPlay"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackErrorCode.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackErrorCode.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class PlaybackErrorCode {
+public enum class PlaybackErrorCode(
+	public val serialName: String
+) {
 	@SerialName("NotAllowed")
-	NOT_ALLOWED,
+	NOT_ALLOWED("NotAllowed"),
 	@SerialName("NoCompatibleStream")
-	NO_COMPATIBLE_STREAM,
+	NO_COMPATIBLE_STREAM("NoCompatibleStream"),
 	@SerialName("RateLimitExceeded")
-	RATE_LIMIT_EXCEEDED,
+	RATE_LIMIT_EXCEEDED("RateLimitExceeded"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlaystateCommand.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PlaystateCommand.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,23 +13,28 @@ import kotlinx.serialization.Serializable
  * Enum PlaystateCommand.
  */
 @Serializable
-public enum class PlaystateCommand {
+public enum class PlaystateCommand(
+	public val serialName: String
+) {
 	@SerialName("Stop")
-	STOP,
+	STOP("Stop"),
 	@SerialName("Pause")
-	PAUSE,
+	PAUSE("Pause"),
 	@SerialName("Unpause")
-	UNPAUSE,
+	UNPAUSE("Unpause"),
 	@SerialName("NextTrack")
-	NEXT_TRACK,
+	NEXT_TRACK("NextTrack"),
 	@SerialName("PreviousTrack")
-	PREVIOUS_TRACK,
+	PREVIOUS_TRACK("PreviousTrack"),
 	@SerialName("Seek")
-	SEEK,
+	SEEK("Seek"),
 	@SerialName("Rewind")
-	REWIND,
+	REWIND("Rewind"),
 	@SerialName("FastForward")
-	FAST_FORWARD,
+	FAST_FORWARD("FastForward"),
 	@SerialName("PlayPause")
-	PLAY_PAUSE,
+	PLAY_PAUSE("PlayPause"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PluginStatus.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/PluginStatus.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,19 +13,24 @@ import kotlinx.serialization.Serializable
  * Plugin load status.
  */
 @Serializable
-public enum class PluginStatus {
+public enum class PluginStatus(
+	public val serialName: String
+) {
 	@SerialName("Active")
-	ACTIVE,
+	ACTIVE("Active"),
 	@SerialName("Restart")
-	RESTART,
+	RESTART("Restart"),
 	@SerialName("Deleted")
-	DELETED,
+	DELETED("Deleted"),
 	@SerialName("Superceded")
-	SUPERCEDED,
+	SUPERCEDED("Superceded"),
 	@SerialName("Malfunctioned")
-	MALFUNCTIONED,
+	MALFUNCTIONED("Malfunctioned"),
 	@SerialName("NotSupported")
-	NOT_SUPPORTED,
+	NOT_SUPPORTED("NotSupported"),
 	@SerialName("Disabled")
-	DISABLED,
+	DISABLED("Disabled"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionType.kt
@@ -5,19 +5,25 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ProfileConditionType {
+public enum class ProfileConditionType(
+	public val serialName: String
+) {
 	@SerialName("Equals")
-	EQUALS,
+	EQUALS("Equals"),
 	@SerialName("NotEquals")
-	NOT_EQUALS,
+	NOT_EQUALS("NotEquals"),
 	@SerialName("LessThanEqual")
-	LESS_THAN_EQUAL,
+	LESS_THAN_EQUAL("LessThanEqual"),
 	@SerialName("GreaterThanEqual")
-	GREATER_THAN_EQUAL,
+	GREATER_THAN_EQUAL("GreaterThanEqual"),
 	@SerialName("EqualsAny")
-	EQUALS_ANY,
+	EQUALS_ANY("EqualsAny"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionValue.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionValue.kt
@@ -5,55 +5,61 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ProfileConditionValue {
+public enum class ProfileConditionValue(
+	public val serialName: String
+) {
 	@SerialName("AudioChannels")
-	AUDIO_CHANNELS,
+	AUDIO_CHANNELS("AudioChannels"),
 	@SerialName("AudioBitrate")
-	AUDIO_BITRATE,
+	AUDIO_BITRATE("AudioBitrate"),
 	@SerialName("AudioProfile")
-	AUDIO_PROFILE,
+	AUDIO_PROFILE("AudioProfile"),
 	@SerialName("Width")
-	WIDTH,
+	WIDTH("Width"),
 	@SerialName("Height")
-	HEIGHT,
+	HEIGHT("Height"),
 	@SerialName("Has64BitOffsets")
-	HAS_64_BIT_OFFSETS,
+	HAS_64_BIT_OFFSETS("Has64BitOffsets"),
 	@SerialName("PacketLength")
-	PACKET_LENGTH,
+	PACKET_LENGTH("PacketLength"),
 	@SerialName("VideoBitDepth")
-	VIDEO_BIT_DEPTH,
+	VIDEO_BIT_DEPTH("VideoBitDepth"),
 	@SerialName("VideoBitrate")
-	VIDEO_BITRATE,
+	VIDEO_BITRATE("VideoBitrate"),
 	@SerialName("VideoFramerate")
-	VIDEO_FRAMERATE,
+	VIDEO_FRAMERATE("VideoFramerate"),
 	@SerialName("VideoLevel")
-	VIDEO_LEVEL,
+	VIDEO_LEVEL("VideoLevel"),
 	@SerialName("VideoProfile")
-	VIDEO_PROFILE,
+	VIDEO_PROFILE("VideoProfile"),
 	@SerialName("VideoTimestamp")
-	VIDEO_TIMESTAMP,
+	VIDEO_TIMESTAMP("VideoTimestamp"),
 	@SerialName("IsAnamorphic")
-	IS_ANAMORPHIC,
+	IS_ANAMORPHIC("IsAnamorphic"),
 	@SerialName("RefFrames")
-	REF_FRAMES,
+	REF_FRAMES("RefFrames"),
 	@SerialName("NumAudioStreams")
-	NUM_AUDIO_STREAMS,
+	NUM_AUDIO_STREAMS("NumAudioStreams"),
 	@SerialName("NumVideoStreams")
-	NUM_VIDEO_STREAMS,
+	NUM_VIDEO_STREAMS("NumVideoStreams"),
 	@SerialName("IsSecondaryAudio")
-	IS_SECONDARY_AUDIO,
+	IS_SECONDARY_AUDIO("IsSecondaryAudio"),
 	@SerialName("VideoCodecTag")
-	VIDEO_CODEC_TAG,
+	VIDEO_CODEC_TAG("VideoCodecTag"),
 	@SerialName("IsAvc")
-	IS_AVC,
+	IS_AVC("IsAvc"),
 	@SerialName("IsInterlaced")
-	IS_INTERLACED,
+	IS_INTERLACED("IsInterlaced"),
 	@SerialName("AudioSampleRate")
-	AUDIO_SAMPLE_RATE,
+	AUDIO_SAMPLE_RATE("AudioSampleRate"),
 	@SerialName("AudioBitDepth")
-	AUDIO_BIT_DEPTH,
+	AUDIO_BIT_DEPTH("AudioBitDepth"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ProgramAudio.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ProgramAudio.kt
@@ -5,21 +5,27 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class ProgramAudio {
+public enum class ProgramAudio(
+	public val serialName: String
+) {
 	@SerialName("Mono")
-	MONO,
+	MONO("Mono"),
 	@SerialName("Stereo")
-	STEREO,
+	STEREO("Stereo"),
 	@SerialName("Dolby")
-	DOLBY,
+	DOLBY("Dolby"),
 	@SerialName("DolbyDigital")
-	DOLBY_DIGITAL,
+	DOLBY_DIGITAL("DolbyDigital"),
 	@SerialName("Thx")
-	THX,
+	THX("Thx"),
 	@SerialName("Atmos")
-	ATMOS,
+	ATMOS("Atmos"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/QuickConnectState.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/QuickConnectState.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,11 +13,16 @@ import kotlinx.serialization.Serializable
  * Quick connect state.
  */
 @Serializable
-public enum class QuickConnectState {
+public enum class QuickConnectState(
+	public val serialName: String
+) {
 	@SerialName("Unavailable")
-	UNAVAILABLE,
+	UNAVAILABLE("Unavailable"),
 	@SerialName("Available")
-	AVAILABLE,
+	AVAILABLE("Available"),
 	@SerialName("Active")
-	ACTIVE,
+	ACTIVE("Active"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RatingType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RatingType.kt
@@ -5,13 +5,19 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class RatingType {
+public enum class RatingType(
+	public val serialName: String
+) {
 	@SerialName("Score")
-	SCORE,
+	SCORE("Score"),
 	@SerialName("Likes")
-	LIKES,
+	LIKES("Likes"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RecommendationType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RecommendationType.kt
@@ -5,21 +5,27 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class RecommendationType {
+public enum class RecommendationType(
+	public val serialName: String
+) {
 	@SerialName("SimilarToRecentlyPlayed")
-	SIMILAR_TO_RECENTLY_PLAYED,
+	SIMILAR_TO_RECENTLY_PLAYED("SimilarToRecentlyPlayed"),
 	@SerialName("SimilarToLikedItem")
-	SIMILAR_TO_LIKED_ITEM,
+	SIMILAR_TO_LIKED_ITEM("SimilarToLikedItem"),
 	@SerialName("HasDirectorFromRecentlyPlayed")
-	HAS_DIRECTOR_FROM_RECENTLY_PLAYED,
+	HAS_DIRECTOR_FROM_RECENTLY_PLAYED("HasDirectorFromRecentlyPlayed"),
 	@SerialName("HasActorFromRecentlyPlayed")
-	HAS_ACTOR_FROM_RECENTLY_PLAYED,
+	HAS_ACTOR_FROM_RECENTLY_PLAYED("HasActorFromRecentlyPlayed"),
 	@SerialName("HasLikedDirector")
-	HAS_LIKED_DIRECTOR,
+	HAS_LIKED_DIRECTOR("HasLikedDirector"),
 	@SerialName("HasLikedActor")
-	HAS_LIKED_ACTOR,
+	HAS_LIKED_ACTOR("HasLikedActor"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RecordingStatus.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RecordingStatus.kt
@@ -5,23 +5,29 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class RecordingStatus {
+public enum class RecordingStatus(
+	public val serialName: String
+) {
 	@SerialName("New")
-	NEW,
+	NEW("New"),
 	@SerialName("InProgress")
-	IN_PROGRESS,
+	IN_PROGRESS("InProgress"),
 	@SerialName("Completed")
-	COMPLETED,
+	COMPLETED("Completed"),
 	@SerialName("Cancelled")
-	CANCELLED,
+	CANCELLED("Cancelled"),
 	@SerialName("ConflictedOk")
-	CONFLICTED_OK,
+	CONFLICTED_OK("ConflictedOk"),
 	@SerialName("ConflictedNotOk")
-	CONFLICTED_NOT_OK,
+	CONFLICTED_NOT_OK("ConflictedNotOk"),
 	@SerialName("Error")
-	ERROR,
+	ERROR("Error"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RepeatMode.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/RepeatMode.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class RepeatMode {
+public enum class RepeatMode(
+	public val serialName: String
+) {
 	@SerialName("RepeatNone")
-	REPEAT_NONE,
+	REPEAT_NONE("RepeatNone"),
 	@SerialName("RepeatAll")
-	REPEAT_ALL,
+	REPEAT_ALL("RepeatAll"),
 	@SerialName("RepeatOne")
-	REPEAT_ONE,
+	REPEAT_ONE("RepeatOne"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ScrollDirection.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/ScrollDirection.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * An enum representing the axis that should be scrolled.
  */
 @Serializable
-public enum class ScrollDirection {
+public enum class ScrollDirection(
+	public val serialName: String
+) {
 	@SerialName("Horizontal")
-	HORIZONTAL,
+	HORIZONTAL("Horizontal"),
 	@SerialName("Vertical")
-	VERTICAL,
+	VERTICAL("Vertical"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SendCommandType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SendCommandType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum SendCommandType.
  */
 @Serializable
-public enum class SendCommandType {
+public enum class SendCommandType(
+	public val serialName: String
+) {
 	@SerialName("Unpause")
-	UNPAUSE,
+	UNPAUSE("Unpause"),
 	@SerialName("Pause")
-	PAUSE,
+	PAUSE("Pause"),
 	@SerialName("Stop")
-	STOP,
+	STOP("Stop"),
 	@SerialName("Seek")
-	SEEK,
+	SEEK("Seek"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SeriesStatus.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SeriesStatus.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * Enum SeriesStatus.
  */
 @Serializable
-public enum class SeriesStatus {
+public enum class SeriesStatus(
+	public val serialName: String
+) {
 	@SerialName("Continuing")
-	CONTINUING,
+	CONTINUING("Continuing"),
 	@SerialName("Ended")
-	ENDED,
+	ENDED("Ended"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SessionMessageType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SessionMessageType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,73 +13,78 @@ import kotlinx.serialization.Serializable
  * The different kinds of messages that are used in the WebSocket api.
  */
 @Serializable
-public enum class SessionMessageType {
+public enum class SessionMessageType(
+	public val serialName: String
+) {
 	@SerialName("ForceKeepAlive")
-	FORCE_KEEP_ALIVE,
+	FORCE_KEEP_ALIVE("ForceKeepAlive"),
 	@SerialName("GeneralCommand")
-	GENERAL_COMMAND,
+	GENERAL_COMMAND("GeneralCommand"),
 	@SerialName("UserDataChanged")
-	USER_DATA_CHANGED,
+	USER_DATA_CHANGED("UserDataChanged"),
 	@SerialName("Sessions")
-	SESSIONS,
+	SESSIONS("Sessions"),
 	@SerialName("Play")
-	PLAY,
+	PLAY("Play"),
 	@SerialName("SyncPlayCommand")
-	SYNC_PLAY_COMMAND,
+	SYNC_PLAY_COMMAND("SyncPlayCommand"),
 	@SerialName("SyncPlayGroupUpdate")
-	SYNC_PLAY_GROUP_UPDATE,
+	SYNC_PLAY_GROUP_UPDATE("SyncPlayGroupUpdate"),
 	@SerialName("Playstate")
-	PLAYSTATE,
+	PLAYSTATE("Playstate"),
 	@SerialName("RestartRequired")
-	RESTART_REQUIRED,
+	RESTART_REQUIRED("RestartRequired"),
 	@SerialName("ServerShuttingDown")
-	SERVER_SHUTTING_DOWN,
+	SERVER_SHUTTING_DOWN("ServerShuttingDown"),
 	@SerialName("ServerRestarting")
-	SERVER_RESTARTING,
+	SERVER_RESTARTING("ServerRestarting"),
 	@SerialName("LibraryChanged")
-	LIBRARY_CHANGED,
+	LIBRARY_CHANGED("LibraryChanged"),
 	@SerialName("UserDeleted")
-	USER_DELETED,
+	USER_DELETED("UserDeleted"),
 	@SerialName("UserUpdated")
-	USER_UPDATED,
+	USER_UPDATED("UserUpdated"),
 	@SerialName("SeriesTimerCreated")
-	SERIES_TIMER_CREATED,
+	SERIES_TIMER_CREATED("SeriesTimerCreated"),
 	@SerialName("TimerCreated")
-	TIMER_CREATED,
+	TIMER_CREATED("TimerCreated"),
 	@SerialName("SeriesTimerCancelled")
-	SERIES_TIMER_CANCELLED,
+	SERIES_TIMER_CANCELLED("SeriesTimerCancelled"),
 	@SerialName("TimerCancelled")
-	TIMER_CANCELLED,
+	TIMER_CANCELLED("TimerCancelled"),
 	@SerialName("RefreshProgress")
-	REFRESH_PROGRESS,
+	REFRESH_PROGRESS("RefreshProgress"),
 	@SerialName("ScheduledTaskEnded")
-	SCHEDULED_TASK_ENDED,
+	SCHEDULED_TASK_ENDED("ScheduledTaskEnded"),
 	@SerialName("PackageInstallationCancelled")
-	PACKAGE_INSTALLATION_CANCELLED,
+	PACKAGE_INSTALLATION_CANCELLED("PackageInstallationCancelled"),
 	@SerialName("PackageInstallationFailed")
-	PACKAGE_INSTALLATION_FAILED,
+	PACKAGE_INSTALLATION_FAILED("PackageInstallationFailed"),
 	@SerialName("PackageInstallationCompleted")
-	PACKAGE_INSTALLATION_COMPLETED,
+	PACKAGE_INSTALLATION_COMPLETED("PackageInstallationCompleted"),
 	@SerialName("PackageInstalling")
-	PACKAGE_INSTALLING,
+	PACKAGE_INSTALLING("PackageInstalling"),
 	@SerialName("PackageUninstalled")
-	PACKAGE_UNINSTALLED,
+	PACKAGE_UNINSTALLED("PackageUninstalled"),
 	@SerialName("ActivityLogEntry")
-	ACTIVITY_LOG_ENTRY,
+	ACTIVITY_LOG_ENTRY("ActivityLogEntry"),
 	@SerialName("ScheduledTasksInfo")
-	SCHEDULED_TASKS_INFO,
+	SCHEDULED_TASKS_INFO("ScheduledTasksInfo"),
 	@SerialName("ActivityLogEntryStart")
-	ACTIVITY_LOG_ENTRY_START,
+	ACTIVITY_LOG_ENTRY_START("ActivityLogEntryStart"),
 	@SerialName("ActivityLogEntryStop")
-	ACTIVITY_LOG_ENTRY_STOP,
+	ACTIVITY_LOG_ENTRY_STOP("ActivityLogEntryStop"),
 	@SerialName("SessionsStart")
-	SESSIONS_START,
+	SESSIONS_START("SessionsStart"),
 	@SerialName("SessionsStop")
-	SESSIONS_STOP,
+	SESSIONS_STOP("SessionsStop"),
 	@SerialName("ScheduledTasksInfoStart")
-	SCHEDULED_TASKS_INFO_START,
+	SCHEDULED_TASKS_INFO_START("ScheduledTasksInfoStart"),
 	@SerialName("ScheduledTasksInfoStop")
-	SCHEDULED_TASKS_INFO_STOP,
+	SCHEDULED_TASKS_INFO_STOP("ScheduledTasksInfoStop"),
 	@SerialName("KeepAlive")
-	KEEP_ALIVE,
+	KEEP_ALIVE("KeepAlive"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SortOrder.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SortOrder.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,9 +13,14 @@ import kotlinx.serialization.Serializable
  * An enum representing the sorting order.
  */
 @Serializable
-public enum class SortOrder {
+public enum class SortOrder(
+	public val serialName: String
+) {
 	@SerialName("Ascending")
-	ASCENDING,
+	ASCENDING("Ascending"),
 	@SerialName("Descending")
-	DESCENDING,
+	DESCENDING("Descending"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SubtitleDeliveryMethod.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SubtitleDeliveryMethod.kt
@@ -5,17 +5,23 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class SubtitleDeliveryMethod {
+public enum class SubtitleDeliveryMethod(
+	public val serialName: String
+) {
 	@SerialName("Encode")
-	ENCODE,
+	ENCODE("Encode"),
 	@SerialName("Embed")
-	EMBED,
+	EMBED("Embed"),
 	@SerialName("External")
-	EXTERNAL,
+	EXTERNAL("External"),
 	@SerialName("Hls")
-	HLS,
+	HLS("Hls"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SubtitlePlaybackMode.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SubtitlePlaybackMode.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,15 +13,20 @@ import kotlinx.serialization.Serializable
  * An enum representing a subtitle playback mode.
  */
 @Serializable
-public enum class SubtitlePlaybackMode {
+public enum class SubtitlePlaybackMode(
+	public val serialName: String
+) {
 	@SerialName("Default")
-	DEFAULT,
+	DEFAULT("Default"),
 	@SerialName("Always")
-	ALWAYS,
+	ALWAYS("Always"),
 	@SerialName("OnlyForced")
-	ONLY_FORCED,
+	ONLY_FORCED("OnlyForced"),
 	@SerialName("None")
-	NONE,
+	NONE("None"),
 	@SerialName("Smart")
-	SMART,
+	SMART("Smart"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SyncPlayUserAccessType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/SyncPlayUserAccessType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,11 +13,16 @@ import kotlinx.serialization.Serializable
  * Enum SyncPlayUserAccessType.
  */
 @Serializable
-public enum class SyncPlayUserAccessType {
+public enum class SyncPlayUserAccessType(
+	public val serialName: String
+) {
 	@SerialName("CreateAndJoinGroups")
-	CREATE_AND_JOIN_GROUPS,
+	CREATE_AND_JOIN_GROUPS("CreateAndJoinGroups"),
 	@SerialName("JoinGroups")
-	JOIN_GROUPS,
+	JOIN_GROUPS("JoinGroups"),
 	@SerialName("None")
-	NONE,
+	NONE("None"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TaskCompletionStatus.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TaskCompletionStatus.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum TaskCompletionStatus.
  */
 @Serializable
-public enum class TaskCompletionStatus {
+public enum class TaskCompletionStatus(
+	public val serialName: String
+) {
 	@SerialName("Completed")
-	COMPLETED,
+	COMPLETED("Completed"),
 	@SerialName("Failed")
-	FAILED,
+	FAILED("Failed"),
 	@SerialName("Cancelled")
-	CANCELLED,
+	CANCELLED("Cancelled"),
 	@SerialName("Aborted")
-	ABORTED,
+	ABORTED("Aborted"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TaskState.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TaskState.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,11 +13,16 @@ import kotlinx.serialization.Serializable
  * Enum TaskState.
  */
 @Serializable
-public enum class TaskState {
+public enum class TaskState(
+	public val serialName: String
+) {
 	@SerialName("Idle")
-	IDLE,
+	IDLE("Idle"),
 	@SerialName("Cancelling")
-	CANCELLING,
+	CANCELLING("Cancelling"),
 	@SerialName("Running")
-	RUNNING,
+	RUNNING("Running"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeReason.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeReason.kt
@@ -5,55 +5,61 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class TranscodeReason {
+public enum class TranscodeReason(
+	public val serialName: String
+) {
 	@SerialName("ContainerNotSupported")
-	CONTAINER_NOT_SUPPORTED,
+	CONTAINER_NOT_SUPPORTED("ContainerNotSupported"),
 	@SerialName("VideoCodecNotSupported")
-	VIDEO_CODEC_NOT_SUPPORTED,
+	VIDEO_CODEC_NOT_SUPPORTED("VideoCodecNotSupported"),
 	@SerialName("AudioCodecNotSupported")
-	AUDIO_CODEC_NOT_SUPPORTED,
+	AUDIO_CODEC_NOT_SUPPORTED("AudioCodecNotSupported"),
 	@SerialName("ContainerBitrateExceedsLimit")
-	CONTAINER_BITRATE_EXCEEDS_LIMIT,
+	CONTAINER_BITRATE_EXCEEDS_LIMIT("ContainerBitrateExceedsLimit"),
 	@SerialName("AudioBitrateNotSupported")
-	AUDIO_BITRATE_NOT_SUPPORTED,
+	AUDIO_BITRATE_NOT_SUPPORTED("AudioBitrateNotSupported"),
 	@SerialName("AudioChannelsNotSupported")
-	AUDIO_CHANNELS_NOT_SUPPORTED,
+	AUDIO_CHANNELS_NOT_SUPPORTED("AudioChannelsNotSupported"),
 	@SerialName("VideoResolutionNotSupported")
-	VIDEO_RESOLUTION_NOT_SUPPORTED,
+	VIDEO_RESOLUTION_NOT_SUPPORTED("VideoResolutionNotSupported"),
 	@SerialName("UnknownVideoStreamInfo")
-	UNKNOWN_VIDEO_STREAM_INFO,
+	UNKNOWN_VIDEO_STREAM_INFO("UnknownVideoStreamInfo"),
 	@SerialName("UnknownAudioStreamInfo")
-	UNKNOWN_AUDIO_STREAM_INFO,
+	UNKNOWN_AUDIO_STREAM_INFO("UnknownAudioStreamInfo"),
 	@SerialName("AudioProfileNotSupported")
-	AUDIO_PROFILE_NOT_SUPPORTED,
+	AUDIO_PROFILE_NOT_SUPPORTED("AudioProfileNotSupported"),
 	@SerialName("AudioSampleRateNotSupported")
-	AUDIO_SAMPLE_RATE_NOT_SUPPORTED,
+	AUDIO_SAMPLE_RATE_NOT_SUPPORTED("AudioSampleRateNotSupported"),
 	@SerialName("AnamorphicVideoNotSupported")
-	ANAMORPHIC_VIDEO_NOT_SUPPORTED,
+	ANAMORPHIC_VIDEO_NOT_SUPPORTED("AnamorphicVideoNotSupported"),
 	@SerialName("InterlacedVideoNotSupported")
-	INTERLACED_VIDEO_NOT_SUPPORTED,
+	INTERLACED_VIDEO_NOT_SUPPORTED("InterlacedVideoNotSupported"),
 	@SerialName("SecondaryAudioNotSupported")
-	SECONDARY_AUDIO_NOT_SUPPORTED,
+	SECONDARY_AUDIO_NOT_SUPPORTED("SecondaryAudioNotSupported"),
 	@SerialName("RefFramesNotSupported")
-	REF_FRAMES_NOT_SUPPORTED,
+	REF_FRAMES_NOT_SUPPORTED("RefFramesNotSupported"),
 	@SerialName("VideoBitDepthNotSupported")
-	VIDEO_BIT_DEPTH_NOT_SUPPORTED,
+	VIDEO_BIT_DEPTH_NOT_SUPPORTED("VideoBitDepthNotSupported"),
 	@SerialName("VideoBitrateNotSupported")
-	VIDEO_BITRATE_NOT_SUPPORTED,
+	VIDEO_BITRATE_NOT_SUPPORTED("VideoBitrateNotSupported"),
 	@SerialName("VideoFramerateNotSupported")
-	VIDEO_FRAMERATE_NOT_SUPPORTED,
+	VIDEO_FRAMERATE_NOT_SUPPORTED("VideoFramerateNotSupported"),
 	@SerialName("VideoLevelNotSupported")
-	VIDEO_LEVEL_NOT_SUPPORTED,
+	VIDEO_LEVEL_NOT_SUPPORTED("VideoLevelNotSupported"),
 	@SerialName("VideoProfileNotSupported")
-	VIDEO_PROFILE_NOT_SUPPORTED,
+	VIDEO_PROFILE_NOT_SUPPORTED("VideoProfileNotSupported"),
 	@SerialName("AudioBitDepthNotSupported")
-	AUDIO_BIT_DEPTH_NOT_SUPPORTED,
+	AUDIO_BIT_DEPTH_NOT_SUPPORTED("AudioBitDepthNotSupported"),
 	@SerialName("SubtitleCodecNotSupported")
-	SUBTITLE_CODEC_NOT_SUPPORTED,
+	SUBTITLE_CODEC_NOT_SUPPORTED("SubtitleCodecNotSupported"),
 	@SerialName("DirectPlayError")
-	DIRECT_PLAY_ERROR,
+	DIRECT_PLAY_ERROR("DirectPlayError"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeSeekInfo.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeSeekInfo.kt
@@ -5,13 +5,19 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class TranscodeSeekInfo {
+public enum class TranscodeSeekInfo(
+	public val serialName: String
+) {
 	@SerialName("Auto")
-	AUTO,
+	AUTO("Auto"),
 	@SerialName("Bytes")
-	BYTES,
+	BYTES("Bytes"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TransportStreamTimestamp.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/TransportStreamTimestamp.kt
@@ -5,15 +5,21 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class TransportStreamTimestamp {
+public enum class TransportStreamTimestamp(
+	public val serialName: String
+) {
 	@SerialName("None")
-	NONE,
+	NONE("None"),
 	@SerialName("Zero")
-	ZERO,
+	ZERO("Zero"),
 	@SerialName("Valid")
-	VALID,
+	VALID("Valid"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/UnratedItem.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/UnratedItem.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,23 +13,28 @@ import kotlinx.serialization.Serializable
  * An enum representing an unrated item.
  */
 @Serializable
-public enum class UnratedItem {
+public enum class UnratedItem(
+	public val serialName: String
+) {
 	@SerialName("Movie")
-	MOVIE,
+	MOVIE("Movie"),
 	@SerialName("Trailer")
-	TRAILER,
+	TRAILER("Trailer"),
 	@SerialName("Series")
-	SERIES,
+	SERIES("Series"),
 	@SerialName("Music")
-	MUSIC,
+	MUSIC("Music"),
 	@SerialName("Book")
-	BOOK,
+	BOOK("Book"),
 	@SerialName("LiveTvChannel")
-	LIVE_TV_CHANNEL,
+	LIVE_TV_CHANNEL("LiveTvChannel"),
 	@SerialName("LiveTvProgram")
-	LIVE_TV_PROGRAM,
+	LIVE_TV_PROGRAM("LiveTvProgram"),
 	@SerialName("ChannelContent")
-	CHANNEL_CONTENT,
+	CHANNEL_CONTENT("ChannelContent"),
 	@SerialName("Other")
-	OTHER,
+	OTHER("Other"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/Video3dFormat.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/Video3dFormat.kt
@@ -5,19 +5,25 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public enum class Video3dFormat {
+public enum class Video3dFormat(
+	public val serialName: String
+) {
 	@SerialName("HalfSideBySide")
-	HALF_SIDE_BY_SIDE,
+	HALF_SIDE_BY_SIDE("HalfSideBySide"),
 	@SerialName("FullSideBySide")
-	FULL_SIDE_BY_SIDE,
+	FULL_SIDE_BY_SIDE("FullSideBySide"),
 	@SerialName("FullTopAndBottom")
-	FULL_TOP_AND_BOTTOM,
+	FULL_TOP_AND_BOTTOM("FullTopAndBottom"),
 	@SerialName("HalfTopAndBottom")
-	HALF_TOP_AND_BOTTOM,
+	HALF_TOP_AND_BOTTOM("HalfTopAndBottom"),
 	@SerialName("MVC")
-	MVC,
+	MVC("MVC"),
+	;
+
+	public override fun toString(): String = serialName
 }

--- a/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/VideoType.kt
+++ b/jellyfin-model/src/main/kotlin-generated/org/jellyfin/sdk/model/api/VideoType.kt
@@ -5,6 +5,7 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.model.api
 
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,13 +13,18 @@ import kotlinx.serialization.Serializable
  * Enum VideoType.
  */
 @Serializable
-public enum class VideoType {
+public enum class VideoType(
+	public val serialName: String
+) {
 	@SerialName("VideoFile")
-	VIDEO_FILE,
+	VIDEO_FILE("VideoFile"),
 	@SerialName("Iso")
-	ISO,
+	ISO("Iso"),
 	@SerialName("Dvd")
-	DVD,
+	DVD("Dvd"),
 	@SerialName("BluRay")
-	BLU_RAY,
+	BLU_RAY("BluRay"),
+	;
+
+	public override fun toString(): String = serialName
 }


### PR DESCRIPTION
- Add tests for the `createUrl` function
- Update generator to add a property to all enums called "serialName" (original, I know)
  - Property is a public val, added in constructor
  - Value is the same as the `SerialName` annotation
  - Added a `override fun toString` to return the `serialName` instead of `name`