### PR TITLE
Set input/output in openapi-generator tasks

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -28,7 +28,7 @@ jobs:
           java-version: 17
           cache: gradle
       - name: Run updateApiSpecUnstable and apiDump tasks
-        run: ./gradlew --build-cache --no-daemon --info updateApiSpecUnstable apiDump
+        run: ./gradlew --build-cache --no-daemon --info :openapi-generator:updateApiSpecUnstable apiDump
       - name: Commit changes
         run: |
           git config user.name jellyfin-bot

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Update generated sources and create pull request
         uses: technote-space/create-pr-action@7da7ae9ed86b38dcf6bef74c2a879a900c1fe654 # tag=v2
         with:
-          EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info updateApiSpecStable apiDump
+          EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info :openapi-generator:updateApiSpecStable apiDump
           COMMIT_MESSAGE: 'Update generated sources to ${{ env.STABLE_API_VERSION }}'
           COMMIT_NAME: 'jellyfin-bot'
           COMMIT_EMAIL: 'team@jellyfin.org'

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -46,6 +46,9 @@ tasks.register("generateSources", JavaExec::class) {
 	mainClass.set(application.mainClass)
 	classpath = sourceSets.main.get().runtimeClasspath
 
+	inputs.file(defaultConfig["openApiFile"])
+	outputs.dirs(defaultConfig["apiOutputDir"], defaultConfig["modelsOutputDir"])
+
 	args = defaultConfig
 		.map { listOf("--${it.key}", it.value.toString()) }
 		.flatten()
@@ -69,6 +72,7 @@ arrayOf(
 	tasks.register("downloadApiSpec${flavorPascalCase}", Download::class) {
 		src("https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-${flavor}.json")
 		dest(defaultConfig["openApiFile"])
+		outputs.file(defaultConfig["openApiFile"])
 	}
 
 	tasks.register("updateApiSpec${flavorPascalCase}") {


### PR DESCRIPTION
Like always, testing CI is hard so I have no idea if this is going to work. If it does, this should fix the CI sometimes skipping the apiDump task.
