### PR TITLE
Fix non self closing <see> and <seealso> elements in descriptions

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/DescriptionBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/DescriptionBuilder.kt
@@ -9,9 +9,11 @@ class DescriptionBuilder : Builder<String?, String?> {
 		// Replace <br /> elements with new line
 		Regex("""<br\s?/?>""") to "\n",
 		// Replace <seealso> elements with their value
-		Regex("""<seealso\s+cref="(.*?)"\s?/?>""") to "`$1`",
+		Regex("""<seealso\s+cref="(.*?)"\s?/>""") to "`$1`",
+		Regex("""<seealso\s+cref="(.*?)"\s?>(.*?)</see>""") to "$2 (`$1`)",
 		// Replace <see> elements with their value
-		Regex("""<see\s+cref="(.*?)"\s?/?>""") to "`$1`",
+		Regex("""<see\s+cref="(.*?)"\s?/>""") to "`$1`",
+		Regex("""<see\s+cref="(.*?)"\s?>(.*?)</see>""") to "$2 (`$1`)",
 	)
 
 	override fun build(data: String?): String? {


### PR DESCRIPTION
Fixes some comments on the unstable branch.

Original (source):
```
as well as which <see cref="TranscodingProfiles">containers/codecs to transcode to</see> in case it isn't.
```
Original (openapi):
```
as well as which <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.TranscodingProfiles">containers/codecs to transcode to</see> in case it isn't.
```

Before PR:
```
as well as which `P:MediaBrowser.Model.Dlna.DeviceProfile.TranscodingProfiles`containers/codecs to transcode to</see> in case it isn't.
```

After PR:
```
as well as which containers/codecs to transcode to (`P:MediaBrowser.Model.Dlna.DeviceProfile.TranscodingProfiles`) in case it isn't.
```