### PR TITLE
WebSocketApi fixes

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1069,16 +1069,16 @@ public final class org/jellyfin/sdk/api/operations/YearsApi {
 }
 
 public final class org/jellyfin/sdk/api/sockets/SocketSubscription {
-	public fun <init> (Lorg/jellyfin/sdk/api/sockets/WebSocketApi;Lkotlin/jvm/functions/Function1;)V
-	public final fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun <init> (Lorg/jellyfin/sdk/api/sockets/WebSocketApi;Lkotlin/jvm/functions/Function2;)V
+	public final fun cancel ()V
 }
 
 public final class org/jellyfin/sdk/api/sockets/WebSocketApi {
 	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
-	public final fun cancelSubscription (Lorg/jellyfin/sdk/api/sockets/SocketSubscription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun cancelSubscription (Lorg/jellyfin/sdk/api/sockets/SocketSubscription;)V
 	public final fun publish (Lorg/jellyfin/sdk/model/socket/OutgoingSocketMessage;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun reconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun subscribe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun subscribe (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reconnect ()V
+	public final fun subscribe ()Lkotlinx/coroutines/flow/Flow;
+	public final fun subscribe (Lkotlin/jvm/functions/Function2;)Lorg/jellyfin/sdk/api/sockets/SocketSubscription;
 }
 

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
@@ -7,7 +7,7 @@ import org.jellyfin.sdk.model.socket.IncomingSocketMessage
  */
 public class SocketSubscription(
 	private val webSocketApi: WebSocketApi,
-	internal val callback: (IncomingSocketMessage) -> Unit
+	internal val callback: suspend (IncomingSocketMessage) -> Unit
 ) {
 	/**
 	 * Cancel the subscription and stop listening for messages.

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
@@ -12,5 +12,5 @@ public class SocketSubscription(
 	/**
 	 * Cancel the subscription and stop listening for messages.
 	 */
-	public suspend fun cancel(): Unit = webSocketApi.cancelSubscription(this)
+	public fun cancel(): Unit = webSocketApi.cancelSubscription(this)
 }

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
@@ -7,7 +7,7 @@ import org.jellyfin.sdk.model.socket.IncomingSocketMessage
  */
 public class SocketSubscription(
 	private val webSocketApi: WebSocketApi,
-	internal val callback: suspend (IncomingSocketMessage) -> Unit
+	internal val callback: suspend (IncomingSocketMessage) -> Unit,
 ) {
 	/**
 	 * Cancel the subscription and stop listening for messages.

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/WebSocketApi.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/WebSocketApi.kt
@@ -264,7 +264,7 @@ public class WebSocketApi(
 	 * Start listening to messages. Calls the [block] for each incoming message until
 	 * [SocketSubscription.cancel] is invoked.
 	 */
-	public fun subscribe(block: (IncomingSocketMessage) -> Unit): SocketSubscription {
+	public fun subscribe(block: suspend (IncomingSocketMessage) -> Unit): SocketSubscription {
 		val subscription = SocketSubscription(this, block)
 		subscriptions += subscription
 		subscriptionsChanged()

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/socket/IncomingSocketMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/socket/IncomingSocketMessage.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.UseSerializers
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 import java.util.*
 
-public interface IncomingSocketMessage : SocketMessage {
+public sealed interface IncomingSocketMessage : SocketMessage {
 	/**
 	 * The id of the received message.
 	 *

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/socket/OutgoingSocketMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/socket/OutgoingSocketMessage.kt
@@ -1,4 +1,4 @@
 package org.jellyfin.sdk.model.socket
 
-public interface OutgoingSocketMessage : SocketMessage
+public sealed interface OutgoingSocketMessage : SocketMessage
 

--- a/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/socket/SocketMessage.kt
+++ b/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/socket/SocketMessage.kt
@@ -1,3 +1,3 @@
 package org.jellyfin.sdk.model.socket
 
-public interface SocketMessage
+public sealed interface SocketMessage


### PR DESCRIPTION
- Use sealed interfaces for SocketMessage models
- Remove asynchronous signature from WebSocketApi 
- Use httpClientOptions
