### PR TITLE
Add generator task for stable-pre openapi files

### DIFF
--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -61,13 +61,17 @@ tasks.register("verifySources", JavaExec::class) {
 		.flatten()
 }
 
-arrayOf("stable", "unstable").forEach { flavor ->
-	tasks.register("downloadApiSpec${flavor.capitalize()}", Download::class) {
+arrayOf(
+	"stable" to "Stable",
+	"stable-pre" to "Prerelease",
+	"unstable" to "Unstable",
+).forEach { (flavor, flavorPascalCase) ->
+	tasks.register("downloadApiSpec${flavorPascalCase}", Download::class) {
 		src("https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-${flavor}.json")
 		dest(defaultConfig["openApiFile"])
 	}
 
-	tasks.register("updateApiSpec${flavor.capitalize()}") {
-		dependsOn("downloadApiSpec${flavor.capitalize()}", "generateSources")
+	tasks.register("updateApiSpec${flavorPascalCase}") {
+		dependsOn("downloadApiSpec${flavorPascalCase}", "generateSources")
 	}
 }


### PR DESCRIPTION
Because someone decided to change the structure of the openapi files again.... Not changing the CI for this one though so if we decide to keep doing SDK beta releases for server beta's we need to do it manually.

draft because no merge until 1.2.0 is ready