### PR TITLE
Fix ServerVersion comparison failing when build is not set

### DIFF
--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/ServerVersion.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/ServerVersion.kt
@@ -34,7 +34,7 @@ public data class ServerVersion(
 			{ it.major },
 			{ it.minor },
 			{ it.patch },
-			{ it.build ?: -1 }
+			{ it.build ?: 0 }
 		)
 
 		/**

--- a/jellyfin-model/src/commonTest/kotlin/org/jellyfin/sdk/model/discovery/ServerVersionTests.kt
+++ b/jellyfin-model/src/commonTest/kotlin/org/jellyfin/sdk/model/discovery/ServerVersionTests.kt
@@ -3,6 +3,7 @@ package org.jellyfin.sdk.model.discovery
 import org.jellyfin.sdk.model.ServerVersion
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -39,5 +40,8 @@ class ServerVersionTests {
 		assertTrue { ServerVersion(1, 2, 3) > ServerVersion(0, 0, 0) }
 
 		assertTrue { ServerVersion(1, 7, 0, 1) > ServerVersion(1, 7, 0) }
+
+		assertFalse { ServerVersion.fromString("10.8.0")!! < ServerVersion(10, 8, 0, 0) }
+		assertFalse { ServerVersion.fromString("10.8.0")!! < ServerVersion.fromString("10.8.0")!! }
 	}
 }


### PR DESCRIPTION
This issue causes the RecommendedServerDiscovery to reject 10.8 servers.. oops