### PR TITLE
Fix formatting of LocalDateTimeSerializer encoding and add tests

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -11055,6 +11055,8 @@ public final class org/jellyfin/sdk/model/extensions/PairExtensionsKt {
 
 public final class org/jellyfin/sdk/model/serializer/LocalDateTimeSerializer : kotlinx/serialization/KSerializer {
 	public fun <init> ()V
+	public fun <init> (Ljava/time/ZoneId;)V
+	public synthetic fun <init> (Ljava/time/ZoneId;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/time/LocalDateTime;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/serializer/LocalDateTimeSerializer.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/serializer/LocalDateTimeSerializer.kt
@@ -9,12 +9,15 @@ import kotlinx.serialization.encoding.Encoder
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
 /**
  * Serializer to read zoned date times as local date time and writing it back
  */
-public class LocalDateTimeSerializer : KSerializer<LocalDateTime> {
+public class LocalDateTimeSerializer(
+	private val zoneId: ZoneId = ZoneId.systemDefault(),
+) : KSerializer<LocalDateTime> {
 	override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 
 	override fun deserialize(decoder: Decoder): LocalDateTime = try {
@@ -26,5 +29,5 @@ public class LocalDateTimeSerializer : KSerializer<LocalDateTime> {
 	}
 
 	override fun serialize(encoder: Encoder, value: LocalDateTime): Unit =
-		encoder.encodeString(value.atZone(ZoneId.systemDefault()).toString())
+		encoder.encodeString(value.atZone(zoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
 }

--- a/jellyfin-model/src/test/kotlin/org/jellyfin/sdk/model/serializer/LocalDateTimeSerializerTests.kt
+++ b/jellyfin-model/src/test/kotlin/org/jellyfin/sdk/model/serializer/LocalDateTimeSerializerTests.kt
@@ -1,0 +1,64 @@
+package org.jellyfin.sdk.model.serializer
+
+import kotlinx.serialization.json.Json
+import java.time.LocalDateTime
+import java.time.ZoneId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+public class LocalDateTimeSerializerTests {
+	@Test
+	public fun `Encodes dates and times (UTC)`() {
+		val instance = LocalDateTimeSerializer(ZoneId.of("UTC"))
+
+		assertEquals(
+			""""2021-06-30T01:33:07Z"""",
+			Json.encodeToString(instance, LocalDateTime.of(2021, 6, 30, 1, 33, 7))
+		)
+	}
+
+	@Test
+	public fun `Encodes dates and times (Offset)`() {
+		val instance = LocalDateTimeSerializer(ZoneId.of("UTC+01:00"))
+
+		assertEquals(
+			""""2021-06-30T01:33:07+01:00"""",
+			Json.encodeToString(instance, LocalDateTime.of(2021, 6, 30, 1, 33, 7))
+		)
+	}
+
+	@Test
+	public fun `Parses minimum value`() {
+		val instance = LocalDateTimeSerializer(ZoneId.of("UTC"))
+
+		assertEquals(LocalDateTime.MIN, Json.decodeFromString(instance, """"0001-01-01T00:00:00""""))
+	}
+
+	@Test
+	public fun `Parses dates and times (UTC)`() {
+		val instance = LocalDateTimeSerializer(ZoneId.of("UTC"))
+
+		assertEquals(
+			LocalDateTime.of(2021, 6, 30, 1, 33, 7),
+			Json.decodeFromString(instance, """"2021-06-30T01:33:07Z"""")
+		)
+		assertEquals(
+			LocalDateTime.of(2021, 6, 30, 1, 33, 7, 420000000),
+			Json.decodeFromString(instance, """"2021-06-30T01:33:07.420Z"""")
+		)
+	}
+
+	@Test
+	public fun `Parses dates and times (Offset)`() {
+		val instance = LocalDateTimeSerializer(ZoneId.of("UTC+01:00"))
+
+		assertEquals(
+			LocalDateTime.of(2021, 6, 30, 1, 33, 7),
+			Json.decodeFromString(instance, """"2021-06-30T01:33:07+01:00"""")
+		)
+		assertEquals(
+			LocalDateTime.of(2021, 6, 30, 1, 33, 7, 420000000),
+			Json.decodeFromString(instance, """"2021-06-30T01:33:07.420+01:00"""")
+		)
+	}
+}


### PR DESCRIPTION
Should fix #285 although not directly tested with the api operation mentioned in the issue.