### PR TITLE
Add ParameterValidation framework with initial IntRangeValidation

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationParameter.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationParameter.kt
@@ -8,5 +8,6 @@ data class ApiServiceOperationParameter(
 	val type: TypeName,
 	val defaultValue: Any?,
 	val description: String?,
-	val deprecated: Boolean
+	val deprecated: Boolean,
+	val validation: ParameterValidation?,
 )

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/IntRangeValidation.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/IntRangeValidation.kt
@@ -1,0 +1,6 @@
+package org.jellyfin.openapi.model
+
+data class IntRangeValidation(
+	val min: Int,
+	val max: Int,
+) : ParameterValidation

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ParameterValidation.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ParameterValidation.kt
@@ -1,0 +1,3 @@
+package org.jellyfin.openapi.model
+
+sealed interface ParameterValidation


### PR DESCRIPTION
Allows for client-side checking of values based on the metadata available in the OpenAPI specification. Right now (with 10.7.x) none of the parameters add any validation metadata.

Sample of generated code with the changes from https://github.com/jellyfin/jellyfin/pull/6276

```kotlin
	/**
	 * Tests the network with a request with the size of the bitrate.
	 *
	 * @param size The bitrate. Defaults to 102400.
	 */
	public suspend fun getBitrateTestBytes(size: Int? = 102400): Response<ByteReadChannel> {
		val pathParameters = emptyMap<String, Any?>()
		val queryParameters = mutableMapOf<String, Any?>()
		require(size in 0..100000000) { "Parameter \"size\" must be in range 0..100000000 (inclusive)." }
		queryParameters["size"] = size
		val data = null
		val response = api.`get`<ByteReadChannel>("/Playback/BitrateTest", pathParameters,
				queryParameters, data)
		return response
	}
```