### PR TITLE
Ensure device name has no special characters

### DIFF
--- a/jellyfin-platform-android/src/main/kotlin/org/jellyfin/sdk/interaction/AndroidDevice.kt
+++ b/jellyfin-platform-android/src/main/kotlin/org/jellyfin/sdk/interaction/AndroidDevice.kt
@@ -10,9 +10,21 @@ import org.jellyfin.sdk.model.DeviceInfo
 public fun androidDevice(context: Context): DeviceInfo {
 	val id = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 
+	// Ensure device name has no special characters or fallback to manufacturer and model else the connection will fail
+	val testDeviceName = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+		val deviceName = Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+		if (deviceName.matches("([^\\x20-\\x7E])".toRegex())) {
+			deviceName
+		} else {
+			null
+		}
+	} else {
+		null
+	}
+
 	// Use name from device settings
-	val name = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-		Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+	val name = if (testDeviceName != null) {
+		testDeviceName
 	} else {
 		// Concatenate the name based on manufacturer and model
 		val manufacturer = Build.MANUFACTURER


### PR DESCRIPTION
The below checks for "special characters" on client level wasn't enough to cause the client not being able to connect to the server when it has special characters in the device name. Proposed to have checks at SDK level instead. Additionally to fallback to use the manufacturer and model string instead if the device name has special characters:

https://github.com/jellyfin/jellyfin-android/blob/0d2457cf660f6ba2cd9c4013f7afdd044b357f0d/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt#L63