### PR TITLE
Add retry logic to SocketInstance

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1187,6 +1187,7 @@ public final class org/jellyfin/sdk/api/sockets/OkHttpWebsocketSession : org/jel
 	public fun <init> (Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lkotlinx/coroutines/channels/Channel;Lkotlin/coroutines/CoroutineContext;)V
 	public fun connect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1207,6 +1208,7 @@ public final class org/jellyfin/sdk/api/sockets/SocketInstance {
 public abstract interface class org/jellyfin/sdk/api/sockets/SocketInstanceConnection {
 	public abstract fun connect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketInstanceConnection.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketInstanceConnection.kt
@@ -1,9 +1,17 @@
 package org.jellyfin.sdk.api.sockets
 
+import kotlinx.coroutines.flow.StateFlow
+
 /**
  * Reusable WebSocket connection. Constructed using [SocketConnectionFactory].
  */
 public interface SocketInstanceConnection {
+	/**
+	 * State of the connection. Requires at least the [SocketInstanceState.ERROR] and [SocketInstanceState.DISCONNECTED]
+	 * states to be implemented.
+	 */
+	public val state: StateFlow<SocketInstanceState>
+
 	/**
 	 * Connect to [url]. If there is an existing connection it will be automatically closed. After the connection is
 	 * initialized the messageListener supplied via the factory will be called until [disconnect] is called or the

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/helper/ReconnectHelper.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/helper/ReconnectHelper.kt
@@ -1,9 +1,61 @@
 package org.jellyfin.sdk.api.sockets.helper
 
-internal class ReconnectHelper {
-	fun reportConnect() {}
-	fun reportDisconnect(){}
-	fun reset() {}
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import mu.KotlinLogging
+import kotlin.time.Duration.Companion.seconds
 
-	fun shouldReconnectNow() {}
+private val logger = KotlinLogging.logger {}
+
+internal class ReconnectHelper(
+	private val coroutineScope: CoroutineScope,
+	private val reconnect: suspend () -> Unit,
+) {
+	private var reconnectJob: Job? = null
+	private var attempts = 0
+
+	fun reset() {
+		logger.debug { "Resetting" }
+		reconnectJob?.cancel()
+		attempts = 0
+	}
+
+	fun notifyReconnect() {
+		reconnectJob?.cancel()
+		attempts++
+		logger.debug { "Notified about reconnect, attempts=${attempts}" }
+	}
+
+	fun notifyConnected() {
+		attempts = 0
+		logger.debug { "Notified about connect, attempts reset" }
+	}
+
+	fun scheduleReconnect(error: Boolean = false): Boolean {
+		reconnectJob?.cancel()
+
+		if (attempts > RETRY_ATTEMPTS) {
+			logger.debug { "Reconnect schedule failed: exceeded maximum retry attempts" }
+			return false
+		}
+
+		reconnectJob = coroutineScope.launch {
+			val retryAfter = if (error) RETRY_ERROR else RETRY_NORMAL
+
+			logger.info { "Reconnect scheduled in $retryAfter (error=$error)" }
+
+			delay(retryAfter)
+			reconnect()
+		}
+
+		return true
+	}
+
+	companion object {
+		val RETRY_NORMAL = 5.seconds
+		val RETRY_ERROR = 30.seconds
+		const val RETRY_ATTEMPTS = 5
+	}
 }


### PR DESCRIPTION
Fixes #361 

This PR adds automatic reconnection abilities to the WebSocket code. It's fairly simple for now; retry 5 times when a disconnect/error occurs. Error will wait 30 seconds before retrying while a "normal" disconnect retries after 5. The algorithm could definitely be improved in the future, but  this will do for now.