### PR TITLE
Move ApiClient HTTP methods to extension functions

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -147,20 +147,20 @@ public final class org/jellyfin/sdk/api/info/ApiConstants {
 }
 
 public final class org/jellyfin/sdk/api/operations/ActivityLogApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getLogEntries (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getLogEntries$default (Lorg/jellyfin/sdk/api/operations/ActivityLogApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/ApiKeyApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun createKey (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getKeys (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun revokeKey (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/ArtistsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getAlbumArtists (Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getAlbumArtists$default (Lorg/jellyfin/sdk/api/operations/ArtistsApi;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getArtistByName (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -170,7 +170,7 @@ public final class org/jellyfin/sdk/api/operations/ArtistsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/AudioApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getAudioStream (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getAudioStream$default (Lorg/jellyfin/sdk/api/operations/AudioApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getAudioStreamByContainer (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -182,14 +182,14 @@ public final class org/jellyfin/sdk/api/operations/AudioApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/BrandingApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getBrandingCss (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBrandingCss2 (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBrandingOptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/ChannelsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getAllChannelFeatures (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelFeatures (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelItems (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -201,7 +201,7 @@ public final class org/jellyfin/sdk/api/operations/ChannelsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/CollectionApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun addToCollection (Ljava/util/UUID;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun addToCollection$default (Lorg/jellyfin/sdk/api/operations/CollectionApi;Ljava/util/UUID;Ljava/util/Collection;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun createCollection (Ljava/lang/String;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -211,7 +211,7 @@ public final class org/jellyfin/sdk/api/operations/CollectionApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/ConfigurationApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getConfiguration (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getDefaultMetadataOptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getNamedConfiguration (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -223,7 +223,7 @@ public final class org/jellyfin/sdk/api/operations/ConfigurationApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/DashboardApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getConfigurationPages (Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getConfigurationPages$default (Lorg/jellyfin/sdk/api/operations/DashboardApi;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ConfigurationPageType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getDashboardConfigurationPage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -231,7 +231,7 @@ public final class org/jellyfin/sdk/api/operations/DashboardApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/DevicesApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun deleteDevice (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getDeviceInfo (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getDeviceOptions (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -241,7 +241,7 @@ public final class org/jellyfin/sdk/api/operations/DevicesApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/DisplayPreferencesApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getDisplayPreferences (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getDisplayPreferences$default (Lorg/jellyfin/sdk/api/operations/DisplayPreferencesApi;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun updateDisplayPreferences (Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/DisplayPreferencesDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -249,7 +249,7 @@ public final class org/jellyfin/sdk/api/operations/DisplayPreferencesApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/DlnaApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun createProfile (Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createProfile$default (Lorg/jellyfin/sdk/api/operations/DlnaApi;Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun deleteProfile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -261,7 +261,7 @@ public final class org/jellyfin/sdk/api/operations/DlnaApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/DlnaServerApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getConnectionManager (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getConnectionManager2 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getConnectionManager3 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -285,7 +285,7 @@ public final class org/jellyfin/sdk/api/operations/DlnaServerApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/DynamicHlsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getHlsAudioSegment (Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getHlsAudioSegment$default (Lorg/jellyfin/sdk/api/operations/DynamicHlsApi;Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getHlsAudioSegmentUrl (Ljava/util/UUID;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Z)Ljava/lang/String;
@@ -313,7 +313,7 @@ public final class org/jellyfin/sdk/api/operations/DynamicHlsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/EnvironmentApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getDefaultDirectoryBrowser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getDirectoryContents (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getDirectoryContents$default (Lorg/jellyfin/sdk/api/operations/EnvironmentApi;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -324,7 +324,7 @@ public final class org/jellyfin/sdk/api/operations/EnvironmentApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/FilterApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getQueryFilters (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getQueryFilters$default (Lorg/jellyfin/sdk/api/operations/FilterApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getQueryFiltersLegacy (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -332,7 +332,7 @@ public final class org/jellyfin/sdk/api/operations/FilterApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/GenresApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getGenre (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getGenre$default (Lorg/jellyfin/sdk/api/operations/GenresApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGenres (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -340,7 +340,7 @@ public final class org/jellyfin/sdk/api/operations/GenresApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/HlsSegmentApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getHlsAudioSegmentLegacyAac (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getHlsAudioSegmentLegacyAacUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
 	public static synthetic fun getHlsAudioSegmentLegacyAacUrl$default (Lorg/jellyfin/sdk/api/operations/HlsSegmentApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
@@ -357,7 +357,7 @@ public final class org/jellyfin/sdk/api/operations/HlsSegmentApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/ImageApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun deleteItemImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun deleteItemImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun deleteItemImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -432,7 +432,7 @@ public final class org/jellyfin/sdk/api/operations/ImageApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/ImageByNameApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getGeneralImage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGeneralImageUrl (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
 	public static synthetic fun getGeneralImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageByNameApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
@@ -448,7 +448,7 @@ public final class org/jellyfin/sdk/api/operations/ImageByNameApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/InstantMixApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getInstantMixFromAlbum (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getInstantMixFromAlbum$default (Lorg/jellyfin/sdk/api/operations/InstantMixApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getInstantMixFromArtists (Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -470,7 +470,7 @@ public final class org/jellyfin/sdk/api/operations/InstantMixApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/ItemLookupApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun applySearchCriteria (Ljava/util/UUID;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun applySearchCriteria$default (Lorg/jellyfin/sdk/api/operations/ItemLookupApi;Ljava/util/UUID;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/RemoteSearchResult;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getBookRemoteSearchResults (Lorg/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -486,13 +486,13 @@ public final class org/jellyfin/sdk/api/operations/ItemLookupApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/ItemRefreshApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun post (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun post$default (Lorg/jellyfin/sdk/api/operations/ItemRefreshApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/ItemUpdateApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getMetadataEditorInfo (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun updateItem (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/BaseItemDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun updateItemContentType (Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -500,7 +500,7 @@ public final class org/jellyfin/sdk/api/operations/ItemUpdateApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/ItemsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getItems (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Collection;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getItems$default (Lorg/jellyfin/sdk/api/operations/ItemsApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Collection;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;IIILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getItemsByUserId (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Collection;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -510,7 +510,7 @@ public final class org/jellyfin/sdk/api/operations/ItemsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/LibraryApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun deleteItem (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun deleteItems (Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun deleteItems$default (Lorg/jellyfin/sdk/api/operations/LibraryApi;Ljava/util/Collection;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -561,7 +561,7 @@ public final class org/jellyfin/sdk/api/operations/LibraryApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/LibraryStructureApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun addMediaPath (Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/MediaPathDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun addMediaPath$default (Lorg/jellyfin/sdk/api/operations/LibraryStructureApi;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/MediaPathDto;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun addVirtualFolder (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;Ljava/util/Collection;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/AddVirtualFolderDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -579,7 +579,7 @@ public final class org/jellyfin/sdk/api/operations/LibraryStructureApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/LiveTvApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun addListingProvider (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun addListingProvider$default (Lorg/jellyfin/sdk/api/operations/LiveTvApi;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/ListingsProviderInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun addTunerHost (Lorg/jellyfin/sdk/model/api/TunerHostInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -656,7 +656,7 @@ public final class org/jellyfin/sdk/api/operations/LiveTvApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/LocalizationApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getCountries (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCultures (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getLocalizationOptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -664,7 +664,7 @@ public final class org/jellyfin/sdk/api/operations/LocalizationApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/MediaInfoApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun closeLiveStream (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBitrateTestBytes (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getBitrateTestBytes$default (Lorg/jellyfin/sdk/api/operations/MediaInfoApi;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -681,13 +681,13 @@ public final class org/jellyfin/sdk/api/operations/MediaInfoApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/MoviesApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getMovieRecommendations (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getMovieRecommendations$default (Lorg/jellyfin/sdk/api/operations/MoviesApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/MusicGenresApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getMusicGenre (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getMusicGenre$default (Lorg/jellyfin/sdk/api/operations/MusicGenresApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getMusicGenres (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -695,7 +695,7 @@ public final class org/jellyfin/sdk/api/operations/MusicGenresApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/NotificationsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun createAdminNotification (Lorg/jellyfin/sdk/model/api/AdminNotificationDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getNotificationServices (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getNotificationTypes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -710,7 +710,7 @@ public final class org/jellyfin/sdk/api/operations/NotificationsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/PackageApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun cancelPackageInstallation (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPackageInfo (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getPackageInfo$default (Lorg/jellyfin/sdk/api/operations/PackageApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -722,7 +722,7 @@ public final class org/jellyfin/sdk/api/operations/PackageApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/PersonsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getPerson (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getPerson$default (Lorg/jellyfin/sdk/api/operations/PersonsApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getPersons (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/UUID;Ljava/util/UUID;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -730,7 +730,7 @@ public final class org/jellyfin/sdk/api/operations/PersonsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/PlayStateApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun markPlayedItem (Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun markPlayedItem$default (Lorg/jellyfin/sdk/api/operations/PlayStateApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/time/LocalDateTime;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun markUnplayedItem (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -751,7 +751,7 @@ public final class org/jellyfin/sdk/api/operations/PlayStateApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/PlaylistsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun addToPlaylist (Ljava/util/UUID;Ljava/util/Collection;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun addToPlaylist$default (Lorg/jellyfin/sdk/api/operations/PlaylistsApi;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun createPlaylist (Lorg/jellyfin/sdk/model/api/CreatePlaylistDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -766,7 +766,7 @@ public final class org/jellyfin/sdk/api/operations/PlaylistsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/PluginsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun disablePlugin (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun enablePlugin (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/Version;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPluginConfiguration (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -782,7 +782,7 @@ public final class org/jellyfin/sdk/api/operations/PluginsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/QuickConnectApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun activate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun authorize (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun available (Lorg/jellyfin/sdk/model/api/QuickConnectState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -794,7 +794,7 @@ public final class org/jellyfin/sdk/api/operations/QuickConnectApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/RemoteImageApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun downloadRemoteImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun downloadRemoteImage$default (Lorg/jellyfin/sdk/api/operations/RemoteImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getRemoteImageProviders (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -803,7 +803,7 @@ public final class org/jellyfin/sdk/api/operations/RemoteImageApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/ScheduledTasksApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getTask (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTasks (Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getTasks$default (Lorg/jellyfin/sdk/api/operations/ScheduledTasksApi;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -813,13 +813,13 @@ public final class org/jellyfin/sdk/api/operations/ScheduledTasksApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/SearchApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun get (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lorg/jellyfin/sdk/api/operations/SearchApi;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/SessionApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun addUserToSession (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun addUserToSession$default (Lorg/jellyfin/sdk/api/operations/SessionApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun displayContent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -847,7 +847,7 @@ public final class org/jellyfin/sdk/api/operations/SessionApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/StartupApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun completeWizard (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getFirstUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getFirstUser2 (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -859,7 +859,7 @@ public final class org/jellyfin/sdk/api/operations/StartupApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/StudiosApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getStudio (Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getStudio$default (Lorg/jellyfin/sdk/api/operations/StudiosApi;Ljava/lang/String;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getStudios (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -867,7 +867,7 @@ public final class org/jellyfin/sdk/api/operations/StudiosApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/SubtitleApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun deleteSubtitle (Ljava/util/UUID;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun downloadRemoteSubtitles (Ljava/util/UUID;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getFallbackFont (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -892,13 +892,13 @@ public final class org/jellyfin/sdk/api/operations/SubtitleApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/SuggestionsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getSuggestions (Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getSuggestions$default (Lorg/jellyfin/sdk/api/operations/SuggestionsApi;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/SyncPlayApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun syncPlayBuffering (Lorg/jellyfin/sdk/model/api/BufferRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun syncPlayCreateGroup (Lorg/jellyfin/sdk/model/api/NewGroupRequestDto;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun syncPlayGetGroups (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -923,7 +923,7 @@ public final class org/jellyfin/sdk/api/operations/SyncPlayApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/SystemApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getEndpointInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getLogFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPingSystem (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -937,18 +937,18 @@ public final class org/jellyfin/sdk/api/operations/SystemApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/TimeSyncApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getUtcTime (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/TrailersApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getTrailers (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Collection;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getTrailers$default (Lorg/jellyfin/sdk/api/operations/TrailersApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Double;Ljava/lang/Double;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Collection;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;IIILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/TvShowsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getEpisodes (Ljava/util/UUID;Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getEpisodes$default (Lorg/jellyfin/sdk/api/operations/TvShowsApi;Ljava/util/UUID;Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/Integer;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getNextUp (Ljava/util/UUID;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -960,7 +960,7 @@ public final class org/jellyfin/sdk/api/operations/TvShowsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/UniversalAudioApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getUniversalAudioStream (Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getUniversalAudioStream$default (Lorg/jellyfin/sdk/api/operations/UniversalAudioApi;Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getUniversalAudioStreamUrl (Ljava/util/UUID;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Z)Ljava/lang/String;
@@ -968,7 +968,7 @@ public final class org/jellyfin/sdk/api/operations/UniversalAudioApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/UserApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun authenticateUser (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun authenticateUser$default (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun authenticateUserByName (Lorg/jellyfin/sdk/model/api/AuthenticateUserByName;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -997,7 +997,7 @@ public final class org/jellyfin/sdk/api/operations/UserApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/UserLibraryApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun deleteUserItemRating (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun deleteUserItemRating$default (Lorg/jellyfin/sdk/api/operations/UserLibraryApi;Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getIntros (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1021,7 +1021,7 @@ public final class org/jellyfin/sdk/api/operations/UserLibraryApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/UserViewsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getGroupingOptions (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getGroupingOptions$default (Lorg/jellyfin/sdk/api/operations/UserViewsApi;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getUserViews (Ljava/util/UUID;Ljava/lang/Boolean;Ljava/util/Collection;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1029,14 +1029,14 @@ public final class org/jellyfin/sdk/api/operations/UserViewsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/VideoAttachmentsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getAttachment (Ljava/util/UUID;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getAttachmentUrl (Ljava/util/UUID;Ljava/lang/String;IZ)Ljava/lang/String;
 	public static synthetic fun getAttachmentUrl$default (Lorg/jellyfin/sdk/api/operations/VideoAttachmentsApi;Ljava/util/UUID;Ljava/lang/String;IZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jellyfin/sdk/api/operations/VideoHlsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getLiveHlsStream (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getLiveHlsStream$default (Lorg/jellyfin/sdk/api/operations/VideoHlsApi;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;IILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getLiveHlsStreamUrl (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jellyfin/sdk/model/api/EncodingContext;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Z)Ljava/lang/String;
@@ -1044,7 +1044,7 @@ public final class org/jellyfin/sdk/api/operations/VideoHlsApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/VideosApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun deleteAlternateSources (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getAdditionalPart (Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getAdditionalPart$default (Lorg/jellyfin/sdk/api/operations/VideosApi;Ljava/util/UUID;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -1061,7 +1061,7 @@ public final class org/jellyfin/sdk/api/operations/VideosApi {
 }
 
 public final class org/jellyfin/sdk/api/operations/YearsApi {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/KtorClient;)V
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun getYear (ILjava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getYear$default (Lorg/jellyfin/sdk/api/operations/YearsApi;ILjava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getYears (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Collection;Ljava/util/UUID;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Collection;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ActivityLogApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ActivityLogApi.kt
@@ -11,13 +11,14 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.DateTime
 import org.jellyfin.sdk.model.api.ActivityLogEntryQueryResult
 
 public class ActivityLogApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets activity log entries.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ApiKeyApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ApiKeyApi.kt
@@ -10,12 +10,15 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.AuthenticationInfoQueryResult
 
 public class ApiKeyApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Create a new api key.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ArtistsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ArtistsApi.kt
@@ -14,8 +14,9 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -24,7 +25,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemFilter
 
 public class ArtistsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets all album artists from a given item, folder, or the entire library.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
@@ -15,14 +15,15 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.EncodingContext
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 
 public class AudioApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets an audio stream.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/BrandingApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/BrandingApi.kt
@@ -8,12 +8,13 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.collections.emptyMap
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.api.BrandingOptions
 
 public class BrandingApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets branding css.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ChannelsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ChannelsApi.kt
@@ -14,8 +14,9 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.ChannelFeatures
@@ -24,7 +25,7 @@ import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.SortOrder
 
 public class ChannelsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get all channel features.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/CollectionApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/CollectionApi.kt
@@ -13,13 +13,15 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.CollectionCreationResult
 
 public class CollectionApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Adds items to a collection.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
@@ -12,14 +12,16 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.MediaEncoderPathDto
 import org.jellyfin.sdk.model.api.MetadataOptions
 import org.jellyfin.sdk.model.api.ServerConfiguration
 
 public class ConfigurationApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets application configuration.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DashboardApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DashboardApi.kt
@@ -11,13 +11,14 @@ import kotlin.String
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.api.ConfigurationPageInfo
 import org.jellyfin.sdk.model.api.ConfigurationPageType
 
 public class DashboardApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets the configuration pages.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
@@ -11,15 +11,18 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.DeviceInfo
 import org.jellyfin.sdk.model.api.DeviceInfoQueryResult
 import org.jellyfin.sdk.model.api.DeviceOptions
 
 public class DevicesApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Deletes a device.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DisplayPreferencesApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DisplayPreferencesApi.kt
@@ -9,14 +9,16 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.DisplayPreferencesDto
 
 public class DisplayPreferencesApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get Display Preferences.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaApi.kt
@@ -11,13 +11,16 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.DeviceProfileInfo
 
 public class DlnaApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Creates a profile.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaServerApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaServerApi.kt
@@ -11,11 +11,13 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 
 public class DlnaServerApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets Dlna media receiver registrar xml.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
@@ -15,14 +15,15 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.EncodingContext
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 
 public class DynamicHlsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets a video stream using HTTP live streaming.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/EnvironmentApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/EnvironmentApi.kt
@@ -13,14 +13,16 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.DefaultDirectoryBrowserInfoDto
 import org.jellyfin.sdk.model.api.FileSystemEntryInfo
 import org.jellyfin.sdk.model.api.ValidatePathDto
 
 public class EnvironmentApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get Default directory browser.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/FilterApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/FilterApi.kt
@@ -12,14 +12,15 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.QueryFilters
 import org.jellyfin.sdk.model.api.QueryFiltersLegacy
 
 public class FilterApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets query filters.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/GenresApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/GenresApi.kt
@@ -13,8 +13,9 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -22,7 +23,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 
 public class GenresApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets a genre, by name.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
@@ -12,11 +12,13 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
 
 public class HlsSegmentApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets the specified audio segment for an audio item.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
@@ -15,16 +15,19 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageInfo
 import org.jellyfin.sdk.model.api.ImageType
 
 public class ImageApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Delete an item's image.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageByNameApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageByNameApi.kt
@@ -12,12 +12,13 @@ import kotlin.String
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.api.ImageByNameInfo
 
 public class ImageByNameApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get General Image.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/InstantMixApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/InstantMixApi.kt
@@ -14,15 +14,16 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 
 public class InstantMixApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Creates an instant playlist based on a given album.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemLookupApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemLookupApi.kt
@@ -12,8 +12,10 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.AlbumInfoRemoteSearchQuery
 import org.jellyfin.sdk.model.api.ArtistInfoRemoteSearchQuery
@@ -28,7 +30,7 @@ import org.jellyfin.sdk.model.api.SeriesInfoRemoteSearchQuery
 import org.jellyfin.sdk.model.api.TrailerInfoRemoteSearchQuery
 
 public class ItemLookupApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Applies search criteria to an item and refreshes metadata.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemRefreshApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemRefreshApi.kt
@@ -10,13 +10,14 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.MetadataRefreshMode
 
 public class ItemRefreshApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Refreshes metadata for an item.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemUpdateApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemUpdateApi.kt
@@ -10,14 +10,16 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.MetadataEditorInfo
 
 public class ItemUpdateApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets metadata editor info for an item.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemsApi.kt
@@ -14,9 +14,10 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.DateTime
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -29,7 +30,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.VideoType
 
 public class ItemsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets items based on a query.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
@@ -17,8 +17,11 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.AllThemeMediaResult
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -30,7 +33,7 @@ import org.jellyfin.sdk.model.api.MediaUpdateInfoDto
 import org.jellyfin.sdk.model.api.ThemeMediaResult
 
 public class LibraryApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Deletes an item from the library and filesystem.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryStructureApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryStructureApi.kt
@@ -14,8 +14,11 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.AddVirtualFolderDto
 import org.jellyfin.sdk.model.api.CollectionTypeOptions
 import org.jellyfin.sdk.model.api.MediaPathDto
@@ -24,7 +27,7 @@ import org.jellyfin.sdk.model.api.UpdateMediaPathRequestDto
 import org.jellyfin.sdk.model.api.VirtualFolderInfo
 
 public class LibraryStructureApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Add a media path to a library.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
@@ -17,8 +17,11 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.DateTime
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -43,7 +46,7 @@ import org.jellyfin.sdk.model.api.TunerChannelMapping
 import org.jellyfin.sdk.model.api.TunerHostInfo
 
 public class LiveTvApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Adds a listings provider.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LocalizationApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LocalizationApi.kt
@@ -9,15 +9,16 @@ import kotlin.Any
 import kotlin.String
 import kotlin.collections.List
 import kotlin.collections.emptyMap
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.api.CountryInfo
 import org.jellyfin.sdk.model.api.CultureDto
 import org.jellyfin.sdk.model.api.LocalizationOption
 import org.jellyfin.sdk.model.api.ParentalRating
 
 public class LocalizationApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets known countries.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
@@ -15,9 +15,11 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.LiveStreamResponse
 import org.jellyfin.sdk.model.api.OpenLiveStreamDto
@@ -25,7 +27,7 @@ import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.api.PlaybackInfoResponse
 
 public class MediaInfoApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Closes a media source.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MoviesApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MoviesApi.kt
@@ -13,14 +13,15 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.RecommendationDto
 
 public class MoviesApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets movie recommendations.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MusicGenresApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MusicGenresApi.kt
@@ -14,8 +14,9 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -23,7 +24,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 
 public class MusicGenresApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets a music genre, by name.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/NotificationsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/NotificationsApi.kt
@@ -11,9 +11,11 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.AdminNotificationDto
 import org.jellyfin.sdk.model.api.NameIdPair
 import org.jellyfin.sdk.model.api.NotificationResultDto
@@ -21,7 +23,7 @@ import org.jellyfin.sdk.model.api.NotificationTypeInfo
 import org.jellyfin.sdk.model.api.NotificationsSummaryDto
 
 public class NotificationsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Sends a notification to all admins.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PackageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PackageApi.kt
@@ -11,14 +11,17 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.PackageInfo
 import org.jellyfin.sdk.model.api.RepositoryInfo
 
 public class PackageApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Cancels a package installation.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PersonsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PersonsApi.kt
@@ -13,8 +13,9 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -23,7 +24,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemFilter
 
 public class PersonsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get person by name.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlayStateApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlayStateApi.kt
@@ -13,9 +13,11 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.DateTime
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.PlayMethod
@@ -26,7 +28,7 @@ import org.jellyfin.sdk.model.api.RepeatMode
 import org.jellyfin.sdk.model.api.UserItemDataDto
 
 public class PlayStateApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Marks an item as played for user.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlaylistsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlaylistsApi.kt
@@ -15,9 +15,12 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.CreatePlaylistDto
@@ -26,7 +29,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.PlaylistCreationResult
 
 public class PlaylistsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Adds items to a playlist.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
@@ -14,8 +14,11 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BasePluginConfiguration
 import org.jellyfin.sdk.model.api.PluginInfo
@@ -23,7 +26,7 @@ import org.jellyfin.sdk.model.api.PluginSecurityInfo
 import org.jellyfin.sdk.model.api.Version
 
 public class PluginsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Disable a plugin.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/QuickConnectApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/QuickConnectApi.kt
@@ -12,13 +12,15 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.QuickConnectResult
 import org.jellyfin.sdk.model.api.QuickConnectState
 
 public class QuickConnectApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Temporarily activates quick connect for five minutes.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/RemoteImageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/RemoteImageApi.kt
@@ -13,15 +13,17 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.ImageProviderInfo
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.RemoteImageResult
 
 public class RemoteImageApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Downloads a remote image for an item.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ScheduledTasksApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ScheduledTasksApi.kt
@@ -12,13 +12,16 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.TaskInfo
 import org.jellyfin.sdk.model.api.TaskTriggerInfo
 
 public class ScheduledTasksApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get task by id.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SearchApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SearchApi.kt
@@ -13,13 +13,14 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.SearchHintResult
 
 public class SearchApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets the search hint result.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SessionApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SessionApi.kt
@@ -16,9 +16,12 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.ClientCapabilitiesDto
 import org.jellyfin.sdk.model.api.GeneralCommand
@@ -30,7 +33,7 @@ import org.jellyfin.sdk.model.api.PlaystateCommand
 import org.jellyfin.sdk.model.api.SessionInfo
 
 public class SessionApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Adds an additional user to a session.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/StartupApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/StartupApi.kt
@@ -9,14 +9,16 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.emptyMap
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.StartupConfigurationDto
 import org.jellyfin.sdk.model.api.StartupRemoteAccessDto
 import org.jellyfin.sdk.model.api.StartupUserDto
 
 public class StartupApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Completes the startup wizard.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/StudiosApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/StudiosApi.kt
@@ -13,8 +13,9 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -22,7 +23,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 
 public class StudiosApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets a studio by name.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
@@ -16,15 +16,18 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.FontFile
 import org.jellyfin.sdk.model.api.RemoteSubtitleInfo
 import org.jellyfin.sdk.model.api.UploadSubtitleDto
 
 public class SubtitleApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Deletes an external subtitle file.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SuggestionsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SuggestionsApi.kt
@@ -12,14 +12,15 @@ import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 
 public class SuggestionsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets suggestions.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SyncPlayApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SyncPlayApi.kt
@@ -10,8 +10,10 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.BufferRequestDto
 import org.jellyfin.sdk.model.api.GroupInfoDto
 import org.jellyfin.sdk.model.api.IgnoreWaitRequestDto
@@ -31,7 +33,7 @@ import org.jellyfin.sdk.model.api.SetRepeatModeRequestDto
 import org.jellyfin.sdk.model.api.SetShuffleModeRequestDto
 
 public class SyncPlayApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Notify SyncPlay group that member is buffering.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SystemApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SystemApi.kt
@@ -11,8 +11,10 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.api.EndPointInfo
 import org.jellyfin.sdk.model.api.LogFile
 import org.jellyfin.sdk.model.api.PublicSystemInfo
@@ -20,7 +22,7 @@ import org.jellyfin.sdk.model.api.SystemInfo
 import org.jellyfin.sdk.model.api.WakeOnLanInfo
 
 public class SystemApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets information about the request endpoint.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TimeSyncApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TimeSyncApi.kt
@@ -8,12 +8,13 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.collections.emptyMap
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.api.UtcTimeResponse
 
 public class TimeSyncApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets the current UTC time.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TrailersApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TrailersApi.kt
@@ -14,8 +14,9 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.DateTime
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -28,7 +29,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.VideoType
 
 public class TrailersApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Finds movies and trailers similar to a given trailer.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TvShowsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TvShowsApi.kt
@@ -13,15 +13,16 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 
 public class TvShowsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets episodes for a tv season.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
@@ -14,12 +14,13 @@ import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 
 public class UniversalAudioApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets an audio stream.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserApi.kt
@@ -12,9 +12,12 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.AuthenticateUserByName
 import org.jellyfin.sdk.model.api.AuthenticationResult
@@ -31,7 +34,7 @@ import org.jellyfin.sdk.model.api.UserDto
 import org.jellyfin.sdk.model.api.UserPolicy
 
 public class UserApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Authenticates a user.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserLibraryApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserLibraryApi.kt
@@ -14,9 +14,12 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -25,7 +28,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.UserItemDataDto
 
 public class UserLibraryApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Deletes a user's saved personal rating for an item.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserViewsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserViewsApi.kt
@@ -13,15 +13,16 @@ import kotlin.collections.List
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.SpecialViewOptionDto
 
 public class UserViewsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get user view grouping options.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
@@ -12,12 +12,13 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 
 public class VideoAttachmentsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Get video attachment.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoHlsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoHlsApi.kt
@@ -15,14 +15,15 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.EncodingContext
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 
 public class VideoHlsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets a hls live stream.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
@@ -18,15 +18,18 @@ import kotlin.collections.Map
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
+import org.jellyfin.sdk.api.client.extensions.delete
+import org.jellyfin.sdk.api.client.extensions.post
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
 import org.jellyfin.sdk.model.api.EncodingContext
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 
 public class VideosApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Removes alternate video sources.

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/YearsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/YearsApi.kt
@@ -13,8 +13,9 @@ import kotlin.collections.Collection
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
 import kotlin.collections.mutableMapOf
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
+import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemDtoQueryResult
@@ -23,7 +24,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.SortOrder
 
 public class YearsApi(
-	private val api: KtorClient
+	private val api: ApiClient
 ) {
 	/**
 	 * Gets a year.

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -22,30 +22,8 @@ public expect open class KtorClient(
 	 */
 	public val client: HttpClient
 
-	@Suppress("ThrowsCount")
 	public suspend inline fun <reified T> request(
 		method: HttpMethod = HttpMethod.Get,
-		pathTemplate: String,
-		pathParameters: Map<String, Any?> = emptyMap(),
-		queryParameters: Map<String, Any?> = emptyMap(),
-		requestBody: Any? = null,
-	): Response<T>
-
-	public suspend inline fun <reified T> get(
-		pathTemplate: String,
-		pathParameters: Map<String, Any?> = emptyMap(),
-		queryParameters: Map<String, Any?> = emptyMap(),
-		requestBody: Any? = null,
-	): Response<T>
-
-	public suspend inline fun <reified T> post(
-		pathTemplate: String,
-		pathParameters: Map<String, Any?> = emptyMap(),
-		queryParameters: Map<String, Any?> = emptyMap(),
-		requestBody: Any? = null,
-	): Response<T>
-
-	public suspend inline fun <reified T> delete(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.sdk.api.client.extensions
+
+import io.ktor.http.*
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.Response
+
+public suspend inline fun <reified T> ApiClient.get(
+	pathTemplate: String,
+	pathParameters: Map<String, Any?> = emptyMap(),
+	queryParameters: Map<String, Any?> = emptyMap(),
+	requestBody: Any? = null,
+): Response<T> = (this as KtorClient).request(
+	method = HttpMethod.Get,
+	pathTemplate = pathTemplate,
+	pathParameters = pathParameters,
+	queryParameters = queryParameters,
+	requestBody = requestBody
+)
+
+public suspend inline fun <reified T> ApiClient.post(
+	pathTemplate: String,
+	pathParameters: Map<String, Any?> = emptyMap(),
+	queryParameters: Map<String, Any?> = emptyMap(),
+	requestBody: Any? = null,
+): Response<T> = (this as KtorClient).request(
+	method = HttpMethod.Post,
+	pathTemplate = pathTemplate,
+	pathParameters = pathParameters,
+	queryParameters = queryParameters,
+	requestBody = requestBody
+)
+
+public suspend inline fun <reified T> ApiClient.delete(
+	pathTemplate: String,
+	pathParameters: Map<String, Any?> = emptyMap(),
+	queryParameters: Map<String, Any?> = emptyMap(),
+	requestBody: Any? = null,
+): Response<T> = (this as KtorClient).request(
+	method = HttpMethod.Delete,
+	pathTemplate = pathTemplate,
+	pathParameters = pathParameters,
+	queryParameters = queryParameters,
+	requestBody = requestBody
+)

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -162,43 +162,4 @@ public actual open class KtorClient actual constructor(
 			throw err
 		}
 	}
-
-	public actual suspend inline fun <reified T> get(
-		pathTemplate: String,
-		pathParameters: Map<String, Any?>,
-		queryParameters: Map<String, Any?>,
-		requestBody: Any?,
-	): Response<T> = request(
-		method = HttpMethod.Get,
-		pathTemplate = pathTemplate,
-		pathParameters = pathParameters,
-		queryParameters = queryParameters,
-		requestBody = requestBody
-	)
-
-	public actual suspend inline fun <reified T> post(
-		pathTemplate: String,
-		pathParameters: Map<String, Any?>,
-		queryParameters: Map<String, Any?>,
-		requestBody: Any?,
-	): Response<T> = request(
-		method = HttpMethod.Post,
-		pathTemplate = pathTemplate,
-		pathParameters = pathParameters,
-		queryParameters = queryParameters,
-		requestBody = requestBody
-	)
-
-	public actual suspend inline fun <reified T> delete(
-		pathTemplate: String,
-		pathParameters: Map<String, Any?>,
-		queryParameters: Map<String, Any?>,
-		requestBody: Any?,
-	): Response<T> = request(
-		method = HttpMethod.Delete,
-		pathTemplate = pathTemplate,
-		pathParameters = pathParameters,
-		queryParameters = queryParameters,
-		requestBody = requestBody
-	)
 }

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.sdk
 
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.info.ApiConstants
@@ -48,7 +49,7 @@ public class Jellyfin(
 		clientInfo: ClientInfo? = options.clientInfo,
 		deviceInfo: DeviceInfo? = options.deviceInfo,
 		httpClientOptions: HttpClientOptions = HttpClientOptions(),
-	): KtorClient {
+	): ApiClient {
 		checkNotNull(clientInfo) {
 			"ClientInfo needs to be set when calling createApi() or by providing it when constructing the Jellyfin instance"
 		}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -120,9 +120,9 @@ open class OperationBuilder(
 
 		// Call API
 		addStatement(
-			"val response = %L.%N<%T>(%S, pathParameters, queryParameters, data)",
+			"val response = %L.%M<%T>(%S, pathParameters, queryParameters, data)",
 			Strings.API_CLIENT_PARAMETER_NAME,
-			data.method.toString().lowercase(),
+			MemberName(Packages.API_METHODS, data.method.toString().lowercase(), true),
 			data.returnType,
 			data.pathTemplate
 		)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Classes.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Classes.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.openapi.constants
 
 object Classes {
-	const val API_CLIENT = "KtorClient"
+	const val API_CLIENT = "ApiClient"
 	const val API_RESPONSE = "Response"
 
 	object Serializers {

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Packages.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Packages.kt
@@ -22,6 +22,11 @@ object Packages {
 	const val API_EXCEPTION = "org.jellyfin.sdk.api.client.exception"
 
 	/**
+	 * Package for the API method extension functions
+	 */
+	const val API_METHODS = "org.jellyfin.sdk.api.client.extensions"
+
+	/**
 	 * Package for the generated models
 	 */
 	const val MODEL = "org.jellyfin.sdk.model.api"

--- a/samples/java-cli/src/main/java/org/jellyfin/sample/cli/Main.java
+++ b/samples/java-cli/src/main/java/org/jellyfin/sample/cli/Main.java
@@ -2,7 +2,7 @@ package org.jellyfin.sample.cli;
 
 import org.jellyfin.sdk.Jellyfin;
 import org.jellyfin.sdk.JellyfinOptions;
-import org.jellyfin.sdk.api.client.KtorClient;
+import org.jellyfin.sdk.api.client.ApiClient;
 import org.jellyfin.sdk.api.client.compatibility.JavaDataCallback;
 import org.jellyfin.sdk.api.operations.UserApi;
 import org.jellyfin.sdk.model.ClientInfo;
@@ -24,7 +24,7 @@ public class Main {
 
         // TODO Replace below with a proper CLI that compares to the kotlin-cli sample
         Logger logger = LoggerFactory.getLogger(Main.class);
-        KtorClient client = jellyfin.createApi("https://demo.jellyfin.org/stable/");
+        ApiClient client = jellyfin.createApi("https://demo.jellyfin.org/stable/");
 
         CountDownLatch latch = new CountDownLatch(1);
         UserApi userApi = new UserApi(client);


### PR DESCRIPTION
This PR moves the get, post and delete functions from the KtorClient to extension functions on ApiClient (although casted to KtorClient right now..). This is the initial change needed to fix #207 and most code is not dependent on the KtorClient implementation anymore. The ApiClient interface is now used as much as possible.

Part of #207