### PR TITLE
Publish openapi-unstable branch as openapi-unstable-SNAPSHOT

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -6,6 +6,7 @@ on:
       - v*
     branches:
       - master
+      - openapi-unstable
 
 jobs:
   publish:
@@ -23,6 +24,9 @@ jobs:
       - name: Set JELLYFIN_VERSION
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
+      - name: Set JELLYFIN_BRANCH
+        if: ${{ startsWith(github.ref, 'refs/heads/') }}
+        run: echo "JELLYFIN_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
       - name: Run publish task
         run: ./gradlew --no-daemon --info publish closeAndReleaseSonatypeStagingRepository
         env:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ implementation("org.jellyfin.sdk:jellyfin-platform-android:$sdkVersion")
    ```
 </details>
 
+<details>
+  <summary>Using SNAPSHOT versions</summary>
+
+  When working on new features in your application you might need a build of the SDK targetting the next server version.
+  For this use case we publish two SNAPSHOT releases: `master-SNAPSHOT` and `openapi-unstable-SNAPSHOT`. To use the
+  snaphot versions, add the snapshot repository to your build script:
+  `https://s01.oss.sonatype.org/content/repositories/snapshots/`
+
+  An example using Gradle with Kotlin DSL that only allows the `master-SNAPSHOT` version:
+
+  ```kotlin
+  repositories {
+      maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+          content {
+              // Only allow SDK snapshots
+              includeVersionByRegex("org\\.jellyfin\\.sdk", ".*", "master-SNAPSHOT")
+          }
+      }
+  }
+   ```
+</details>
+
 ## Usage
 
 ### Creating a Jellyfin instance

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 // Versioning
 allprojects {
 	group = "org.jellyfin.sdk"
-	version = getProperty("jellyfin.version")?.removePrefix("v") ?: "latest-SNAPSHOT"
+	version = createVersion()
 
 	// Add default dependency repositories
 	repositories.defaultRepositories()

--- a/buildSrc/src/main/kotlin/Properties.kt
+++ b/buildSrc/src/main/kotlin/Properties.kt
@@ -7,6 +7,17 @@ fun Project.getProperty(name: String): String? {
 	// sample.var --> SAMPLE_VAR
 	val environmentName = name.toUpperCase().replace(".", "_")
 	val value = findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
-	logger.info("getProperty($name): $environmentName - found=${!value.isNullOrBlank()}")
+	logger.debug("getProperty($name): $environmentName - found=${!value.isNullOrBlank()}")
 	return value
+}
+
+/**
+ * Helper function to create the SDK version using the `jellyfin.version` and `jellyfin.branch` properties.
+ * Uses [getProperty] to retrieve the properties. Defaults to `latest-SNAPSHOT` if both properties are not set.
+ */
+fun Project.createVersion(): String {
+	val jellyfinVersion = getProperty("jellyfin.version")?.removePrefix("v")
+	val jellyfinBranch = getProperty("jellyfin.branch")?.let { "$it-SNAPSHOT" }
+
+	return jellyfinVersion ?: jellyfinBranch ?: "latest-SNAPSHOT"
 }


### PR DESCRIPTION
- Add jellyfin.branch property to create versions from a branch name
- Publish openapi-unstable branch as openapi-unstable-SNAPSHOT
- getProperty log set to debug
- Rename `latest-SNAPSHOT` to `master-SNAPSHOT`
  - latest is now a fallback which is not used in CI, update your projects using the snapshots to use `master-SNAPSHOT`!

This PR is untested since I can't test this on my fork.