### PR TITLE
Add MissingBaseUrlException to replace IllegalArgumentException

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -110,6 +110,12 @@ public final class org/jellyfin/sdk/api/client/exception/InvalidStatusException 
 	public final fun getStatus ()I
 }
 
+public final class org/jellyfin/sdk/api/client/exception/MissingBaseUrlException : org/jellyfin/sdk/api/client/exception/ApiClientException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class org/jellyfin/sdk/api/client/exception/MissingPathVariableException : org/jellyfin/sdk/api/client/exception/ApiClientException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.sdk.api.client
 
+import org.jellyfin.sdk.api.client.exception.MissingBaseUrlException
 import org.jellyfin.sdk.api.client.util.UrlBuilder
 import org.jellyfin.sdk.api.operations.Api
 import org.jellyfin.sdk.model.ClientInfo
@@ -61,7 +62,7 @@ public abstract class ApiClient {
 		queryParameters: Map<String, Any?> = emptyMap(),
 		includeCredentials: Boolean = false,
 	): String = UrlBuilder.buildUrl(
-		requireNotNull(baseUrl),
+		baseUrl ?: throw MissingBaseUrlException(),
 		pathTemplate,
 		pathParameters,
 		queryParameters.run {

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/exception/MissingBaseUrlException.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/exception/MissingBaseUrlException.kt
@@ -1,0 +1,8 @@
+package org.jellyfin.sdk.api.client.exception
+
+public class MissingBaseUrlException(
+	cause: Throwable? = null,
+) : ApiClientException(
+	"Required value baseUrl is null. Provide it by setting ApiClient.baseUrl.",
+	cause
+)


### PR DESCRIPTION
A client often catches the generic ApiClientException when using the API. In some cases the base url might be unset.

This PR adds a new MissingBaseUrlException that is used now. Just like we do for user id's with the MissingUserIdException.