### PR TITLE
Add ApiClientFactory option to allow different http clients

### DIFF
--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -2,22 +2,29 @@ package org.jellyfin.sdk
 
 import android.content.Context
 import org.jellyfin.sdk.android.androidDevice
+import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.util.ApiClientFactory
 
 public actual data class JellyfinOptions(
 	public val context: Context,
 	public actual val clientInfo: ClientInfo?,
 	public actual val deviceInfo: DeviceInfo?,
+	public actual val apiClientFactory: ApiClientFactory,
 ) {
 	public actual class Builder {
 		public var context: Context? = null
 		public var clientInfo: ClientInfo? = null
+		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
-			requireNotNull(context) { "An Android context is required when using the jellyfin-android platform." },
-			clientInfo,
+			context = requireNotNull(context) {
+				"An Android context is required when using the jellyfin-android platform."
+			},
+			clientInfo = clientInfo,
 			deviceInfo = androidDevice(context!!),
+			apiClientFactory = apiClientFactory,
 		)
 	}
 

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -2,7 +2,6 @@ package org.jellyfin.sdk
 
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.HttpClientOptions
-import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.info.ApiConstants
 import org.jellyfin.sdk.discovery.DiscoveryService
 import org.jellyfin.sdk.model.ClientInfo
@@ -57,7 +56,7 @@ public class Jellyfin(
 			"DeviceInfo needs to be set when calling createApi() or by providing it when constructing the Jellyfin instance"
 		}
 
-		return KtorClient(
+		return options.apiClientFactory.create(
 			baseUrl = baseUrl,
 			accessToken = accessToken,
 			userId = userId,

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -2,10 +2,12 @@ package org.jellyfin.sdk
 
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.util.ApiClientFactory
 
 public expect class JellyfinOptions {
 	public val clientInfo: ClientInfo?
 	public val deviceInfo: DeviceInfo?
+	public val apiClientFactory: ApiClientFactory
 
 	@Suppress("EmptyDefaultConstructor")
 	public class Builder() {

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/util/ApiClientFactory.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/util/ApiClientFactory.kt
@@ -1,0 +1,19 @@
+package org.jellyfin.sdk.util
+
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.UUID
+
+public fun interface ApiClientFactory {
+	@Suppress("LongParameterList")
+	public fun create(
+		baseUrl: String?,
+		accessToken: String?,
+		userId: UUID?,
+		clientInfo: ClientInfo,
+		deviceInfo: DeviceInfo,
+		httpClientOptions: HttpClientOptions,
+	): ApiClient
+}

--- a/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -1,19 +1,24 @@
 package org.jellyfin.sdk
 
+import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.util.ApiClientFactory
 
 public actual data class JellyfinOptions(
 	public actual val clientInfo: ClientInfo?,
 	public actual val deviceInfo: DeviceInfo?,
+	public actual val apiClientFactory: ApiClientFactory,
 ) {
 	public actual class Builder {
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
+		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
-			clientInfo,
-			deviceInfo,
+			clientInfo = clientInfo,
+			deviceInfo = deviceInfo,
+			apiClientFactory = apiClientFactory,
 		)
 	}
 


### PR DESCRIPTION
Add a new option to change the to-be-used ApiClient implementation. This isn't that useful right now as the HTTP method extension functions (get,post,delete) cast the interface to KtorClient. This is something I hope to fix in an upcoming PR.

Part of #207 