### PR TITLE
Require explicit enabling of publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,30 +39,8 @@ apiValidation {
 
 subprojects {
 	// Enable required plugins
-	apply<SigningPlugin>()
-	apply<MavenPublishPlugin>()
 	apply<io.gitlab.arturbosch.detekt.DetektPlugin>()
 	apply<org.jetbrains.dokka.gradle.DokkaPlugin>()
-
-	// Run block after creating project specific configuration
-	afterEvaluate {
-		// Add signing config
-		configure<SigningExtension> {
-			val signingKey = getProperty("signing.key")
-			val signingPassword = getProperty("signing.password") ?: ""
-
-			if (signingKey != null) {
-				useInMemoryPgpKeys(signingKey, signingPassword)
-				val publishing: PublishingExtension by project
-				sign(publishing.publications)
-			}
-		}
-
-		// Add POM to projects that use publishing
-		configure<PublishingExtension> {
-			publications.withType<MavenPublication>().forEach(MavenPublication::defaultPom)
-		}
-	}
 
 	// Detekt linting
 	detekt {

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -1,0 +1,34 @@
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.kotlin.dsl.*
+import org.gradle.plugins.signing.SigningExtension
+import org.gradle.plugins.signing.SigningPlugin
+
+fun Project.enablePublishing(init: PublishingExtension.() -> Unit = {}) {
+	apply<SigningPlugin>()
+	apply<MavenPublishPlugin>()
+
+	extensions.getByType<PublishingExtension>().init()
+
+	// Run block after creating project specific configuration
+	afterEvaluate {
+		// Add signing config
+		configure<SigningExtension> {
+			val signingKey = getProperty("signing.key")
+			val signingPassword = getProperty("signing.password") ?: ""
+
+			if (signingKey != null) {
+				useInMemoryPgpKeys(signingKey, signingPassword)
+				val publishing: PublishingExtension by project
+				sign(publishing.publications)
+			}
+		}
+
+		// Add POM to projects that use publishing
+		configure<PublishingExtension> {
+			publications.withType<MavenPublication>().forEach(MavenPublication::defaultPom)
+		}
+	}
+}

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -42,12 +42,14 @@ kotlin {
 	}
 }
 
-val javadocJar by tasks.creating(Jar::class) {
-	dependsOn(tasks.getByName("dokkaHtml"))
-	archiveClassifier.set("javadoc")
-	from("$buildDir/dokka/html")
-}
+enablePublishing {
+	val javadocJar by tasks.creating(Jar::class) {
+		dependsOn(tasks.getByName("dokkaHtml"))
+		archiveClassifier.set("javadoc")
+		from("$buildDir/dokka/html")
+	}
 
-publishing.publications.withType<MavenPublication> {
-	artifact(javadocJar)
+	publications.withType<MavenPublication> {
+		artifact(javadocJar)
+	}
 }

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -88,13 +88,14 @@ android {
 	}
 }
 
-val javadocJar by tasks.creating(Jar::class) {
-	// FIXME: Dokka is failing for this module - temporarily disabled
-	// dependsOn(tasks.getByName("dokkaHtml"))
-	archiveClassifier.set("javadoc")
-	// from("$buildDir/dokka/html")
-}
+enablePublishing {
+	val javadocJar by tasks.creating(Jar::class) {
+		dependsOn(tasks.getByName("dokkaHtml"))
+		archiveClassifier.set("javadoc")
+		from("$buildDir/dokka/html")
+	}
 
-publishing.publications.withType<MavenPublication> {
-	artifact(javadocJar)
+	publications.withType<MavenPublication> {
+		artifact(javadocJar)
+	}
 }

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -32,12 +32,14 @@ kotlin {
 	}
 }
 
-val javadocJar by tasks.creating(Jar::class) {
-	dependsOn(tasks.getByName("dokkaHtml"))
-	archiveClassifier.set("javadoc")
-	from("$buildDir/dokka/html")
-}
+enablePublishing {
+	val javadocJar by tasks.creating(Jar::class) {
+		dependsOn(tasks.getByName("dokkaHtml"))
+		archiveClassifier.set("javadoc")
+		from("$buildDir/dokka/html")
+	}
 
-publishing.publications.withType<MavenPublication> {
-	artifact(javadocJar)
+	publications.withType<MavenPublication> {
+		artifact(javadocJar)
+	}
 }


### PR DESCRIPTION
Prevents testutils (and potential future projects) from being published, also moves publishing config to AFTER the kotlin block to fix jellyfin-core-android POM and jellyfin-core Dokka

---

- Explicit `enablePublishing` call to avoid accidental publishing of new packages
- Fix POM not always working
- Fix Dokka not in jellyfin-core

I can probably move the javadoc code the the enablePublishing function but didn't want refactor too much right now, just want to get 1.1.0 out