### PR TITLE
Use Java 17 as default and move to Adoptium distribution

### DIFF
--- a/.github/workflows/sdk-lint.yaml
+++ b/.github/workflows/sdk-lint.yaml
@@ -16,8 +16,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 11
+          distribution: temurin
+          java-version: 17
           cache: gradle
       - name: Run detekt and lint tasks
         run: ./gradlew --build-cache --no-daemon --info detekt lint

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -19,8 +19,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 11
+          distribution: temurin
+          java-version: 17
       - name: Set JELLYFIN_VERSION
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 16]
+        java: [11, 17]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: ${{ matrix.java }}
           cache: gradle
       - name: Run test task
@@ -35,8 +35,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 11
+          distribution: temurin
+          java-version: 17
           cache: gradle
       - name: Run apiCheck task
         run: ./gradlew --build-cache --no-daemon --info apiCheck
@@ -51,8 +51,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 11
+          distribution: temurin
+          java-version: 17
           cache: gradle
       - name: Run verifySources task
         run: ./gradlew --build-cache --no-daemon --info verifySources

--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 11
+          distribution: temurin
+          java-version: 17
           cache: gradle
       - name: Run updateApiSpecUnstable and apiDump tasks
         run: ./gradlew --build-cache --no-daemon --info updateApiSpecUnstable apiDump

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -15,8 +15,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 11
+          distribution: temurin
+          java-version: 17
           cache: gradle
       - name: Set STABLE_API_VERSION
         run: |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.incremental=true
 kotlin.mpp.stability.nowarn=true
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
- The AdoptOpenJDK project stopped and migrating to Adoptium is recommended: 
   https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
- Matrix builds (tests) now use Java 11 and 17 instead of 11 and 16.