### PR TITLE
Add extensions to read arguments from GeneralCommandMessage

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -11243,6 +11243,13 @@ public final class org/jellyfin/sdk/model/api/XmlAttribute$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class org/jellyfin/sdk/model/extensions/GeneralCommandMessageExtensionsKt {
+	public static final fun contains (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Ljava/lang/String;)Z
+	public static final fun get (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun get (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;[Ljava/lang/String;)Ljava/util/List;
+	public static final fun getValue (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/String;
+}
+
 public final class org/jellyfin/sdk/model/extensions/PairExtensionsKt {
 	public static final fun toNameGuidPair (Lkotlin/Pair;)Lorg/jellyfin/sdk/model/api/NameGuidPair;
 	public static final fun toNameIdPair (Lkotlin/Pair;)Lorg/jellyfin/sdk/model/api/NameIdPair;

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/extensions/GeneralCommandMessageExtensions.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/extensions/GeneralCommandMessageExtensions.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.sdk.model.extensions
+
+import org.jellyfin.sdk.model.socket.GeneralCommandMessage
+import kotlin.reflect.KProperty
+
+// Single get
+public operator fun GeneralCommandMessage.get(name: String): String? =
+	arguments.entries.firstOrNull { (key) ->
+		key.contentEquals(name, ignoreCase = true)
+	}?.value
+
+// Multi get
+public operator fun GeneralCommandMessage.get(vararg names: String): List<String?> =
+	names.map(::get)
+
+// Property delegation
+public operator fun GeneralCommandMessage.getValue(thisRef: Any?, property: KProperty<*>): String? =
+	get(property.name)
+
+// Value checking
+public operator fun GeneralCommandMessage.contains(name: String): Boolean =
+	arguments.any { (key) ->
+		key.contentEquals(name, ignoreCase = true)
+	}

--- a/jellyfin-model/src/jvmTest/kotlin/org/jellyfin/sdk/model/extensions/GeneralCommandMessageExtensionTests.kt
+++ b/jellyfin-model/src/jvmTest/kotlin/org/jellyfin/sdk/model/extensions/GeneralCommandMessageExtensionTests.kt
@@ -1,0 +1,71 @@
+package org.jellyfin.sdk.model.extensions
+
+import org.jellyfin.sdk.model.api.GeneralCommandType
+import org.jellyfin.sdk.model.socket.GeneralCommandMessage
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GeneralCommandMessageExtensionTests {
+	private val dataArguments = mapOf(
+		"Header" to "This is the header",
+		"Text" to "This is the text",
+		"TimeoutMs" to "4000"
+	)
+	private val message = GeneralCommandMessage(
+		messageId = UUID.randomUUID(),
+		command = GeneralCommandType.DISPLAY_MESSAGE,
+		userId = UUID.randomUUID(),
+		arguments = dataArguments
+	)
+
+	@Test
+	fun `GeneralCommandMessage allows array access for arguments`() {
+		val header = message["Header"]
+		val text = message["Text"]
+		val timeoutMs = message["TimeoutMs"]
+
+		assertEquals("This is the header", header)
+		assertEquals("This is the text", text)
+		assertEquals("4000", timeoutMs)
+	}
+
+	@Test
+	fun `GeneralCommandMessage allows multi-array access for arguments`() {
+		val (header, text, timeoutMs) = message["Header", "Text", "TimeoutMs"]
+
+		assertEquals("This is the header", header)
+		assertEquals("This is the text", text)
+		assertEquals("4000", timeoutMs)
+	}
+
+	@Test
+	fun `GeneralCommandMessage allows property delegation read access for arguments`() {
+		val header by message
+		val text by message
+		val timeoutMs by message
+
+		assertEquals("This is the header", header)
+		assertEquals("This is the text", text)
+		assertEquals("4000", timeoutMs)
+	}
+
+	@Test
+	fun `GeneralCommandMessage allows checking for values`() {
+		assertEquals(true, "Header" in message)
+		assertEquals(true, "Text" in message)
+		assertEquals(true, "TimeoutMs" in message)
+		assertEquals(false, "Unknown" in message)
+	}
+
+	@Test
+	fun `GeneralCommandMessage extensions are case insensitive`() {
+		assertEquals(true, "header" in message)
+		assertEquals(true, "HEADER" in message)
+		assertEquals(true, "Header" in message)
+
+		assertEquals("This is the header", message["header"])
+		assertEquals("This is the header", message["HEADER"])
+		assertEquals("This is the header", message["Header"])
+	}
+}


### PR DESCRIPTION
GeneralCommandType is the most often used WebSocket message from the server but it's actual informative content (callled arguments) is just a map<string,string>. There is no schema for it (not even in the server!).

To make it easier to read information I added some (operator) extension functions that are case insensitive to allow reading the command messages.

The tests use a valid DISPLAY_MESSAGE command.


--

This is one of multiple pull requests that will rewrite the WebSocket API to make it easier to work with.