### PR TITLE
Fix authorization header encoding sometimes not working

### DIFF
--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder.kt
@@ -2,9 +2,17 @@ package org.jellyfin.sdk.api.client.util
 
 public object AuthorizationHeaderBuilder {
 	public const val AUTHORIZATION_SCHEME: String = "MediaBrowser"
-	private val ENCODING_REGEX = "[^\\w\\s]".toRegex()
 
-	public fun encodeParameterValue(raw: String): String = raw.replace(ENCODING_REGEX, "").trim()
+	public fun encodeParameterValue(raw: String): String = raw
+		// Trim whitespace
+		.trim()
+		// Only allow ASCII characters
+		.toByteArray(Charsets.US_ASCII)
+		.toString(Charsets.US_ASCII)
+		// Remove characters used for parsing
+		.replace('=', '?')
+		.replace(',', '?')
+		.replace('"', '?')
 
 	public fun buildParameter(key: String, value: String): String {
 		// Check for bad strings to prevent endless hours debugging why the server throws http 500 errors

--- a/jellyfin-api/src/test/kotlin/org/jellyfin/sdk/api/client/AuthorizationHeaderBuilderTests.kt
+++ b/jellyfin-api/src/test/kotlin/org/jellyfin/sdk/api/client/AuthorizationHeaderBuilderTests.kt
@@ -10,10 +10,11 @@ public class AuthorizationHeaderBuilderTests {
 	@Test
 	public fun `encodeParameter removes special characters`() {
 		assertEquals("test", encodeParameterValue("""test"""))
-		assertEquals("test", encodeParameterValue("""test+"""))
-		assertEquals("test", encodeParameterValue("""'test'"""))
-		assertEquals("", encodeParameterValue("""今日は"""))
-		assertEquals("", encodeParameterValue("""水母"""))
+		assertEquals("test+", encodeParameterValue("""test+"""))
+		assertEquals("'test'", encodeParameterValue("""'test'"""))
+		assertEquals("???", encodeParameterValue("""今日は"""))
+		assertEquals("??", encodeParameterValue("""水母"""))
+		assertEquals("??????", encodeParameterValue("""ἈᾼᾺΆᾍᾋ"""))
 	}
 
 	@Test


### PR DESCRIPTION
The regex probably adapted to the system language, allowing incorrect characters. This fixes the issue (tested by one of our users).

Replaces/fixes #295 