### PR TITLE
Add extension function for authenticateWithQuickConnect that takes the secret directly

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -203,6 +203,7 @@ public final class org/jellyfin/sdk/api/client/extensions/ApiClientExtensionsKt 
 
 public final class org/jellyfin/sdk/api/client/extensions/UserApiExtensionsKt {
 	public static final fun authenticateUserByName (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun authenticateWithQuickConnect (Lorg/jellyfin/sdk/api/operations/UserApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/client/util/ApiSerializer {

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/UserApiExtensions.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/UserApiExtensions.kt
@@ -4,16 +4,28 @@ import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.operations.UserApi
 import org.jellyfin.sdk.model.api.AuthenticateUserByName
 import org.jellyfin.sdk.model.api.AuthenticationResult
+import org.jellyfin.sdk.model.api.QuickConnectDto
 
 /**
  * Extension function for the authenticateUserByName operation that accepts the username and password directly
  */
 public suspend inline fun UserApi.authenticateUserByName(
 	username: String,
-	password: String
+	password: String,
 ): Response<AuthenticationResult> = authenticateUserByName(
 	data = AuthenticateUserByName(
 		username = username,
 		pw = password
+	)
+)
+
+/**
+ * Extension function for the authenticateWithQuickConnect operation that accepts the secret directly
+ */
+public suspend inline fun UserApi.authenticateWithQuickConnect(
+	secret: String,
+): Response<AuthenticationResult> = authenticateWithQuickConnect(
+	data = QuickConnectDto(
+		secret = secret
 	)
 )


### PR DESCRIPTION
`val response by api.userApi.authenticateWithQuickConnect(QuickConnectDto(secret))`
vs
`val response by api.userApi.authenticateWithQuickConnect(secret)`