### PR TITLE
Correctly set member names in OperationBuilder

### DIFF
--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ActivityLogApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ActivityLogApi.kt
@@ -10,6 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.ActivityLogEntryQueryResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ApiKeyApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ApiKeyApi.kt
@@ -8,6 +8,8 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.AuthenticationInfoQueryResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ArtistsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ArtistsApi.kt
@@ -12,6 +12,9 @@ import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
@@ -14,6 +14,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Map
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.EncodingContext

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/BrandingApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/BrandingApi.kt
@@ -7,6 +7,7 @@ package org.jellyfin.sdk.api.operations
 
 import kotlin.Any
 import kotlin.String
+import kotlin.collections.emptyMap
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BrandingOptions

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ChannelsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ChannelsApi.kt
@@ -12,6 +12,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/CollectionApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/CollectionApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.CollectionCreationResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
@@ -10,6 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.MediaEncoderPathDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DashboardApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DashboardApi.kt
@@ -9,6 +9,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.ConfigurationPageInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
@@ -10,6 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.DeviceInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DisplayPreferencesApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DisplayPreferencesApi.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 import kotlin.Any
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaApi.kt
@@ -9,6 +9,8 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.DeviceProfile

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaServerApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaServerApi.kt
@@ -9,6 +9,8 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
@@ -14,6 +14,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Map
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.EncodingContext

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/EnvironmentApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/EnvironmentApi.kt
@@ -11,6 +11,8 @@ import kotlin.Deprecated
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.DefaultDirectoryBrowserInfoDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/FilterApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/FilterApi.kt
@@ -10,6 +10,9 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.QueryFilters

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/GenresApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/GenresApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
@@ -10,6 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
@@ -14,6 +14,8 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ImageByNameApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ImageByNameApi.kt
@@ -10,6 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.ImageByNameInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/InstantMixApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/InstantMixApi.kt
@@ -12,6 +12,9 @@ import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemLookupApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemLookupApi.kt
@@ -11,6 +11,8 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.AlbumInfoRemoteSearchQuery

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemRefreshApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemRefreshApi.kt
@@ -10,6 +10,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.MetadataRefreshMode

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemUpdateApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemUpdateApi.kt
@@ -9,6 +9,8 @@ import java.util.UUID
 import kotlin.Any
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ItemsApi.kt
@@ -13,6 +13,9 @@ import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
@@ -15,6 +15,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.AllThemeMediaResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryStructureApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryStructureApi.kt
@@ -11,6 +11,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.AddVirtualFolderDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
@@ -16,6 +16,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LocalizationApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/LocalizationApi.kt
@@ -8,6 +8,7 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.emptyMap
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.CountryInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
@@ -14,6 +14,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/MoviesApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/MoviesApi.kt
@@ -11,6 +11,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.ItemFields

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/MusicGenresApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/MusicGenresApi.kt
@@ -12,6 +12,9 @@ import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/NotificationsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/NotificationsApi.kt
@@ -9,6 +9,8 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PackageApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PackageApi.kt
@@ -10,6 +10,8 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.PackageInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PersonsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PersonsApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PlayStateApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PlayStateApi.kt
@@ -13,6 +13,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PlaylistsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PlaylistsApi.kt
@@ -13,6 +13,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
@@ -13,6 +13,8 @@ import kotlin.Deprecated
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BasePluginConfiguration

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/QuickConnectApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/QuickConnectApi.kt
@@ -10,6 +10,8 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.QuickConnectResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/RemoteImageApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/RemoteImageApi.kt
@@ -12,6 +12,8 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.ImageProviderInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ScheduledTasksApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/ScheduledTasksApi.kt
@@ -10,6 +10,8 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.TaskInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SearchApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SearchApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.SearchHintResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SessionApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SessionApi.kt
@@ -14,6 +14,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/StartupApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/StartupApi.kt
@@ -8,6 +8,7 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.emptyMap
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.StartupConfigurationDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/StudiosApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/StudiosApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
@@ -15,6 +15,8 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.FontFile

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SuggestionsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SuggestionsApi.kt
@@ -11,6 +11,8 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SyncPlayApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SyncPlayApi.kt
@@ -9,6 +9,7 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BufferRequestDto

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SystemApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/SystemApi.kt
@@ -9,6 +9,8 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.EndPointInfo

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/TimeSyncApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/TimeSyncApi.kt
@@ -7,6 +7,7 @@ package org.jellyfin.sdk.api.operations
 
 import kotlin.Any
 import kotlin.String
+import kotlin.collections.emptyMap
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.UtcTimeResponse

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/TrailersApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/TrailersApi.kt
@@ -13,6 +13,9 @@ import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/TvShowsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/TvShowsApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
@@ -13,6 +13,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UserApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UserApi.kt
@@ -11,6 +11,8 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UserLibraryApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UserLibraryApi.kt
@@ -12,6 +12,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UserViewsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/UserViewsApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
@@ -11,6 +11,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/VideoHlsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/VideoHlsApi.kt
@@ -14,6 +14,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Map
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.EncodingContext

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
@@ -16,6 +16,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.Map
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult

--- a/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/YearsApi.kt
+++ b/jellyfin-api/src/main/kotlin-generated/org/jellyfin/sdk/api/operations/YearsApi.kt
@@ -11,6 +11,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.model.api.BaseItemDto

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -32,7 +32,9 @@ open class OperationBuilder(
 		returns(ClassName(Packages.API_CLIENT, Classes.API_RESPONSE).plusParameter(data.returnType))
 	}
 
-	protected fun buildParameter(data: ApiServiceOperationParameter) = ParameterSpec.builder(data.name, data.type).apply {
+	protected fun buildParameter(
+		data: ApiServiceOperationParameter,
+	) = ParameterSpec.builder(data.name, data.type).apply {
 		// Determine class name without parameters
 		val typeClassName = when (data.type) {
 			is ClassName -> data.type
@@ -48,9 +50,12 @@ open class OperationBuilder(
 			is CustomDefaultValue -> defaultValue(data.defaultValue.build())
 			// Set value to null by default for nullable values
 			null -> when {
-				typeClassName == Collection::class.asClassName() -> defaultValue("%N()", "emptyList")
-				typeClassName == List::class.asClassName() -> defaultValue("%N()", "emptyList")
-				typeClassName == Map::class.asClassName() -> defaultValue("%N()", "emptyMap")
+				typeClassName == Collection::class.asClassName() ->
+					defaultValue("%M()", MemberName("kotlin.collections", "emptyList"))
+				typeClassName == List::class.asClassName() ->
+					defaultValue("%M()", MemberName("kotlin.collections", "emptyList"))
+				typeClassName == Map::class.asClassName() ->
+					defaultValue("%M()", MemberName("kotlin.collections", "emptyMap"))
 				data.type.isNullable -> defaultValue("%L", "null")
 			}
 		}
@@ -67,8 +72,8 @@ open class OperationBuilder(
 	) {
 		// Create map
 		// val $(name) = $("emptyMap"|"mutableMapOf")<String, Any?>()
-		val mapType = if (parameters.isEmpty()) "emptyMap" else "mutableMapOf"
-		addStatement("val %N = %N<%T, %T?>()", name, mapType, String::class, Any::class)
+		val mapType = MemberName("kotlin.collections", if (parameters.isEmpty()) "emptyMap" else "mutableMapOf")
+		addStatement("val %N = %M<%T, %T?>()", name, mapType, String::class, Any::class)
 
 		// Add parameters
 		parameters.forEach { parameter ->


### PR DESCRIPTION
- Use %M instead of %N so the imports are properly created

No real significant changes except for the fact that it adds imports for stuff that is imported by default.