### PR TITLE
Add OkHttpWebsocketSession for JVM and Android targets

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1189,6 +1189,12 @@ public final class org/jellyfin/sdk/api/sockets/ListenerRegistrationExtensionsKt
 	public static synthetic fun addSyncPlayCommandsListener$default (Lorg/jellyfin/sdk/api/sockets/SocketInstance;Ljava/util/Set;ZLorg/jellyfin/sdk/api/sockets/listener/SocketMessageReceiver;ILjava/lang/Object;)Lorg/jellyfin/sdk/api/sockets/listener/SocketListener;
 }
 
+public final class org/jellyfin/sdk/api/sockets/OkHttpWebsocketSession : org/jellyfin/sdk/api/sockets/SocketInstanceConnection {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lkotlinx/coroutines/channels/Channel;Lkotlinx/coroutines/channels/Channel;Lkotlin/coroutines/CoroutineContext;)V
+	public fun connect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class org/jellyfin/sdk/api/sockets/SocketConnectionFactory {
 	public abstract fun create (Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lkotlinx/coroutines/channels/Channel;Lkotlinx/coroutines/channels/Channel;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/OkHttpWebsocketSession.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/OkHttpWebsocketSession.kt
@@ -1,0 +1,116 @@
+package org.jellyfin.sdk.api.sockets
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import mu.KotlinLogging
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
+
+private val logger = KotlinLogging.logger {}
+
+public class OkHttpWebsocketSession(
+	clientOptions: HttpClientOptions,
+	private val incomingMessageChannel: Channel<String>,
+	private val outgoingMessageChannel: Channel<String>,
+	context: CoroutineContext,
+) : SocketInstanceConnection {
+	private companion object {
+		private const val CLOSE_REASON_NORMAL = 1000
+	}
+
+	private val coroutineScope = CoroutineScope(context)
+	private val client = OkHttpClient.Builder().apply {
+		followRedirects(clientOptions.followRedirects)
+
+		connectTimeout(clientOptions.connectTimeout, TimeUnit.MILLISECONDS)
+		readTimeout(clientOptions.socketTimeout, TimeUnit.MILLISECONDS)
+		writeTimeout(clientOptions.socketTimeout, TimeUnit.MILLISECONDS)
+	}.build()
+	private var webSocket: WebSocket? = null
+	private var messageForwardJob: Job? = null
+	private val state = MutableStateFlow(SocketInstanceState.DISCONNECTED)
+
+	private val listener = object : WebSocketListener() {
+		override fun onOpen(webSocket: WebSocket, response: Response) {
+			logger.info { "WebSocket has opened" }
+			state.value = SocketInstanceState.CONNECTED
+		}
+
+		override fun onMessage(webSocket: WebSocket, text: String) {
+			logger.info { "Receiving (raw) message $text" }
+
+			coroutineScope.launch {
+				incomingMessageChannel.send(text)
+			}
+		}
+
+		override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+			logger.warn { "Ignoring a binary message" }
+		}
+
+		override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+			logger.info { "WebSocket is closing, code=$code, reason=$reason" }
+			state.value = SocketInstanceState.DISCONNECTED
+
+			messageForwardJob?.cancel()
+			messageForwardJob = null
+		}
+
+		@Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+		override fun onClosed(closedWebSocket: WebSocket, code: Int, reason: String) {
+			logger.info { "WebSocket has closed, code=$code, reason=$reason" }
+			state.value = SocketInstanceState.DISCONNECTED
+
+			if (webSocket == closedWebSocket) webSocket = null
+		}
+
+		@Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+		override fun onFailure(failedWebSocket: WebSocket, t: Throwable, response: Response?) {
+			logger.warn(t) { "WebSocket has failed" }
+			state.value = SocketInstanceState.ERROR
+
+			// When onFailure is called, the onClosing and onClosed functions are not called
+			messageForwardJob?.cancel()
+			messageForwardJob = null
+			if (webSocket == failedWebSocket) webSocket = null
+		}
+	}
+
+	override suspend fun connect(url: String): Boolean {
+		if (webSocket != null) disconnect()
+
+		val request = Request.Builder().apply {
+			url(url)
+		}.build()
+
+		state.value = SocketInstanceState.CONNECTING
+		webSocket = client.newWebSocket(request, listener)
+
+		messageForwardJob = coroutineScope.launch {
+			for (message in outgoingMessageChannel) {
+				logger.info { "Sending (raw) message $message" }
+
+				webSocket?.send(message)
+			}
+		}
+
+		return state.first { it != SocketInstanceState.CONNECTING } == SocketInstanceState.CONNECTED
+	}
+
+	override suspend fun disconnect() {
+		state.value = SocketInstanceState.DISCONNECTED
+		webSocket?.close(CLOSE_REASON_NORMAL, null)
+		webSocket = null
+	}
+}

--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -3,7 +3,7 @@ package org.jellyfin.sdk
 import android.content.Context
 import org.jellyfin.sdk.android.androidDevice
 import org.jellyfin.sdk.api.client.KtorClient
-import org.jellyfin.sdk.api.sockets.KtorSocketInstanceConnection
+import org.jellyfin.sdk.api.sockets.OkHttpWebsocketSession
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
@@ -21,7 +21,7 @@ public actual data class JellyfinOptions(
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
 		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
-		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::KtorSocketInstanceConnection)
+		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpWebsocketSession)
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
 			context = requireNotNull(context) {

--- a/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -1,7 +1,7 @@
 package org.jellyfin.sdk
 
 import org.jellyfin.sdk.api.client.KtorClient
-import org.jellyfin.sdk.api.sockets.KtorSocketInstanceConnection
+import org.jellyfin.sdk.api.sockets.OkHttpWebsocketSession
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
@@ -17,7 +17,7 @@ public actual data class JellyfinOptions(
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
 		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
-		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::KtorSocketInstanceConnection)
+		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpWebsocketSession)
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
 			clientInfo = clientInfo,


### PR DESCRIPTION
Unfortunately the Ktor WebSocket implementation causes exceptions that we're unable to catch when the socket connection ends abruptly (e.g. jellyfin server stopping, network going offline etc.).
The OkHttp implementation does not have this issue, so it's going to be the default, with a fallback to Ktor for "multiplatform" support.

Required for #361 