### PR TITLE
Add verify function to openapi-generator

### DIFF
--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -57,3 +57,28 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Run apiCheck task
         run: ./gradlew --build-cache --no-daemon --info apiCheck
+
+  verify-openapi-sources:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Setup Gradle cache
+        uses: actions/cache@v2.1.6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run verifySources task
+        run: ./gradlew --build-cache --no-daemon --info verifySources
+

--- a/openapi-generator/README.md
+++ b/openapi-generator/README.md
@@ -17,6 +17,8 @@ The following Gradle tasks can be used to run the generator:
 
  - **generateSources**  
    Reads the openapi.json files and generates Kotlin source code.
+ - **verifySources**  
+   Reads the openapi.json files and verifies existing files.
  - **downloadApiSpecStable & downloadApiSpecUnstable**  
    Downloads the openapi.json file from repo.jellyfin.org.
  - **updateApiSpecStable & updateApiSpecUnstable**  

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
 	// Dependency Injection
 	implementation(libs.koin)
 
+	// Logging
+	implementation(libs.kotlin.logging)
+	runtimeOnly(libs.slf4j.simple)
+
 	// Testing
 	testImplementation(libs.kotlin.test.junit)
 }

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -32,22 +32,35 @@ dependencies {
 	testImplementation(libs.kotlin.test.junit)
 }
 
