### PR TITLE
Deprecate WebSocketApi

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -192,7 +192,7 @@ public final class org/jellyfin/sdk/api/client/extensions/ApiClientExtensionsKt 
 	public static final fun getYearsApi (Lorg/jellyfin/sdk/api/client/ApiClient;)Lorg/jellyfin/sdk/api/operations/YearsApi;
 }
 
-public final class org/jellyfin/sdk/api/client/extensions/CommonApiClientExtensionsKt {
+public final class org/jellyfin/sdk/api/client/extensions/JvmApiClientExtensionsKt {
 	public static final fun getWebSocket (Lorg/jellyfin/sdk/api/client/ApiClient;)Lorg/jellyfin/sdk/api/sockets/WebSocketApi;
 }
 

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/extensions/ApiClientExtensions.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/extensions/ApiClientExtensions.kt
@@ -1,9 +1,11 @@
-@file:JvmName("CommonApiClientExtensionsKt")
+@file:JvmName("JvmApiClientExtensionsKt")
 
 package org.jellyfin.sdk.api.client.extensions
 
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.sockets.WebSocketApi
 
+@Suppress("DeprecatedCallableAddReplaceWith")
+@Deprecated("Replaced with the new SocketApi. This class will be removed in the next SDK release.")
 public val ApiClient.webSocket: WebSocketApi
 	get() = getOrCreateApi { WebSocketApi(it) }

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/SocketSubscription.kt
@@ -5,6 +5,7 @@ import org.jellyfin.sdk.model.socket.IncomingSocketMessage
 /**
  * Subscription to the [WebSocketApi] that can be cancelled.
  */
+@Deprecated("Replaced with the new SocketApi. This class will be removed in the next SDK release.")
 public class SocketSubscription(
 	private val webSocketApi: WebSocketApi,
 	internal val callback: suspend (IncomingSocketMessage) -> Unit,

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/WebSocketApi.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/WebSocketApi.kt
@@ -121,6 +121,7 @@ private val logger = KotlinLogging.logger {}
  *
  * The user should verify the access token is correct as the server does not respond to bad authorization.
  */
+@Deprecated("Replaced with the new SocketApi. This class will be removed in the next SDK release.")
 public class WebSocketApi(
 	private val api: ApiClient,
 ) : Api {


### PR DESCRIPTION
Preparations for upcoming SocketApi pull request. This one deprecates to old API.

The aim is to remove it completely after 1.2.0 (so probably 1.3 or 1.4).