### PR TITLE
Add DisplayPreferencesDtoNullabilityFixHook

### DIFF
--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DisplayPreferencesDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DisplayPreferencesDto.kt
@@ -56,7 +56,7 @@ public data class DisplayPreferencesDto(
 	 * Gets or sets the custom prefs.
 	 */
 	@SerialName("CustomPrefs")
-	public val customPrefs: Map<String, String>? = null,
+	public val customPrefs: Map<String, String?>,
 	/**
 	 * Gets or sets the scroll direction.
 	 */

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
@@ -3,6 +3,7 @@ package org.jellyfin.openapi.hooks
 import org.jellyfin.openapi.hooks.api.BinaryOperationUrlHook
 import org.jellyfin.openapi.hooks.api.PlayStateServiceNameHook
 import org.jellyfin.openapi.hooks.model.DefaultUserIdHook
+import org.jellyfin.openapi.hooks.model.DisplayPreferencesDtoNullabilityFixHook
 import org.jellyfin.openapi.hooks.model.ImageMapsHook
 import org.jellyfin.openapi.hooks.model.SyncPlayGroupUpdateHook
 import org.koin.dsl.bind
@@ -11,6 +12,7 @@ import org.koin.dsl.module
 val hooksModule = module {
 	single { ImageMapsHook() } bind TypeBuilderHook::class
 	single { SyncPlayGroupUpdateHook() } bind TypeBuilderHook::class
+	single { DisplayPreferencesDtoNullabilityFixHook() } bind TypeBuilderHook::class
 
 	single { BinaryOperationUrlHook() } bind OperationUrlHook::class
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/DisplayPreferencesDtoNullabilityFixHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/DisplayPreferencesDtoNullabilityFixHook.kt
@@ -1,0 +1,21 @@
+package org.jellyfin.openapi.hooks.model
+
+import com.squareup.kotlinpoet.typeNameOf
+import io.swagger.v3.oas.models.media.Schema
+import org.jellyfin.openapi.builder.openapi.OpenApiTypeBuilder
+import org.jellyfin.openapi.hooks.ModelTypePath
+import org.jellyfin.openapi.hooks.TypeBuilderHook
+import org.jellyfin.openapi.hooks.TypePath
+
+/**
+ * A hook that modifies the type of the "customPrefs" property in "DisplayPreferencesDto" to fix a nullability issue.
+ * In the 10.7 API specification the value of the map is incorrectly labelled as not-null.
+ * This hook changes the type to the exact type emitted from the 10.8 alpha API specification.
+ */
+@OptIn(ExperimentalStdlibApi::class)
+class DisplayPreferencesDtoNullabilityFixHook : TypeBuilderHook {
+	override fun onBuildType(path: TypePath, schema: Schema<*>, typeBuilder: OpenApiTypeBuilder) = when (path) {
+		ModelTypePath("DisplayPreferencesDto", "customPrefs") -> typeNameOf<Map<String, String?>>()
+		else -> null
+	}
+}


### PR DESCRIPTION
A hook that modifies the type of the "customPrefs" property in "DisplayPreferencesDto" to fix a nullability issue. In the 10.7 API specification the value of the map is incorrectly labelled as not-null. This hook changes the type to the exact type emitted from the 10.8 alpha API specification.

**This change needs to be reverted when the SDK starts using the 10.8 API specification.**