### PR TITLE
Replace slf4j with kotlin-logging

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "1.5.10"
+kotlinlogging = "2.0.10"
 kotlinx-coroutines = "1.5.0"
 kotlinx-serialization = "1.2.1"
 ktor = "1.6.0"
@@ -11,6 +12,7 @@ androidx-core = { module = "androidx.core:core-ktx", version = "1.5.0" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.2.0" }
 kasechange = { module = "net.pearx.kasechange:kasechange", version = "1.3.0" }
 koin = { module = "io.insert-koin:koin-core", version = "3.1.0" }
+kotlinlogging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlinlogging" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.8.0" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
@@ -18,6 +20,5 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-client-serialization-jvm", version.ref = "ktor" }
-slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 swaggerParser = { module = "io.swagger.parser.v3:swagger-parser", version = "2.0.26" }

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 	implementation(libs.ktor.serialization)
 
 	// Logging
-	implementation(libs.slf4j.api)
+	implementation(libs.kotlinlogging)
 	testImplementation(libs.slf4j.simple)
 
 	// Unit testing

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -12,6 +12,7 @@ import io.ktor.network.sockets.*
 import io.ktor.util.*
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import mu.KotlinLogging
 import org.jellyfin.sdk.api.client.exception.InvalidContentException
 import org.jellyfin.sdk.api.client.exception.InvalidStatusException
 import org.jellyfin.sdk.api.client.exception.TimeoutException
@@ -20,7 +21,6 @@ import org.jellyfin.sdk.api.client.util.PathBuilder
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.UUID
-import org.slf4j.LoggerFactory
 import java.net.UnknownHostException
 
 public open class KtorClient(
@@ -104,12 +104,14 @@ public open class KtorClient(
 		queryParameters: Map<String, Any?> = emptyMap(),
 		requestBody: Any? = null,
 	): Response<T> {
-		val logger = LoggerFactory.getLogger(this::class.java)
 		val url = createUrl(pathTemplate, pathParameters, queryParameters)
 
 		// Log HTTP call with access token removed
-		val safeUrl = accessToken?.let { url.replace(it, "******") } ?: url
-		logger.info("$method $safeUrl")
+		val logger = KotlinLogging.logger {}
+		logger.info {
+			val safeUrl = accessToken?.let { url.replace(it, "******") } ?: url
+			"$method $safeUrl"
+		}
 
 		@Suppress("SwallowedException", "TooGenericExceptionCaught")
 		try {

--- a/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/WebSocketApi.kt
+++ b/jellyfin-api/src/main/kotlin/org/jellyfin/sdk/api/sockets/WebSocketApi.kt
@@ -17,11 +17,13 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 import kotlinx.serialization.serializer
+import mu.KotlinLogging
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.api.SessionMessageType
 import org.jellyfin.sdk.model.api.SessionMessageType.*
 import org.jellyfin.sdk.model.socket.*
-import org.slf4j.LoggerFactory
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Provides realtime communication with the Jellyfin server.
@@ -84,8 +86,6 @@ public class WebSocketApi(
 		SCHEDULED_TASKS_INFO_STOP -> null
 	} ?: throw NotImplementedError("Messages of type $this should not be sent by the server.")
 
-	private val logger = LoggerFactory.getLogger("WebSocketApi")
-
 	private val client: HttpClient = HttpClient {
 		followRedirects = api.httpClientOptions.followRedirects
 
@@ -134,7 +134,7 @@ public class WebSocketApi(
 	private suspend fun SendChannel<Frame>.write() = outgoingMessageChannel
 		.receiveAsFlow()
 		.onEach { text ->
-			logger.info("Sending message {}", text)
+			logger.info { "Sending message $text" }
 			send(Frame.Text(text))
 		}
 		.catch { logger.error(it) }
@@ -200,7 +200,7 @@ public class WebSocketApi(
 
 		// Read text from frame
 		val text = readText()
-		logger.info("Received message {}", text)
+		logger.info { "Received message $text" }
 
 		// Read JSON object from text
 		val message = json.parseToJsonElement(text)

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 	api(libs.ktor.http)
 
 	// Logging
-	implementation(libs.slf4j.api)
+	implementation(libs.kotlinlogging)
 	testImplementation(libs.slf4j.simple)
 
 	// Testing

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -1,13 +1,15 @@
 package org.jellyfin.sdk.discovery
 
 import io.ktor.http.*
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Parses the given [input] and allows to fix common mistakes.
  */
 public class AddressCandidateHelper(
-	private val input: String
+	private val input: String,
 ) {
 	public companion object {
 		/**
@@ -33,11 +35,10 @@ public class AddressCandidateHelper(
 
 	private val candidates = mutableSetOf<Url>()
 	private val prioritizeComparator = Comparator<Url> { a, b -> b.score() - a.score() }
-	private val logger = LoggerFactory.getLogger("AddressCandidateHelper")
 
 	init {
 		try {
-			logger.debug("Input is $input")
+			logger.debug { "Input is $input" }
 
 			// Add the input as initial candidate
 			candidates.add(URLBuilder().apply {

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
@@ -5,14 +5,16 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import mu.KotlinLogging
 import org.jellyfin.sdk.model.api.ServerDiscoveryInfo
-import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.net.DatagramPacket
 import java.net.DatagramSocket
 import java.net.InetAddress
 import java.net.SocketTimeoutException
 import kotlin.coroutines.coroutineContext
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Used to discover Jellyfin servers in the local network.
@@ -32,7 +34,6 @@ public class LocalServerDiscovery(
 		public const val DISCOVERY_MAX_SERVERS: Int = 15
 	}
 
-	private val logger = LoggerFactory.getLogger("LocalServerDiscovery")
 	private val json = Json {
 		ignoreUnknownKeys = true
 	}
@@ -65,7 +66,7 @@ public class LocalServerDiscovery(
 
 			// Convert message to string
 			val message = String(packet.data, 0, packet.length)
-			logger.debug("""Received message "$message"""")
+			logger.debug { """Received message "$message"""" }
 
 			// Read as JSON
 			val info = json.decodeFromString(ServerDiscoveryInfo.serializer(), message)

--- a/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/main/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import mu.KotlinLogging
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.jellyfin.sdk.api.client.Response
@@ -15,8 +16,9 @@ import org.jellyfin.sdk.api.client.exception.TimeoutException
 import org.jellyfin.sdk.api.operations.SystemApi
 import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.api.PublicSystemInfo
-import org.slf4j.LoggerFactory
 import kotlin.system.measureTimeMillis
+
+private val logger = KotlinLogging.logger {}
 
 public class RecommendedServerDiscovery(
 	private val jellyfin: Jellyfin,
@@ -33,8 +35,6 @@ public class RecommendedServerDiscovery(
 		val systemInfo: Result<PublicSystemInfo>,
 		val responseTime: Long,
 	)
-
-	private val logger = LoggerFactory.getLogger("RecommendedServerDiscovery")
 
 	@Suppress("MagicNumber")
 	private fun assignScore(result: SystemInfoResult): RecommendedServerInfo {


### PR DESCRIPTION
Kotlin-logging still uses slf4j under the hood so nothing changes for our apps, just add sl4fj-simple as dependency to see the logs from the SDK like always.