### PR TITLE
add java utility to consume suspend functions and move package

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9afb3ca688fc12c761a0e9e4321e4d24e977a4a8916c8a768b1fe05ddb4d6b66
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionSha256Sum=23b89f8eac363f5f4b8336e0530c7295c55b728a9caa5268fdd4a532610d5392
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -72,6 +72,39 @@ public final class org/jellyfin/sdk/android/AndroidDeviceKt {
 	public static final fun androidDevice (Landroid/content/Context;)Lorg/jellyfin/sdk/model/DeviceInfo;
 }
 
+public final class org/jellyfin/sdk/compatibility/JavaContinuation {
+	public static final field INSTANCE Lorg/jellyfin/sdk/compatibility/JavaContinuation;
+	public static final fun get (Ljava/util/function/BiConsumer;)Lkotlin/coroutines/Continuation;
+	public static final fun get (Ljava/util/function/BiConsumer;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlin/coroutines/Continuation;
+	public static synthetic fun get$default (Ljava/util/function/BiConsumer;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lkotlin/coroutines/Continuation;
+}
+
+public final class org/jellyfin/sdk/compatibility/JavaFlow {
+	public static final field INSTANCE Lorg/jellyfin/sdk/compatibility/JavaFlow;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static synthetic fun collect$default (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+}
+
+public abstract interface class org/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback {
+	public abstract fun onCompletion (Ljava/lang/Throwable;)V
+}
+
+public final class org/jellyfin/sdk/compatibility/JavaFlow$FlowJob : java/io/Closeable {
+	public fun <init> (Lkotlinx/coroutines/Job;)V
+	public fun close ()V
+}
+
+public abstract interface class org/jellyfin/sdk/compatibility/JavaFlow$ResultCallback {
+	public abstract fun onResult (Ljava/lang/Object;)V
+}
+
+public abstract interface class org/jellyfin/sdk/compatibility/JavaFlow$StartCallback {
+	public abstract fun onStart ()V
+}
+
 public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
 	public static final field Companion Lorg/jellyfin/sdk/discovery/AddressCandidateHelper$Companion;
 	public static final field JF_HTTPS_PORT I
@@ -215,32 +248,6 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$Unsupported
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class org/jellyfin/sdk/discovery/compatibility/JavaFlow {
-	public static final field INSTANCE Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static synthetic fun collect$default (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-}
-
-public abstract interface class org/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback {
-	public abstract fun onCompletion (Ljava/lang/Throwable;)V
-}
-
-public final class org/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob : java/io/Closeable {
-	public fun <init> (Lkotlinx/coroutines/Job;)V
-	public fun close ()V
-}
-
-public abstract interface class org/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback {
-	public abstract fun onResult (Ljava/lang/Object;)V
-}
-
-public abstract interface class org/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback {
-	public abstract fun onStart ()V
 }
 
 public abstract interface class org/jellyfin/sdk/util/ApiClientFactory {

--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -75,8 +75,6 @@ public final class org/jellyfin/sdk/android/AndroidDeviceKt {
 public final class org/jellyfin/sdk/compatibility/JavaContinuation {
 	public static final field INSTANCE Lorg/jellyfin/sdk/compatibility/JavaContinuation;
 	public static final fun get (Lorg/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback;)Lkotlin/coroutines/Continuation;
-	public static final fun get (Lorg/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlin/coroutines/Continuation;
-	public static synthetic fun get$default (Lorg/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lkotlin/coroutines/Continuation;
 }
 
 public abstract interface class org/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback {

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -62,8 +62,6 @@ public final class org/jellyfin/sdk/JellyfinOptionsKt {
 public final class org/jellyfin/sdk/compatibility/JavaContinuation {
 	public static final field INSTANCE Lorg/jellyfin/sdk/compatibility/JavaContinuation;
 	public static final fun get (Lorg/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback;)Lkotlin/coroutines/Continuation;
-	public static final fun get (Lorg/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlin/coroutines/Continuation;
-	public static synthetic fun get$default (Lorg/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lkotlin/coroutines/Continuation;
 }
 
 public abstract interface class org/jellyfin/sdk/compatibility/JavaContinuation$ReturnCallback {

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -59,6 +59,39 @@ public final class org/jellyfin/sdk/JellyfinOptionsKt {
 	public static final fun createJellyfinOptions (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/JellyfinOptions;
 }
 
+public final class org/jellyfin/sdk/compatibility/JavaContinuation {
+	public static final field INSTANCE Lorg/jellyfin/sdk/compatibility/JavaContinuation;
+	public static final fun get (Ljava/util/function/BiConsumer;)Lkotlin/coroutines/Continuation;
+	public static final fun get (Ljava/util/function/BiConsumer;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlin/coroutines/Continuation;
+	public static synthetic fun get$default (Ljava/util/function/BiConsumer;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lkotlin/coroutines/Continuation;
+}
+
+public final class org/jellyfin/sdk/compatibility/JavaFlow {
+	public static final field INSTANCE Lorg/jellyfin/sdk/compatibility/JavaFlow;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+	public static synthetic fun collect$default (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Lorg/jellyfin/sdk/compatibility/JavaFlow$FlowJob;
+}
+
+public abstract interface class org/jellyfin/sdk/compatibility/JavaFlow$CompletionCallback {
+	public abstract fun onCompletion (Ljava/lang/Throwable;)V
+}
+
+public final class org/jellyfin/sdk/compatibility/JavaFlow$FlowJob : java/io/Closeable {
+	public fun <init> (Lkotlinx/coroutines/Job;)V
+	public fun close ()V
+}
+
+public abstract interface class org/jellyfin/sdk/compatibility/JavaFlow$ResultCallback {
+	public abstract fun onResult (Ljava/lang/Object;)V
+}
+
+public abstract interface class org/jellyfin/sdk/compatibility/JavaFlow$StartCallback {
+	public abstract fun onStart ()V
+}
+
 public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
 	public static final field Companion Lorg/jellyfin/sdk/discovery/AddressCandidateHelper$Companion;
 	public static final field JF_HTTPS_PORT I
@@ -202,32 +235,6 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$Unsupported
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class org/jellyfin/sdk/discovery/compatibility/JavaFlow {
-	public static final field INSTANCE Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static final fun collect (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-	public static synthetic fun collect$default (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback;Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob;
-}
-
-public abstract interface class org/jellyfin/sdk/discovery/compatibility/JavaFlow$CompletionCallback {
-	public abstract fun onCompletion (Ljava/lang/Throwable;)V
-}
-
-public final class org/jellyfin/sdk/discovery/compatibility/JavaFlow$FlowJob : java/io/Closeable {
-	public fun <init> (Lkotlinx/coroutines/Job;)V
-	public fun close ()V
-}
-
-public abstract interface class org/jellyfin/sdk/discovery/compatibility/JavaFlow$ResultCallback {
-	public abstract fun onResult (Ljava/lang/Object;)V
-}
-
-public abstract interface class org/jellyfin/sdk/discovery/compatibility/JavaFlow$StartCallback {
-	public abstract fun onStart ()V
 }
 
 public abstract interface class org/jellyfin/sdk/util/ApiClientFactory {

--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/compatibility/JavaContinuation.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/compatibility/JavaContinuation.kt
@@ -1,0 +1,28 @@
+package org.jellyfin.sdk.compatibility
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import java.util.function.BiConsumer
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Compatibility class to use Kotlin suspend functions in Java files.
+ */
+public object JavaContinuation {
+	/**
+	 * .
+	 * @param resultCallback Called when the function ends with error or data.
+	 */
+	@JvmOverloads
+	@JvmStatic
+	public fun <R> get(resultCallback: BiConsumer<Throwable?,R?>, dispatcher: CoroutineDispatcher = Dispatchers.Default): Continuation<R> {
+		return object : Continuation<R> {
+			override val context: CoroutineContext
+				get() = dispatcher
+			override fun resumeWith(result: Result<R>) {
+				resultCallback.accept(result.exceptionOrNull(), result.getOrNull())
+			}
+		}
+	}
+}

--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/compatibility/JavaContinuation.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/compatibility/JavaContinuation.kt
@@ -1,9 +1,7 @@
 package org.jellyfin.sdk.compatibility
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.Continuation
-import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Compatibility class to use Kotlin suspend functions in Java files.
@@ -14,17 +12,13 @@ public object JavaContinuation {
 	}
 	/**
 	 * .
-	 * @param resultCallback Called when the function ends with error or data.
+	 * @param returnCallback Called when the function ends with error or data.
 	 */
-	@JvmOverloads
 	@JvmStatic
-	public fun <R> get(returnCallback: ReturnCallback<R>, dispatcher: CoroutineDispatcher = Dispatchers.Default): Continuation<R> {
+	public fun <R> get(returnCallback: ReturnCallback<R>): Continuation<R> {
 		return object : Continuation<R> {
-			override val context: CoroutineContext
-				get() = dispatcher
-			override fun resumeWith(result: Result<R>) {
-				returnCallback.onReturn(result.exceptionOrNull(), result.getOrNull())
-			}
+			override val context = EmptyCoroutineContext
+			override fun resumeWith(result: Result<R>) = returnCallback.onReturn(result.exceptionOrNull(), result.getOrNull())
 		}
 	}
 }

--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/compatibility/JavaFlow.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/compatibility/JavaFlow.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.sdk.discovery.compatibility
+package org.jellyfin.sdk.compatibility
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

Hi again. 
Still missing another util to consume all the sdk utilities from Java. I have added it next to the JavaFlow and I've moved the package with the two utils to the root of the core.
I have tried to implement it similar to what we did with the JavaFlow, it can be used as follows:
```java
suspendFn(..., JavaContinuation.get((err, result)->{
            // ...
}));
```
Hope everything is correct.
Regards
