### PR TITLE
Use dokkaHtml instead of dokkaJavadoc for published documentation 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ slf4j = "1.7.31"
 [plugins]
 binarycompatibilityvalidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.6.0" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.17.1" }
-dokka = { id = "org.jetbrains.dokka", version = "1.4.32" }
+dokka = { id = "org.jetbrains.dokka", version = "1.5.0" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 nexuspublish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.1.0" }
 

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -47,9 +47,9 @@ kotlin {
 }
 
 val javadocJar by tasks.creating(Jar::class) {
-	dependsOn(tasks.getByName("dokkaJavadoc"))
+	dependsOn(tasks.getByName("dokkaHtml"))
 	archiveClassifier.set("javadoc")
-	from("$buildDir/dokka/javadoc")
+	from("$buildDir/dokka/html")
 }
 
 publishing.publications.withType<MavenPublication> {

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -36,9 +36,9 @@ kotlin {
 }
 
 val javadocJar by tasks.creating(Jar::class) {
-	dependsOn(tasks.getByName("dokkaJavadoc"))
+	dependsOn(tasks.getByName("dokkaHtml"))
 	archiveClassifier.set("javadoc")
-	from("$buildDir/dokka/javadoc")
+	from("$buildDir/dokka/html")
 }
 
 publishing.publications.withType<MavenPublication> {


### PR DESCRIPTION
- Use dokkaHtml instead of dokkaJavadoc for published documentation 
  - Only for MPP projects - others still use javadoc!
  - This fixes an issue where dokkaJavadoc didn't work and provides multiplatform information in the documentation
- Update Dokka to 1.5.0

Requires #306 