### PR TITLE
Use testutils in all modules

### DIFF
--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -37,15 +37,6 @@ kotlin {
 		val commonTest by getting {
 			dependencies {
 				implementation(projects.testutils)
-				implementation(libs.kotlin.test.annotations.common)
-				implementation(libs.kotlin.test.common)
-			}
-		}
-
-		val jvmTest by getting {
-			dependencies {
-				implementation(libs.kotlin.test.junit)
-				implementation(libs.slf4j.simple)
 			}
 		}
 	}

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -35,8 +35,7 @@ kotlin {
 
 		val commonTest by getting {
 			dependencies {
-				implementation(libs.slf4j.simple)
-				implementation(libs.kotlin.test.junit)
+				implementation(projects.testutils)
 			}
 		}
 

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
 
 		val commonTest by getting {
 			dependencies {
-				implementation(libs.kotlin.test.junit)
+				implementation(projects.testutils)
 				implementation(libs.kotlinx.serialization.json)
 			}
 		}

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 	runtimeOnly(libs.slf4j.simple)
 
 	// Testing
-	testImplementation(libs.kotlin.test.junit)
+	testImplementation(projects.testutils)
 }
 
 val defaultConfig = mapOf(

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -17,9 +17,16 @@ kotlin {
 		val commonMain by getting {
 			dependencies {
 				api(libs.kotlinx.coroutines)
+				api(libs.kotlin.test.common)
+				api(libs.kotlin.test.annotations.common)
 			}
 		}
 
-		val jvmMain by getting {}
+		val jvmMain by getting {
+			dependencies {
+				implementation(libs.slf4j.simple)
+				api(libs.kotlin.test.junit)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Depends on #327. Uses `testutils` for all modules and add common dependencies to testutils. This removes the junit dependency in commonTest (which is not allowed) and makes it easier to test modules by just adding a single dependency.