### PR TITLE
Update @OptIn annotations

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
@@ -20,7 +20,6 @@ import org.jellyfin.sdk.model.socket.IncomingSocketMessage
 import org.jellyfin.sdk.model.socket.OutgoingSocketMessage
 import org.jellyfin.sdk.model.socket.RawIncomingSocketMessage
 
-@OptIn(InternalSerializationApi::class)
 public object ApiSerializer {
 	private const val SOCKET_MESSAGE_DATA = "Data"
 	private const val SOCKET_MESSAGE_MESSAGE_ID = "MessageId"
@@ -37,6 +36,7 @@ public object ApiSerializer {
 		encodeDefaults = true
 	}
 
+	@OptIn(InternalSerializationApi::class)
 	public fun encodeRequestBody(requestBody: Any? = null): String? {
 		if (requestBody == null) return null
 
@@ -49,7 +49,7 @@ public object ApiSerializer {
 		else -> json.decodeFromString(responseBody.readRemaining().readText())
 	}
 
-	@OptIn(ExperimentalSerializationApi::class)
+	@OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
 	public fun encodeSocketMessage(message: OutgoingSocketMessage): String {
 		// Serialize with default serializer
 		val serializer = message::class.serializer() as KSerializer<Any>

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/DisplayPreferencesDtoNullabilityFixHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/DisplayPreferencesDtoNullabilityFixHook.kt
@@ -12,7 +12,6 @@ import org.jellyfin.openapi.hooks.TypePath
  * In the 10.7 API specification the value of the map is incorrectly labelled as not-null.
  * This hook changes the type to the exact type emitted from the 10.8 alpha API specification.
  */
-@OptIn(ExperimentalStdlibApi::class)
 class DisplayPreferencesDtoNullabilityFixHook : TypeBuilderHook {
 	override fun onBuildType(path: TypePath, schema: Schema<*>, typeBuilder: OpenApiTypeBuilder) = when (path) {
 		ModelTypePath("DisplayPreferencesDto", "customPrefs") -> typeNameOf<Map<String, String?>>()


### PR DESCRIPTION
- Remove useless `@OptIn(ExperimentalStdlibApi::class)` from DisplayPreferencesDtoNullabilityFixHook
- Move `@OptIn(InternalSerializationApi::class)` to functions that require it in ApiSerializer