### PR TITLE
Update dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-kotlin = "1.5.20"
+kotlin = "1.5.30"
 kotlin-logging = "2.0.10"
-kotlinx-coroutines = "1.5.0"
-kotlinx-serialization = "1.2.1"
-ktor = "1.6.0"
-slf4j = "1.7.31"
+kotlinx-coroutines = "1.5.1"
+kotlinx-serialization = "1.2.2"
+ktor = "1.6.3"
+slf4j = "1.7.32"
 
 [plugins]
 binarycompatibilityvalidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.6.0" }
@@ -14,16 +14,16 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 nexuspublish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.1.0" }
 
 [libraries]
-android-gradle = { module = "com.android.tools.build:gradle", version = "7.0.0" }
+android-gradle = { module = "com.android.tools.build:gradle", version = "7.0.1" }
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.2.0" }
-androidx-core = { module = "androidx.core:core-ktx", version = "1.5.0" }
+androidx-core = { module = "androidx.core:core-ktx", version = "1.6.0" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.2.0" }
 kasechange = { module = "net.pearx.kasechange:kasechange", version = "1.3.0" }
-koin = { module = "io.insert-koin:koin-core", version = "3.1.0" }
+koin = { module = "io.insert-koin:koin-core", version = "3.1.2" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-kotlinpoet = { module = "com.squareup:kotlinpoet", version = "1.8.0" }
+kotlinpoet = { module = "com.squareup:kotlinpoet", version = "1.9.0" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -31,4 +31,4 @@ ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
-swaggerParser = { module = "io.swagger.parser.v3:swagger-parser", version = "2.0.26" }
+swaggerParser = { module = "io.swagger.parser.v3:swagger-parser", version = "2.0.27" }

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -57,6 +57,7 @@ public actual open class KtorClient actual constructor(
 		}
 	}
 
+	@OptIn(InternalAPI::class) // Required for Ktor URLBuilder
 	override fun createUrl(
 		pathTemplate: String,
 		pathParameters: Map<String, Any?>,


### PR DESCRIPTION
- KotlinPoet update required for #314 
- Kotlin update requires the `@OptIn` in KtorClient now - Ktor marks a lot of their code as internal but exposes it and even uses it in their documentation. The current warning is about the `parameters.append` calls.