### PR TITLE
Bare minimum changes to allow JitPack build of final apiclient version without JCenter dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
 	id("maven-publish")
-	id("io.gitlab.arturbosch.detekt").version("1.9.1")
+//	id("io.gitlab.arturbosch.detekt").version("1.9.1")
 }
 
 // Versioning
@@ -11,31 +11,31 @@ allprojects {
 
 buildscript {
 	repositories {
+		mavenCentral()
 		google()
-		jcenter()
 	}
 
 	dependencies {
-		classpath("com.android.tools.build:gradle:4.1.1")
+		classpath("com.android.tools.build:gradle:4.0.2")
 		classpath(kotlin("gradle-plugin", "1.3.72"))
 	}
 }
 
 allprojects {
 	repositories {
+		mavenCentral()
 		google()
-		jcenter()
 	}
 
 	// Publishing
 	plugins.apply("maven-publish")
-	publishing.repositories.jellyfinBintray(this)
+//	publishing.repositories.jellyfinBintray(this)
 
 	// Detekt
-	plugins.apply("io.gitlab.arturbosch.detekt")
-	detekt {
-		buildUponDefaultConfig = true
-		ignoreFailures = true
-		config = files("$rootDir/detekt.yml")
-	}
+//	plugins.apply("io.gitlab.arturbosch.detekt")
+//	detekt {
+//		buildUponDefaultConfig = true
+//		ignoreFailures = true
+//		config = files("$rootDir/detekt.yml")
+//	}
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-	jcenter()
+	mavenCentral()
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,7 @@ object Dependencies {
 	}
 
 	// Non-categorised dependencies
-	const val volley = "com.android.volley:volley:1.1.1"
+	const val volley = "com.android.volley:volley:1.2.0"
 	const val gson = "com.google.code.gson:gson:2.8.6"
 	const val javaWebSocket = "org.java-websocket:Java-WebSocket:1.4.1"
 	const val junit = "junit:junit:4.12"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 android.useAndroidX=true
 kotlin.incremental=true
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 
 # When publishing the "secure" checksums Bintray is unable to correctly identify the versions
 # and will use the artifact names (modules) as version names

--- a/samples/kotlin-console/build.gradle.kts
+++ b/samples/kotlin-console/build.gradle.kts
@@ -8,7 +8,7 @@ application {
 }
 
 repositories {
-	jcenter()
+	mavenCentral()
 
 	// Repository needed for kotlinx-cli
 	maven("https://kotlin.bintray.com/kotlinx")


### PR DESCRIPTION
This is the final change for the legacy apiclient. With these changes JitPack should be able to build the release and the apiclient doesn't need JCenter dependencies. **It is highly advised to upgrade to the new SDK, this release is not supported.**

- Disabled Detekt
- Disabled publishing to JCenter
- Removed JCenter repository
- Added MavenCentral repository
- Increased memory for Gradle builds (prevents out of memory)
- Updated Volley to 1.2.0 (1.1.x not available on MavenCentral)
- Downgrade Android build tools to 4.0.x because 4.1 doesn't support the Gradle version