### PR TITLE
Emit issue information in RecommendedServerDiscovery

### DIFF
--- a/jellyfin-core/api/jellyfin-core.api
+++ b/jellyfin-core/api/jellyfin-core.api
@@ -112,18 +112,21 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerDiscovery {
 }
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerInfo {
-	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;)V
+	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
 	public final fun component3 ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
-	public final fun component4 ()Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
-	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lorg/jellyfin/sdk/model/api/PublicSystemInfo;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public final fun component4 ()Ljava/util/Collection;
+	public final fun component5-d1pmJ48 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Lkotlin/Result;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun firstIssueOrNull ()Lorg/jellyfin/sdk/discovery/RecommendedServerIssue;
 	public final fun getAddress ()Ljava/lang/String;
+	public final fun getIssues ()Ljava/util/Collection;
 	public final fun getResponseTime ()J
 	public final fun getScore ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
-	public final fun getSystemInfo ()Lorg/jellyfin/sdk/model/api/PublicSystemInfo;
+	public final fun getSystemInfo-d1pmJ48 ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -135,5 +138,68 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerInfoScore : java/
 	public static final field OK Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public static fun values ()[Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
+}
+
+public abstract interface class org/jellyfin/sdk/discovery/RecommendedServerIssue {
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$InvalidProductName : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$InvalidProductName;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$InvalidProductName;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$InvalidProductName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProductName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$MissingSystemInfo : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$MissingSystemInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$MissingSystemInfo;Ljava/lang/Throwable;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$MissingSystemInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$MissingVersion : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public static final field INSTANCE Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$MissingVersion;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public fun <init> (Lorg/jellyfin/sdk/model/ServerVersion;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public final fun copy (Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$SlowResponse : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$SlowResponse;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$SlowResponse;JILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$SlowResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResponseTime ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$UnsupportedServerVersion : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public fun <init> (Lorg/jellyfin/sdk/model/ServerVersion;)V
+	public final fun component1 ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public final fun copy (Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$UnsupportedServerVersion;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$UnsupportedServerVersion;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$UnsupportedServerVersion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfo.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfo.kt
@@ -6,5 +6,12 @@ public data class RecommendedServerInfo(
 	val address: String,
 	val responseTime: Long,
 	val score: RecommendedServerInfoScore,
-	val systemInfo: PublicSystemInfo?,
-)
+	val issues: Collection<RecommendedServerIssue>,
+	val systemInfo: Result<PublicSystemInfo>,
+) {
+	/**
+	 * The issues are ordered by importance. When showing a single issue to an end user you
+	 * normally want to show the first one.
+	 */
+	public fun firstIssueOrNull(): RecommendedServerIssue? = issues.firstOrNull()
+}

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerIssue.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerIssue.kt
@@ -1,0 +1,38 @@
+package org.jellyfin.sdk.discovery
+
+import org.jellyfin.sdk.model.ServerVersion
+
+public sealed interface RecommendedServerIssue {
+	/**
+	 * No system information found. This could happen due too networking issues or an invalid server address.
+	 */
+	public data class MissingSystemInfo(public val throwable: Throwable?) : RecommendedServerIssue
+
+	/**
+	 * The product name in the system information is incorrect.
+	 */
+	public data class InvalidProductName(public val productName: String?) : RecommendedServerIssue
+
+	/**
+	 * No version found in system information.
+	 */
+	public object MissingVersion : RecommendedServerIssue {
+		override fun toString(): String = this::class.simpleName!!
+	}
+
+	/**
+	 * The SDK does not support the server version.
+	 */
+	public data class UnsupportedServerVersion(public val version: ServerVersion) : RecommendedServerIssue
+
+	/**
+	 * The SDK uses a newer version of the API compared to the server. While this normally shouldn't be a problem, it
+	 * may potentially cause problems like crashes.
+	 */
+	public data class OutdatedServerVersion(public val version: ServerVersion) : RecommendedServerIssue
+
+	/**
+	 * The system information response was slow.
+	 */
+	public data class SlowResponse(public val responseTime: Long) : RecommendedServerIssue
+}

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
@@ -44,9 +44,15 @@ class Discover(
 				append(" (")
 				append("replied in ${it.responseTime}ms")
 				append(", ")
-				if (it.systemInfo == null) append("system information not found")
+				if (it.systemInfo.isFailure) append("system information not found")
 				else append("system information found")
 				append(")")
+				it.issues.forEach {
+					appendLine()
+					append("\t")
+					append(it)
+				}
+
 			}.let(::println)
 		}
 	}


### PR DESCRIPTION
This change adds more information to the output of RecommendedServerDiscovery that can help a user debug why they can't connect to their server. The scoring is still the same but now includes a list of issues, in case of `NoSystemInfo` the exception thrown when trying to GET the public server info is added. This one can be an ApiClientException or another Throwable.


Example output of the Kotlin CLI (command `discover https://demo.jellyfin.org/stable`, names of issues renamed after this output was added to the PR)
```
Starting discovery for https://demo.jellyfin.org/stable
Found 3 candidates
https://demo.jellyfin.org/stable: GREAT (replied in 707ms, system information found)
https://demo.jellyfin.org:8096/stable: BAD (replied in 5012ms, system information not found)
	NoSystemInfo(err=org.jellyfin.sdk.api.client.exception.TimeoutException: Request timeout has expired [url=https://demo.jellyfin.org:8096/stable/System/Info/Public, request_timeout=5000 ms])
	org.jellyfin.sdk.discovery.RecommendedServerIssue$NoVersion@4738a206
	SlowResponse(responseTime=5012)
https://demo.jellyfin.org:8920/stable: BAD (replied in 5005ms, system information not found)
	NoSystemInfo(err=org.jellyfin.sdk.api.client.exception.TimeoutException: Request timeout has expired [url=https://demo.jellyfin.org:8920/stable/System/Info/Public, request_timeout=5000 ms])
	org.jellyfin.sdk.discovery.RecommendedServerIssue$NoVersion@4738a206
	SlowResponse(responseTime=5005)
```