### PR TITLE
Increase minimum supported Jellyfin version to 10.8.1

### DIFF
--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -8,7 +8,6 @@ import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.model.UUID
-import kotlin.jvm.JvmOverloads
 
 public class Jellyfin(
 	public val options: JellyfinOptions,
@@ -71,7 +70,7 @@ public class Jellyfin(
 		/**
 		 * The minimum server version expected to work. Lower versions may work but are not supported.
 		 */
-		public val minimumVersion: ServerVersion = ServerVersion(10, 8, 0, 0)
+		public val minimumVersion: ServerVersion = ServerVersion(10, 8, 1, 0)
 
 		/**
 		 * The exact server version used to generate the API. Should be equal or higher than [minimumVersion].


### PR DESCRIPTION
10.8.1 will add a few changes to the newly introduced Splashscreen API. One of these changes is the possibility to disable the splashscreen completely. This adds a new (not-null) boolean property called `splashscreenEnabled` to the `BrandingOptions` model which is a breaking change. Therefor we'll increase the minimum supported Jellyfin version in a patch update.

The removed import is because the annotation is imported by default and was no longer needed.