### PR TITLE
Separate content (de)serialization from ApiClient

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,5 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
-ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 swaggerParser = { module = "io.swagger.parser.v3:swagger-parser", version = "2.0.27" }

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -8,6 +8,7 @@ public abstract interface class org/jellyfin/sdk/api/client/ApiClient {
 	public abstract fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public abstract fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
 	public abstract fun getUserId ()Ljava/util/UUID;
+	public abstract fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setAccessToken (Ljava/lang/String;)V
 	public abstract fun setBaseUrl (Ljava/lang/String;)V
 	public abstract fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
@@ -22,6 +23,7 @@ public final class org/jellyfin/sdk/api/client/ApiClient$Companion {
 public final class org/jellyfin/sdk/api/client/ApiClient$DefaultImpls {
 	public static fun createUrl (Lorg/jellyfin/sdk/api/client/ApiClient;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Z)Ljava/lang/String;
 	public static synthetic fun createUrl$default (Lorg/jellyfin/sdk/api/client/ApiClient;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun request$default (Lorg/jellyfin/sdk/api/client/ApiClient;Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/client/HttpClientOptions {
@@ -43,22 +45,37 @@ public final class org/jellyfin/sdk/api/client/HttpClientOptions {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/jellyfin/sdk/api/client/HttpMethod : java/lang/Enum {
+	public static final field DELETE Lorg/jellyfin/sdk/api/client/HttpMethod;
+	public static final field GET Lorg/jellyfin/sdk/api/client/HttpMethod;
+	public static final field POST Lorg/jellyfin/sdk/api/client/HttpMethod;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/HttpMethod;
+	public static fun values ()[Lorg/jellyfin/sdk/api/client/HttpMethod;
+}
+
 public class org/jellyfin/sdk/api/client/KtorClient : org/jellyfin/sdk/api/client/ApiClient {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun createUrl (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Z)Ljava/lang/String;
 	public fun getAccessToken ()Ljava/lang/String;
 	public fun getBaseUrl ()Ljava/lang/String;
-	public final fun getClient ()Lio/ktor/client/HttpClient;
 	public fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
 	public fun getUserId ()Ljava/util/UUID;
+	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun setAccessToken (Ljava/lang/String;)V
 	public fun setBaseUrl (Ljava/lang/String;)V
 	public fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
 	public fun setUserId (Ljava/util/UUID;)V
+}
+
+public final class org/jellyfin/sdk/api/client/RawResponse {
+	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;ILjava/util/Map;)V
+	public final fun getBody ()Lio/ktor/utils/io/ByteReadChannel;
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getStatus ()I
 }
 
 public final class org/jellyfin/sdk/api/client/Response {
@@ -119,6 +136,13 @@ public final class org/jellyfin/sdk/api/client/extensions/MediaInfoApiExtensions
 
 public final class org/jellyfin/sdk/api/client/extensions/UserApiExtensionsKt {
 	public static final fun authenticateUserByName (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jellyfin/sdk/api/client/util/ApiSerializer {
+	public static final field INSTANCE Lorg/jellyfin/sdk/api/client/util/ApiSerializer;
+	public final fun encodeRequestBody (Ljava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun encodeRequestBody$default (Lorg/jellyfin/sdk/api/client/util/ApiSerializer;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
 }
 
 public final class org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder {

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -21,8 +21,8 @@ kotlin {
 				implementation(projects.jellyfinModel)
 
 				implementation(libs.kotlinx.coroutines)
+				implementation(libs.kotlinx.serialization.json)
 				implementation(libs.ktor.core)
-				implementation(libs.ktor.serialization)
 
 				implementation(libs.kotlin.logging)
 			}

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
@@ -67,4 +67,12 @@ public interface ApiClient {
 			else this
 		}
 	)
+
+	public suspend fun request(
+		method: HttpMethod = HttpMethod.GET,
+		pathTemplate: String,
+		pathParameters: Map<String, Any?> = emptyMap(),
+		queryParameters: Map<String, Any?> = emptyMap(),
+		requestBody: Any? = null,
+	): RawResponse
 }

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/HttpMethod.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/HttpMethod.kt
@@ -1,0 +1,7 @@
+package org.jellyfin.sdk.api.client
+
+public enum class HttpMethod {
+	GET,
+	POST,
+	DELETE,
+}

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -1,9 +1,5 @@
 package org.jellyfin.sdk.api.client
 
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.UUID
@@ -16,17 +12,11 @@ public expect open class KtorClient(
 	deviceInfo: DeviceInfo,
 	httpClientOptions: HttpClientOptions,
 ) : ApiClient {
-	/**
-	 * Internal HTTP client. Should not be used directly. Use [request] instead.
-	 * Exposed publicly to allow inline functions to work.
-	 */
-	public val client: HttpClient
-
-	public suspend inline fun <reified T> request(
-		method: HttpMethod = HttpMethod.Get,
+	public override suspend fun request(
+		method: HttpMethod,
 		pathTemplate: String,
-		pathParameters: Map<String, Any?> = emptyMap(),
-		queryParameters: Map<String, Any?> = emptyMap(),
-		requestBody: Any? = null,
-	): Response<T>
+		pathParameters: Map<String, Any?>,
+		queryParameters: Map<String, Any?>,
+		requestBody: Any?,
+	): RawResponse
 }

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
@@ -1,0 +1,15 @@
+package org.jellyfin.sdk.api.client
+
+import io.ktor.utils.io.*
+import org.jellyfin.sdk.api.client.util.ApiSerializer
+
+public class RawResponse(
+	public val body: ByteReadChannel,
+	public val status: Int,
+	public val headers: Map<String, List<String>>,
+) {
+	public suspend inline fun <reified T : Any> createContent(): T = ApiSerializer.decodeResponseBody(body)
+
+	public suspend inline fun <reified T : Any> createResponse(): Response<T> =
+		Response(createContent(), status, headers)
+}

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/Response.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/Response.kt
@@ -1,18 +1,15 @@
 package org.jellyfin.sdk.api.client
 
-import io.ktor.http.*
 import kotlin.jvm.JvmSynthetic
 import kotlin.reflect.KProperty
 
 /**
  * Response from a HTTP class in the [ApiClient].
- *
- * @param status - See [HttpStatusCode]
  */
 public class Response<T>(
 	public val content: T,
 	public val status: Int,
-	public val headers: Map<String, List<String>>
+	public val headers: Map<String, List<String>>,
 ) {
 	/**
 	 * Get the response content using property delegation.

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
@@ -1,45 +1,44 @@
 package org.jellyfin.sdk.api.client.extensions
 
-import io.ktor.http.*
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.client.HttpMethod
 import org.jellyfin.sdk.api.client.Response
 
-public suspend inline fun <reified T> ApiClient.get(
+public suspend inline fun <reified T : Any> ApiClient.get(
 	pathTemplate: String,
 	pathParameters: Map<String, Any?> = emptyMap(),
 	queryParameters: Map<String, Any?> = emptyMap(),
 	requestBody: Any? = null,
-): Response<T> = (this as KtorClient).request(
-	method = HttpMethod.Get,
+): Response<T> = request(
+	method = HttpMethod.GET,
 	pathTemplate = pathTemplate,
 	pathParameters = pathParameters,
 	queryParameters = queryParameters,
 	requestBody = requestBody
-)
+).createResponse()
 
-public suspend inline fun <reified T> ApiClient.post(
+public suspend inline fun <reified T : Any> ApiClient.post(
 	pathTemplate: String,
 	pathParameters: Map<String, Any?> = emptyMap(),
 	queryParameters: Map<String, Any?> = emptyMap(),
 	requestBody: Any? = null,
-): Response<T> = (this as KtorClient).request(
-	method = HttpMethod.Post,
+): Response<T> = request(
+	method = HttpMethod.POST,
 	pathTemplate = pathTemplate,
 	pathParameters = pathParameters,
 	queryParameters = queryParameters,
 	requestBody = requestBody
-)
+).createResponse()
 
-public suspend inline fun <reified T> ApiClient.delete(
+public suspend inline fun <reified T : Any> ApiClient.delete(
 	pathTemplate: String,
 	pathParameters: Map<String, Any?> = emptyMap(),
 	queryParameters: Map<String, Any?> = emptyMap(),
 	requestBody: Any? = null,
-): Response<T> = (this as KtorClient).request(
-	method = HttpMethod.Delete,
+): Response<T> = request(
+	method = HttpMethod.DELETE,
 	pathTemplate = pathTemplate,
 	pathParameters = pathParameters,
 	queryParameters = queryParameters,
 	requestBody = requestBody
-)
+).createResponse()

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.sdk.api.client.util
+
+import io.ktor.utils.io.*
+import kotlinx.serialization.*
+import kotlinx.serialization.json.Json
+
+@OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
+public object ApiSerializer {
+	public val json: Json = Json {
+		isLenient = false
+		ignoreUnknownKeys = true
+		allowSpecialFloatingPointValues = true
+		useArrayPolymorphism = false
+	}
+
+	public fun encodeRequestBody(requestBody: Any? = null): String? {
+		if (requestBody == null) return null
+
+		return json.encodeToString(requestBody::class.serializer() as KSerializer<Any>, requestBody)
+	}
+
+	public suspend inline fun <reified T : Any> decodeResponseBody(responseBody: ByteReadChannel): T = when (T::class) {
+		is ByteReadChannel -> responseBody as T
+		else -> json.decodeFromString(responseBody.readRemaining().readText())
+	}
+}


### PR DESCRIPTION
- Add new class "RawResponse"
  - ApiClient is now expected to return an instance of RawResponse
  - Uses the new ApiSerializer to read response from RawResponse
- Added ApiClient.request to ApiClient interface
  - no longer inline because of the RawResponse class
- Removed (de)serialization responsibility from Ktor(Client)
- Made the HttpClient in KtorClient private
- Use new ApiSerialization in WebSocketApi

Tested with a private app that authenticates (post body), retrieves library items (response body) and downloads (response body bytestream reading) and it worked without any issues.

This PR closes #207 - It doesn't make KtorClient private but allows custom ApiClient instances now. In the future I'd like to move the KtorClient to a separate Gradle module so it can be omitted for advanced usage of the SDK.