### PR TITLE
Don't throw when baseUrl not set in SocketInstance

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketInstance.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketInstance.kt
@@ -164,6 +164,13 @@ public class SocketInstance internal constructor(
 
 		connection?.disconnect()
 
+		// No base url set. The app might want to set it later and call [updateCredentials]
+		if (baseUrl == null) {
+			logger.info { "Cancelling reconnect because baseUrl is null" }
+			_state.value = SocketInstanceState.DISCONNECTED
+			return
+		}
+
 		connection = socketConnectionFactory.create(
 			api.httpClientOptions,
 			incomingMessages,


### PR DESCRIPTION
Was considering using the "ERROR" state but when we do that the SDK doesn't allow a call to "updateCredentials()" anymore.