### PR TITLE
Fix SerializationException not catched in RawResponse

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
@@ -1,6 +1,10 @@
 package org.jellyfin.sdk.api.client
 
 import io.ktor.utils.io.ByteReadChannel
+import kotlinx.serialization.SerializationException
+import mu.KotlinLogging
+import org.jellyfin.sdk.api.client.exception.ApiClientException
+import org.jellyfin.sdk.api.client.exception.InvalidContentException
 import org.jellyfin.sdk.api.client.util.ApiSerializer
 
 public class RawResponse(
@@ -8,7 +12,20 @@ public class RawResponse(
 	public val status: Int,
 	public val headers: Map<String, List<String>>,
 ) {
-	public suspend inline fun <reified T : Any> createContent(): T = ApiSerializer.decodeResponseBody(body)
+	public suspend inline fun <reified T : Any> createContent(): T {
+		val logger = KotlinLogging.logger {}
+
+		@Suppress("TooGenericExceptionCaught")
+		return try {
+			ApiSerializer.decodeResponseBody(body)
+		} catch (err: SerializationException) {
+			logger.error(err) { "Deserialization failed" }
+			throw InvalidContentException("Deserialization failed", err)
+		} catch (err: Throwable) {
+			logger.error(err) { "Unknown error occurred!" }
+			throw ApiClientException("Unknown error occurred!", err)
+		}
+	}
 
 	public suspend inline fun <reified T : Any> createResponse(): Response<T> =
 		Response(createContent(), status, headers)

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -102,14 +102,14 @@ public actual open class KtorClient actual constructor(
 			logger.debug(err) { "Socket timed out" }
 			throw TimeoutException("Socket timed out", err)
 		} catch (err: NoTransformationFoundException) {
-			logger.error(err) { "Requested model does not exist!?" }
-			throw InvalidContentException("Requested model does not exist!?", err)
+			logger.error(err) { "Requested model does not exist" }
+			throw InvalidContentException("Requested model does not exist", err)
 		} catch (err: SerializationException) {
-			logger.error(err) { "Deserialization failed" }
-			throw InvalidContentException("Deserialization failed", err)
+			logger.error(err) { "Serialization failed" }
+			throw InvalidContentException("Serialization failed", err)
 		} catch (err: Throwable) {
 			logger.error(err) { "Unknown error occurred!" }
-			throw ApiClientException(message = "Unknown error occurred!", cause = err)
+			throw ApiClientException("Unknown error occurred!", err)
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug in #322 where deserialization exceptions would not be caught anymore.

- KtorClient serializes post bodies but doesn't deserialize responses
- RawResponse deserializes responses

Both of the above are used when calling API functions, previously (before 322) the KtorClient would catch response deserialization issues.


_Considering a 1.1.2 release for this change._