### PR TITLE
Generate URL builder function for ClientLogApi.logFile

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -305,6 +305,8 @@ public final class org/jellyfin/sdk/api/operations/ChannelsApi : org/jellyfin/sd
 public final class org/jellyfin/sdk/api/operations/ClientLogApi : org/jellyfin/sdk/api/operations/Api {
 	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;)V
 	public final fun logFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun logFileUrl (Z)Ljava/lang/String;
+	public static synthetic fun logFileUrl$default (Lorg/jellyfin/sdk/api/operations/ClientLogApi;ZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jellyfin/sdk/api/operations/CollectionApi : org/jellyfin/sdk/api/operations/Api {

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ClientLogApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ClientLogApi.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.api.operations
 
 import kotlin.Any
+import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.emptyMap
 import org.jellyfin.sdk.api.client.ApiClient
@@ -25,5 +26,16 @@ public class ClientLogApi(
 		val response = api.post<ClientLogDocumentResponseDto>("/ClientLog/Document", pathParameters,
 				queryParameters, data)
 		return response
+	}
+
+	/**
+	 * Upload a document.
+	 *
+	 * @param includeCredentials Add the access token to the url to make an authenticated request.
+	 */
+	public fun logFileUrl(includeCredentials: Boolean = true): String {
+		val pathParameters = emptyMap<String, Any?>()
+		val queryParameters = emptyMap<String, Any?>()
+		return api.createUrl("/ClientLog/Document", pathParameters, queryParameters, includeCredentials)
 	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.openapi.hooks
 
 import org.jellyfin.openapi.hooks.api.BinaryOperationUrlHook
+import org.jellyfin.openapi.hooks.api.ClientLogOperationUrlHook
 import org.jellyfin.openapi.hooks.api.PlayStateServiceNameHook
 import org.jellyfin.openapi.hooks.model.DefaultUserIdHook
 import org.jellyfin.openapi.hooks.model.ImageMapsHook
@@ -13,6 +14,7 @@ val hooksModule = module {
 	single { SyncPlayGroupUpdateHook() } bind TypeBuilderHook::class
 
 	single { BinaryOperationUrlHook() } bind OperationUrlHook::class
+	single { ClientLogOperationUrlHook() } bind OperationUrlHook::class
 
 	single { PlayStateServiceNameHook() } bind ServiceNameHook::class
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/api/ClientLogOperationUrlHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/api/ClientLogOperationUrlHook.kt
@@ -1,0 +1,11 @@
+package org.jellyfin.openapi.hooks.api
+
+import org.jellyfin.openapi.constants.Strings
+import org.jellyfin.openapi.hooks.OperationUrlHook
+import org.jellyfin.openapi.model.ApiService
+import org.jellyfin.openapi.model.ApiServiceOperation
+
+class ClientLogOperationUrlHook : OperationUrlHook {
+	override fun shouldOperationBuildUrlFun(api: ApiService, operation: ApiServiceOperation) =
+		api.name == "ClientLog${Strings.API_SERVICE_SUFFIX}" && operation.name == "logFile"
+}


### PR DESCRIPTION
For ATV we're not using the SDK to send crash reports, it caches the URL instead and manually creates a connection when a crash occurs. With this change we don't need to add the path to the upload endpoint to the ATV code.