-val openApiFile = file("../openapi.json")
+val defaultConfig = mapOf(
+	"openApiFile" to file("../openapi.json"),
+	"apiOutputDir" to file("../jellyfin-api/src/main/kotlin-generated"),
+	"modelsOutputDir" to file("../jellyfin-model/src/main/kotlin-generated")
+)
+
 tasks.register("generateSources", JavaExec::class) {
 	mainClass.set(application.mainClass)
 	classpath = sourceSets.main.get().runtimeClasspath
 
-	args = mapOf(
-		"openApiFile" to openApiFile,
-		"apiOutputDir" to file("../jellyfin-api/src/main/kotlin-generated"),
-		"modelsOutputDir" to file("../jellyfin-model/src/main/kotlin-generated")
-	).map { listOf("--${it.key}", it.value.toString()) }.flatten()
+	args = defaultConfig
+		.map { listOf("--${it.key}", it.value.toString()) }
+		.flatten()
+}
+
+tasks.register("verifySources", JavaExec::class) {
+	mainClass.set(application.mainClass)
+	classpath = sourceSets.main.get().runtimeClasspath
+
+	args = defaultConfig
+		.plus("verify" to "true")
+		.map { listOf("--${it.key}", it.value.toString()) }
+		.flatten()
 }
 
 arrayOf("stable", "unstable").forEach { flavor ->
 	tasks.register("downloadApiSpec${flavor.capitalize()}", Download::class) {
 		src("https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-${flavor}.json")
-		dest(openApiFile)
+		dest(defaultConfig["openApiFile"])
 	}
 
 	tasks.register("updateApiSpec${flavor.capitalize()}") {

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Generator.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Generator.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.parser.OpenAPIV3Parser
 import io.swagger.v3.parser.core.models.SwaggerParseResult
+import mu.KotlinLogging
 import org.jellyfin.openapi.builder.api.ApiBuilder
 import org.jellyfin.openapi.builder.extra.FileSpecBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiApiServicesBuilder
@@ -13,6 +14,8 @@ import org.jellyfin.openapi.builder.openapi.OpenApiConstantsBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiModelBuilder
 import org.jellyfin.openapi.model.GeneratorResult
 import java.io.File
+
+private val logger = KotlinLogging.logger { }
 
 class Generator(
 	private val fileSpecBuilder: FileSpecBuilder,
@@ -23,7 +26,7 @@ class Generator(
 ) {
 	private fun parse(openApiJson: String): SwaggerParseResult {
 		val parseResult = OpenAPIV3Parser().readContents(openApiJson)
-		parseResult.messages.forEach { println(it) }
+		parseResult.messages.forEach { message -> logger.warn { message } }
 		return parseResult
 	}
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Generator.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Generator.kt
@@ -11,6 +11,7 @@ import org.jellyfin.openapi.builder.extra.FileSpecBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiApiServicesBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiConstantsBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiModelBuilder
+import org.jellyfin.openapi.model.GeneratorResult
 import java.io.File
 
 class Generator(
@@ -39,26 +40,50 @@ class Generator(
 	private fun createApiConstants(info: Info): FileSpec = openApiConstantsBuilder.build(info)
 		.let(fileSpecBuilder::build)
 
-	fun generate(
-		openApiJson: String,
-		apiOutputDir: File,
-		modelsOutputDir: File,
-	) {
+	private fun generateInternal(openApiJson: String): GeneratorResult {
 		val parseResult = parse(openApiJson)
 
 		// Get relevant OpenAPI parts
 		val schemas = parseResult.openAPI.components.schemas
 		val paths = parseResult.openAPI.paths
 
+		// Create models
+		val models = createModels(schemas)
+		// Create API operations
+		val apis = createApis(paths)
+		// Create API constants
+		val constants = createApiConstants(parseResult.openAPI.info)
+
+		return GeneratorResult(models, apis, constants)
+	}
+
+	fun verify(
+		openApiJson: String,
+		apiOutputDir: File,
+		modelsOutputDir: File,
+	): Boolean {
+		val verification = Verification(apiOutputDir, modelsOutputDir)
+		val result = generateInternal(openApiJson)
+
+		return verification.verify(result)
+	}
+
+	fun generate(
+		openApiJson: String,
+		apiOutputDir: File,
+		modelsOutputDir: File,
+	) {
+		val result = generateInternal(openApiJson)
+
 		// Clear output directories
 		modelsOutputDir.deleteRecursively()
 		apiOutputDir.deleteRecursively()
 
 		// Create models
-		createModels(schemas).forEach { file -> file.writeTo(modelsOutputDir) }
+		result.models.forEach { file -> file.writeTo(modelsOutputDir) }
 		// Create API operations
-		createApis(paths).forEach { file -> file.writeTo(apiOutputDir) }
+		result.apis.forEach { file -> file.writeTo(apiOutputDir) }
 		// Create API constants
-		createApiConstants(parseResult.openAPI.info).writeTo(apiOutputDir)
+		result.constants.writeTo(apiOutputDir)
 	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Main.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Main.kt
@@ -3,6 +3,7 @@ package org.jellyfin.openapi
 import org.jellyfin.openapi.hooks.hooksModule
 import org.koin.dsl.koinApplication
 import java.io.File
+import kotlin.system.exitProcess
 
 fun main(vararg args: String) {
 	// Read arguments
@@ -10,17 +11,30 @@ fun main(vararg args: String) {
 	val openApiFile by arguments
 	val apiOutputDir by arguments
 	val modelsOutputDir by arguments
+	val verify = arguments.containsKey("verify")
 
 	// Read OpenAPI json
 	val openApiJson = File(openApiFile).readText()
 
 	// Start Koin
 	val koin = koinApplication { modules(mainModule, hooksModule) }.koin
+	val generator = koin.get<Generator>()
 
-	// Generate OpenAPI output
-	koin.get<Generator>().generate(
-		openApiJson = openApiJson,
-		apiOutputDir = File(apiOutputDir),
-		modelsOutputDir = File(modelsOutputDir)
-	)
+	if (verify) {
+		// Verify OpenAPI output
+		val valid = generator.verify(
+			openApiJson = openApiJson,
+			apiOutputDir = File(apiOutputDir),
+			modelsOutputDir = File(modelsOutputDir)
+		)
+
+		if (!valid) exitProcess(1)
+	} else {
+		// Generate OpenAPI output
+		generator.generate(
+			openApiJson = openApiJson,
+			apiOutputDir = File(apiOutputDir),
+			modelsOutputDir = File(modelsOutputDir)
+		)
+	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Verification.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Verification.kt
@@ -1,0 +1,80 @@
+package org.jellyfin.openapi
+
+import com.squareup.kotlinpoet.FileSpec
+import org.jellyfin.openapi.model.GeneratorResult
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.security.MessageDigest
+import kotlin.io.path.Path
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readText
+import kotlin.io.path.relativeTo
+import kotlin.streams.asSequence
+
+class Verification(
+	apiOutputDir: File,
+	modelsOutputDir: File,
+) {
+	private val apiFiles by getFileTree(apiOutputDir)
+	private val modelFiles by getFileTree(modelsOutputDir)
+
+	private fun getFileTree(directory: File) = lazy {
+		assert(directory.exists() && directory.isDirectory)
+
+		val digest = MessageDigest.getInstance("MD5")
+		val path = directory.toPath()
+
+		Files
+			.walk(path)
+			.asSequence()
+			.filter { it.isRegularFile(LinkOption.NOFOLLOW_LINKS) }
+			.map {
+				val source = it
+					.readText()
+					.replace(System.lineSeparator(), "\n") // Kotlinpoet always uses \n
+					.toByteArray()
+				val hash = digest.digest(source)
+
+				it.relativeTo(path).toString() to hash
+			}
+			.toMap()
+	}
+
+	private fun getFileTree(fileSpecs: Collection<FileSpec>) = lazy {
+		val digest = MessageDigest.getInstance("MD5")
+
+		fileSpecs.map {
+			val obj = it.toJavaFileObject()
+			val hash = digest.digest(it.toString().toByteArray())
+
+			Path(obj.name).toString() to hash
+		}.toMap()
+	}
+
+	private fun compare(current: Map<String, ByteArray>, new: Map<String, ByteArray>): Boolean {
+		val removedKeys = current.keys subtract new.keys
+		val newKeys = new.keys subtract current.keys
+		val modifiedKeys = current.keys
+			.intersect(new.keys)
+			.filter { key -> !current[key].contentEquals(new[key]) }
+
+		removedKeys.forEach { key -> println("$key: removed from sources.") }
+		newKeys.forEach { key -> println("$key: added to sources.") }
+		modifiedKeys.forEach { key ->
+			println("$key: modified (${current[key].toMd5String()} -> ${new[key].toMd5String()}).")
+		}
+
+		return removedKeys.isEmpty() && newKeys.isEmpty() && modifiedKeys.isEmpty()
+	}
+
+	private fun ByteArray?.toMd5String(): String =
+		this?.joinToString(separator = "") { byte -> "%02x".format(byte) } ?: "null"
+
+	fun verify(result: GeneratorResult): Boolean {
+		val newModelFiles by getFileTree(result.models)
+		val newApiFiles by getFileTree(result.apis + result.constants)
+
+		return compare(modelFiles, newModelFiles) && compare(apiFiles, newApiFiles)
+	}
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Verification.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Verification.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.openapi
 
 import com.squareup.kotlinpoet.FileSpec
+import mu.KotlinLogging
 import org.jellyfin.openapi.model.GeneratorResult
 import java.io.File
 import java.nio.file.Files
@@ -11,6 +12,8 @@ import kotlin.io.path.isRegularFile
 import kotlin.io.path.readText
 import kotlin.io.path.relativeTo
 import kotlin.streams.asSequence
+
+private val logger = KotlinLogging.logger { }
 
 class Verification(
 	apiOutputDir: File,
@@ -59,10 +62,18 @@ class Verification(
 			.intersect(new.keys)
 			.filter { key -> !current[key].contentEquals(new[key]) }
 
-		removedKeys.forEach { key -> println("$key: removed from sources.") }
-		newKeys.forEach { key -> println("$key: added to sources.") }
+		removedKeys.forEach { key ->
+			logger.error { "$key: removed from sources." }
+		}
+
+		newKeys.forEach { key ->
+			logger.error { "$key: added to sources." }
+		}
+
 		modifiedKeys.forEach { key ->
-			println("$key: modified (${current[key].toMd5String()} -> ${new[key].toMd5String()}).")
+			logger.error {
+				"$key: modified (${current[key].toMd5String()} -> ${new[key].toMd5String()})."
+			}
 		}
 
 		return removedKeys.isEmpty() && newKeys.isEmpty() && modifiedKeys.isEmpty()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.models.Paths
 import io.swagger.v3.oas.models.media.IntegerSchema
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.parameters.Parameter
+import mu.KotlinLogging
 import net.pearx.kasechange.CaseFormat
 import net.pearx.kasechange.toCamelCase
 import org.jellyfin.openapi.OpenApiGeneratorError
@@ -20,6 +21,8 @@ import org.jellyfin.openapi.hooks.ApiTypePath
 import org.jellyfin.openapi.hooks.DefaultValueHook
 import org.jellyfin.openapi.hooks.ServiceNameHook
 import org.jellyfin.openapi.model.*
+
+private val logger = KotlinLogging.logger { }
 
 class OpenApiApiServicesBuilder(
 	private val apiNameBuilder: ApiNameBuilder,
@@ -95,10 +98,10 @@ class OpenApiApiServicesBuilder(
 
 			if (parameterSpec.`in` == "path") {
 				if (type.isNullable)
-					println("Path parameter $parameterName in $operationName is marked as nullable")
+					logger.warn { "Path parameter $parameterName in $operationName is marked as nullable" }
 
 				if (!path.contains("{${parameterName}}", ignoreCase = true))
-					println("Path parameter $parameterName in $operationName is missing in path $path")
+					logger.warn { "Path parameter $parameterName in $operationName is missing in path $path" }
 			}
 		}
 
@@ -107,7 +110,7 @@ class OpenApiApiServicesBuilder(
 			operation.responses["200"]
 		)
 		if (returnType == Types.NONE && "200" in operation.responses)
-			println("Missing return-type for operation $operationName (status-codes: ${operation.responses.keys})")
+			logger.warn { "Missing return-type for operation $operationName (status-codes: ${operation.responses.keys})" }
 
 		val requireAuthentication = operation.security
 			?.firstOrNull { requirement -> requirement.containsKey(Security.SECURITY_SCHEME) }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/GeneratorResult.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/GeneratorResult.kt
@@ -1,0 +1,9 @@
+package org.jellyfin.openapi.model
+
+import com.squareup.kotlinpoet.FileSpec
+
+data class GeneratorResult(
+	val models: List<FileSpec>,
+	val apis: List<FileSpec>,
+	val constants: FileSpec,
+)


### PR DESCRIPTION
This change adds a new CLI flag to the openapi-generator: "`--verify". When set the generator will not write any files but verify if the existing files are valid. This way we can be sure that a pull request updating lots of generated files is valid and doesn't contain malicious changes.

A new Gradle task is added to run the verify function "verifySources" which is executed as part of the sdk-test workflow.
Additionally, logging in the generator now uses kotlin-logging.

A few samples of possible output:

- File content is different
  ```
  [main] ERROR org.jellyfin.openapi.Verification - org\jellyfin\sdk\model\api\BaseItemDto.kt: modified (128c62b24360ed5a6202dd06f711a2f5 -> 84f916d01872e1f64451c132f096a399).
  ```

- File does not exist in repo - does in spec
  ```
  [main] ERROR org.jellyfin.openapi.Verification - org\jellyfin\sdk\model\api\BaseItemDto.kt: added to sources.
  ```

- File does not exist in spec - does in repo
  ```
  [main] ERROR org.jellyfin.openapi.Verification - org\jellyfin\sdk\model\api\NotBaseItemDto.kt: removed from sources.
  ```


Closes #209 