### PR TITLE
Add bitrate measurement functions

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -102,6 +102,11 @@ public final class org/jellyfin/sdk/api/client/exception/TimeoutException : org/
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class org/jellyfin/sdk/api/client/extensions/MediaInfoApiExtensionsKt {
+	public static final fun detectBitrate (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun measureBitrate (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class org/jellyfin/sdk/api/client/extensions/UserApiExtensionsKt {
 	public static final fun authenticateUserByName (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/extensions/MediaInfoApiExtensions.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/extensions/MediaInfoApiExtensions.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.sdk.api.client.extensions
+
+import org.jellyfin.sdk.api.operations.MediaInfoApi
+import org.jellyfin.sdk.model.BitrateMeasurement
+
+/**
+ * Create a [BitrateMeasurement] for a response of [bytes]. The returned value contains the input, duration and the
+ * bitrate.
+ */
+public suspend fun MediaInfoApi.measureBitrate(bytes: Int): BitrateMeasurement {
+	val now = System.currentTimeMillis()
+
+	// Request the bits
+	getBitrateTestBytes(size = bytes).apply {
+		// Download full content
+		content.awaitContent()
+	}
+
+	// Calculate duration
+	val duration = System.currentTimeMillis() - now
+
+	// Return results
+	return BitrateMeasurement(
+		bytes = bytes,
+		duration = duration,
+	)
+}
+
+/**
+ * Detect the bitrate of the current connection by calling [measureBitrate] until a measurement of at least 1 second or
+ * with the maximum byte size is created.
+ */
+@Suppress("MagicNumber")
+public suspend fun MediaInfoApi.detectBitrate(): BitrateMeasurement {
+	val maxBytes = 10_000_000 // Max is 10 MB
+	var testBytes = 4_000_000 // Start with 4 MB
+
+	var measurement: BitrateMeasurement
+	do {
+		measurement = measureBitrate(testBytes)
+		testBytes += 2_000_000 // Increase by 2 MB
+	} while (measurement.duration <= 1_000 && measurement.bytes < maxBytes)
+
+	return measurement
+}

--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -1,3 +1,17 @@
+public final class org/jellyfin/sdk/model/BitrateMeasurement {
+	public fun <init> (IJ)V
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun copy (IJ)Lorg/jellyfin/sdk/model/BitrateMeasurement;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/BitrateMeasurement;IJILjava/lang/Object;)Lorg/jellyfin/sdk/model/BitrateMeasurement;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBitrate ()J
+	public final fun getBytes ()I
+	public final fun getDuration ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/jellyfin/sdk/model/ClientInfo {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/BitrateMeasurement.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/BitrateMeasurement.kt
@@ -1,0 +1,20 @@
+package org.jellyfin.sdk.model
+
+public data class BitrateMeasurement(
+	/**
+	 * Amount of bytes used to measure the bitrate.
+	 */
+	val bytes: Int,
+
+	/**
+	 * Measurement duration in milliseconds.
+	 */
+	val duration: Long,
+) {
+	/**
+	 * Measured network speed in bits per second.
+	 * Calculated by dividing [bytes] by the [duration] in seconds multiplied by 8 (byte -> bits).
+	 */
+	@Suppress("MagicNumber")
+	val bitrate: Long = bytes * 8000L / duration
+}

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Main.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Main.kt
@@ -2,10 +2,10 @@ package org.jellyfin.sample.cli
 
 import com.github.ajalt.clikt.core.NoOpCliktCommand
 import com.github.ajalt.clikt.core.subcommands
+import org.jellyfin.sample.cli.command.*
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
-import org.jellyfin.sample.cli.command.*
 
 fun main(args: Array<String>) {
 	val jellyfin = Jellyfin {
@@ -14,13 +14,15 @@ fun main(args: Array<String>) {
 	}
 
 	val instance = NoOpCliktCommand(name = "jellyfin").apply {
+		subcommands(Bitrate(jellyfin))
 		subcommands(Discover(jellyfin))
-		subcommands(Login(jellyfin))
 		subcommands(Libraries(jellyfin))
-		subcommands(Users(jellyfin))
-		subcommands(Ping(jellyfin))
+		subcommands(Login(jellyfin))
 		subcommands(Observe(jellyfin))
+		subcommands(Ping(jellyfin))
+		subcommands(Users(jellyfin))
 	}
+
 
 	instance.main(args)
 }

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Bitrate.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Bitrate.kt
@@ -1,0 +1,39 @@
+package org.jellyfin.sample.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import kotlinx.coroutines.runBlocking
+import org.jellyfin.sample.cli.serverOption
+import org.jellyfin.sample.cli.tokenOption
+import org.jellyfin.sdk.Jellyfin
+import org.jellyfin.sdk.api.client.extensions.detectBitrate
+import org.jellyfin.sdk.api.client.extensions.measureBitrate
+import org.jellyfin.sdk.api.operations.MediaInfoApi
+
+class Bitrate(
+	private val jellyfin: Jellyfin,
+) : CliktCommand("Detect or measure bitrate") {
+	private val server by serverOption()
+	private val token by tokenOption()
+	private val bytes by option(
+		"--bytes", "-b",
+		help = "Amount of bytes to request from the server. Leave empty to detect automatically."
+	).int()
+
+	override fun run(): Unit = runBlocking {
+		val api = jellyfin.createApi(baseUrl = server, accessToken = token)
+		val mediaInfoApi = MediaInfoApi(api)
+
+		val measurement = when {
+			bytes != null -> mediaInfoApi.measureBitrate(bytes!!)
+			else -> mediaInfoApi.detectBitrate()
+		}
+
+		echo(buildString {
+			appendLine("Requested ${measurement.bytes} bytes from the server.")
+			appendLine("Reply took ${measurement.duration}ms.")
+			appendLine("Measured bitrate is ${measurement.bitrate} (${measurement.bitrate / 1000000} megabit).")
+		})
+	}
+}


### PR DESCRIPTION
Adds 2 new functions to the `MediaInfoApi` class:

- measureBitrate
- detectBitrate

Both return a `BitrateMeasurement` containing requested bytes, response duration and calculated bitrate.
The detect function should normally take between 0.5-3 seconds but can take longer depending on network conditions.

Additionally adds a new bitrate command to the CLI because why not.