### PR TITLE
Support username and password arguments in kotlin-cli sample

### DIFF
--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Options.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Options.kt
@@ -3,6 +3,11 @@ package org.jellyfin.sample.cli
 import com.github.ajalt.clikt.core.ParameterHolder
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import kotlinx.coroutines.runBlocking
+import org.jellyfin.sdk.Jellyfin
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.authenticateUserByName
+import org.jellyfin.sdk.api.client.extensions.userApi
 
 fun ParameterHolder.serverOption() = option(
 	"-s", "--server",
@@ -10,8 +15,38 @@ fun ParameterHolder.serverOption() = option(
 	envvar = "JELLYFIN_SERVER"
 ).required()
 
-fun ParameterHolder.tokenOption() = option(
-	"-t", "--token",
-	help = "Access token",
-	envvar = "JELLYFIN_TOKEN"
-).required()
+fun ParameterHolder.apiInstanceHolder(jellyfin: Jellyfin): Lazy<ApiClient> {
+	val server = serverOption().also(::registerOption)
+
+	val token = option(
+		"-t", "--token",
+		help = "Access token",
+		envvar = "JELLYFIN_TOKEN"
+	).also(::registerOption)
+
+	val username = option(
+		"-u", "--username",
+		help = "Username"
+	).also(::registerOption)
+
+	val password = option(
+		"-p", "--password",
+		help = "Password"
+	).also(::registerOption)
+
+	return lazy {
+		runBlocking {
+			// Create instance
+			val api = jellyfin.createApi(baseUrl = server.value, accessToken = token.value)
+
+			// Authenticate manually if access token is not provided
+			if (api.accessToken == null && username.value != null) {
+				val response by api.userApi.authenticateUserByName(username.value.orEmpty(), password.value.orEmpty())
+				api.accessToken = response.accessToken
+			}
+
+			// Return
+			api
+		}
+	}
+}

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Bitrate.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Bitrate.kt
@@ -4,30 +4,26 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 import kotlinx.coroutines.runBlocking
-import org.jellyfin.sample.cli.serverOption
-import org.jellyfin.sample.cli.tokenOption
+import org.jellyfin.sample.cli.apiInstanceHolder
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.extensions.detectBitrate
 import org.jellyfin.sdk.api.extensions.measureBitrate
 
 class Bitrate(
-	private val jellyfin: Jellyfin,
+	jellyfin: Jellyfin,
 ) : CliktCommand("Detect or measure bitrate") {
 	private companion object {
 		private const val MEGABIT = 1000000
 	}
 
-	private val server by serverOption()
-	private val token by tokenOption()
+	private val api by apiInstanceHolder(jellyfin)
 	private val bytes by option(
 		"--bytes", "-b",
 		help = "Amount of bytes to request from the server. Leave empty to detect automatically."
 	).int()
 
 	override fun run(): Unit = runBlocking {
-		val api = jellyfin.createApi(baseUrl = server, accessToken = token)
-
 		val measurement = when {
 			bytes != null -> api.mediaInfoApi.measureBitrate(bytes!!)
 			else -> api.mediaInfoApi.detectBitrate()

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Libraries.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Libraries.kt
@@ -2,21 +2,17 @@ package org.jellyfin.sample.cli.command
 
 import com.github.ajalt.clikt.core.CliktCommand
 import kotlinx.coroutines.runBlocking
-import org.jellyfin.sample.cli.serverOption
-import org.jellyfin.sample.cli.tokenOption
+import org.jellyfin.sample.cli.apiInstanceHolder
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.extensions.sessionApi
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 
 class Libraries(
-	private val jellyfin: Jellyfin
+	jellyfin: Jellyfin
 ) : CliktCommand("List all libraries") {
-	private val server by serverOption()
-	private val token by tokenOption()
+	private val api by apiInstanceHolder(jellyfin)
 
 	override fun run(): Unit = runBlocking {
-		val api = jellyfin.createApi(baseUrl = server, accessToken = token)
-
 		val sessionInfo = api.sessionApi.getSessions(deviceId = api.deviceInfo.id).content.firstOrNull()
 		if (sessionInfo == null) println("Unknown session")
 		api.userId = sessionInfo?.userId

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Login.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Login.kt
@@ -1,26 +1,16 @@
 package org.jellyfin.sample.cli.command
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.required
 import kotlinx.coroutines.runBlocking
-import org.jellyfin.sample.cli.serverOption
+import org.jellyfin.sample.cli.apiInstanceHolder
 import org.jellyfin.sdk.Jellyfin
-import org.jellyfin.sdk.api.client.extensions.authenticateUserByName
-import org.jellyfin.sdk.api.client.extensions.userApi
 
 class Login(
-	private val jellyfin: Jellyfin
+	jellyfin: Jellyfin
 ) : CliktCommand("Login to a given server and retrieve an access token") {
-	private val server by serverOption()
-	private val username by option("-u", "--username", help = "Username").required()
-	private val password by option("-p", "--password", help = "Password")
+	private val api by apiInstanceHolder(jellyfin)
 
 	override fun run() = runBlocking {
-		val api = jellyfin.createApi(baseUrl = server)
-
-		val result by api.userApi.authenticateUserByName(username, password.orEmpty())
-
-		if (result.accessToken != null) println(result.accessToken)
+		if (api.accessToken != null) println(api.accessToken)
 	}
 }

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Observe.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Observe.kt
@@ -2,8 +2,7 @@ package org.jellyfin.sample.cli.command
 
 import com.github.ajalt.clikt.core.CliktCommand
 import kotlinx.coroutines.runBlocking
-import org.jellyfin.sample.cli.serverOption
-import org.jellyfin.sample.cli.tokenOption
+import org.jellyfin.sample.cli.apiInstanceHolder
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.extensions.webSocket
 import org.jellyfin.sdk.model.socket.ActivityLogEntryStartMessage
@@ -11,13 +10,11 @@ import org.jellyfin.sdk.model.socket.ScheduledTasksInfoStartMessage
 import org.jellyfin.sdk.model.socket.SessionsStartMessage
 
 class Observe(
-	private val jellyfin: Jellyfin
+	jellyfin: Jellyfin
 ) : CliktCommand("Create a WebSocket connection and listen to all events") {
-	private val server by serverOption()
-	private val token by tokenOption()
+	private val api by apiInstanceHolder(jellyfin)
 
 	override fun run() = runBlocking {
-		val api = jellyfin.createApi(baseUrl = server, accessToken = token)
 		val webSocketApi = api.webSocket
 
 		println("Starting subscription")


### PR DESCRIPTION
Wanted to implement this for a while now...

- Support `--username` and `--password` (optional) in kotlin-cli commands as replacement for `--token`
  - When token is not supplied it will sign in to retrieve a token

This is useful for testing various functions of the SDK, like the WebSockets via the observe command using Gradle (`gradlew :samples:kotlin-cli:run --args="observe --server https://demo.jellyfin.org/stable --username demo"`).