### PR TITLE
Allow custom device info in Android target

### DIFF
--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -56,9 +56,11 @@ public final class org/jellyfin/sdk/JellyfinOptions$Builder {
 	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getContext ()Landroid/content/Context;
+	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun setApiClientFactory (Lorg/jellyfin/sdk/util/ApiClientFactory;)V
 	public final fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public final fun setContext (Landroid/content/Context;)V
+	public final fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
 }
 
 public final class org/jellyfin/sdk/JellyfinOptions$Companion {

--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -16,6 +16,7 @@ public actual data class JellyfinOptions(
 	public actual class Builder {
 		public var context: Context? = null
 		public var clientInfo: ClientInfo? = null
+		public var deviceInfo: DeviceInfo? = null
 		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
@@ -23,7 +24,7 @@ public actual data class JellyfinOptions(
 				"An Android context is required when using the jellyfin-android platform."
 			},
 			clientInfo = clientInfo,
-			deviceInfo = androidDevice(context!!),
+			deviceInfo = deviceInfo ?: androidDevice(context!!),
 			apiClientFactory = apiClientFactory,
 		)
 	}


### PR DESCRIPTION
It still defaults to an automatic implementation which is the recommended way to use it.