### PR TITLE
Move dependency repository definition to build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,12 +10,17 @@ allprojects {
 	group = "org.jellyfin.sdk"
 	version = createVersion()
 
-	// Add default dependency repositories
-	repositories.defaultRepositories()
+	repositories {
+		mavenCentral()
+		google()
+	}
 }
 
 buildscript {
-	repositories.defaultRepositories()
+	repositories {
+		mavenCentral()
+		google()
+	}
 
 	dependencies {
 		classpath(libs.android.gradle)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,0 @@
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-
-fun RepositoryHandler.defaultRepositories() {
-	mavenCentral()
-	google()
-}


### PR DESCRIPTION
I believe this should fix the issue where Renovate can't find androidx dependencies