### PR TITLE
Improve usage of Jellyfin class in Java code

### DIFF
--- a/jellyfin-core/api/jellyfin-core.api
+++ b/jellyfin-core/api/jellyfin-core.api
@@ -1,7 +1,13 @@
 public final class org/jellyfin/sdk/Jellyfin {
 	public static final field Companion Lorg/jellyfin/sdk/Jellyfin$Companion;
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Lorg/jellyfin/sdk/JellyfinOptions$Builder;)V
 	public fun <init> (Lorg/jellyfin/sdk/JellyfinOptions;)V
+	public final fun createApi ()Lorg/jellyfin/sdk/api/client/KtorClient;
+	public final fun createApi (Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/KtorClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/KtorClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;)Lorg/jellyfin/sdk/api/client/KtorClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)Lorg/jellyfin/sdk/api/client/KtorClient;
 	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;)Lorg/jellyfin/sdk/api/client/KtorClient;
 	public static synthetic fun createApi$default (Lorg/jellyfin/sdk/Jellyfin;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;ILjava/lang/Object;)Lorg/jellyfin/sdk/api/client/KtorClient;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -12,6 +12,7 @@ public class Jellyfin(
 	private val options: JellyfinOptions,
 ) {
 	public constructor(initOptions: JellyfinOptions.Builder.() -> Unit) : this(JellyfinOptions.build(initOptions))
+	public constructor(optionsBuilder: JellyfinOptions.Builder) : this(optionsBuilder.build())
 
 	/**
 	 * Get the device information set when creating the Jellyfin instance or null if not set.
@@ -37,6 +38,7 @@ public class Jellyfin(
 	 *
 	 * Throws an [IllegalStateException] when the client or device information is missing.
 	 */
+	@JvmOverloads
 	public fun createApi(
 		baseUrl: String? = null,
 		accessToken: String? = null,


### PR DESCRIPTION
2 changes:

- Add additional constructor so you can pass the `JellyfinOptions.Builder` to the constructor (no need to call `.build()`)
- Add `@JvmOverloads` to the `createApi` function so you can call `jellyfin.createApi("baseurl")` instead of `jellyfin.createApi("baseurl", null, null, null, null)`