### PR TITLE
Allow client to change minimum server version

### DIFF
--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -34,19 +34,21 @@ public final class org/jellyfin/sdk/JellyfinKt {
 
 public final class org/jellyfin/sdk/JellyfinOptions {
 	public static final field Companion Lorg/jellyfin/sdk/JellyfinOptions$Companion;
-	public fun <init> (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
+	public fun <init> (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)V
 	public final fun component1 ()Landroid/content/Context;
 	public final fun component2 ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun component3 ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun component4 ()Lorg/jellyfin/sdk/util/ApiClientFactory;
 	public final fun component5 ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
-	public final fun copy (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/JellyfinOptions;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public final fun component6 ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public final fun copy (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun getMinimumServerVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public final fun getSocketConnectionFactory ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -59,11 +61,13 @@ public final class org/jellyfin/sdk/JellyfinOptions$Builder {
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun getMinimumServerVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public final fun getSocketConnectionFactory ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
 	public final fun setApiClientFactory (Lorg/jellyfin/sdk/util/ApiClientFactory;)V
 	public final fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public final fun setContext (Landroid/content/Context;)V
 	public final fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public final fun setMinimumServerVersion (Lorg/jellyfin/sdk/model/ServerVersion;)V
 	public final fun setSocketConnectionFactory (Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
 }
 

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -27,17 +27,19 @@ public final class org/jellyfin/sdk/JellyfinKt {
 
 public final class org/jellyfin/sdk/JellyfinOptions {
 	public static final field Companion Lorg/jellyfin/sdk/JellyfinOptions$Companion;
-	public fun <init> (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)V
 	public final fun component1 ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun component2 ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun component3 ()Lorg/jellyfin/sdk/util/ApiClientFactory;
 	public final fun component4 ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
-	public final fun copy (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/JellyfinOptions;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public final fun component5 ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public final fun copy (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun getMinimumServerVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public final fun getSocketConnectionFactory ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -49,10 +51,12 @@ public final class org/jellyfin/sdk/JellyfinOptions$Builder {
 	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun getMinimumServerVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public final fun getSocketConnectionFactory ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
 	public final fun setApiClientFactory (Lorg/jellyfin/sdk/util/ApiClientFactory;)V
 	public final fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public final fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public final fun setMinimumServerVersion (Lorg/jellyfin/sdk/model/ServerVersion;)V
 	public final fun setSocketConnectionFactory (Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
 }
 

--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -7,6 +7,7 @@ import org.jellyfin.sdk.api.sockets.OkHttpWebsocketSession
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.util.ApiClientFactory
 
 public actual data class JellyfinOptions(
@@ -15,6 +16,7 @@ public actual data class JellyfinOptions(
 	public actual val deviceInfo: DeviceInfo?,
 	public actual val apiClientFactory: ApiClientFactory,
 	public actual val socketConnectionFactory: SocketConnectionFactory,
+	public actual val minimumServerVersion: ServerVersion,
 ) {
 	public actual class Builder {
 		public var context: Context? = null
@@ -22,6 +24,7 @@ public actual data class JellyfinOptions(
 		public var deviceInfo: DeviceInfo? = null
 		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
 		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpWebsocketSession)
+		public var minimumServerVersion: ServerVersion = Jellyfin.minimumVersion
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
 			context = requireNotNull(context) {
@@ -31,6 +34,7 @@ public actual data class JellyfinOptions(
 			deviceInfo = deviceInfo ?: androidDevice(context!!),
 			apiClientFactory = apiClientFactory,
 			socketConnectionFactory = socketConnectionFactory,
+			minimumServerVersion = minimumServerVersion,
 		)
 	}
 

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -3,6 +3,7 @@ package org.jellyfin.sdk
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.util.ApiClientFactory
 
 public expect class JellyfinOptions {
@@ -10,6 +11,7 @@ public expect class JellyfinOptions {
 	public val deviceInfo: DeviceInfo?
 	public val apiClientFactory: ApiClientFactory
 	public val socketConnectionFactory: SocketConnectionFactory
+	public val minimumServerVersion: ServerVersion
 
 	@Suppress("EmptyDefaultConstructor")
 	public class Builder() {

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
@@ -64,10 +64,15 @@ public class RecommendedServerDiscovery constructor(
 				issues.add(RecommendedServerIssue.MissingVersion)
 				scores.add(RecommendedServerInfoScore.BAD)
 			}
-			// Server might be incompatible because it's below the minimum supported server version
-			version < Jellyfin.minimumVersion -> {
+			// Server might be incompatible because it's below the client specified minimum supported server version
+			version < jellyfin.options.minimumServerVersion -> {
 				issues.add(RecommendedServerIssue.UnsupportedServerVersion(version))
 				scores.add(RecommendedServerInfoScore.OK)
+			}
+			// Server might be incompatible because it's below the SDK specified minimum supported server version
+			version < Jellyfin.minimumVersion -> {
+				issues.add(RecommendedServerIssue.OutdatedServerVersion(version))
+				scores.add(RecommendedServerInfoScore.GOOD)
 			}
 			// API might differ slightly but at least above the minimum version
 			version < Jellyfin.apiVersion -> {

--- a/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -5,6 +5,7 @@ import org.jellyfin.sdk.api.sockets.OkHttpWebsocketSession
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.ServerVersion
 import org.jellyfin.sdk.util.ApiClientFactory
 
 public actual data class JellyfinOptions(
@@ -12,18 +13,21 @@ public actual data class JellyfinOptions(
 	public actual val deviceInfo: DeviceInfo?,
 	public actual val apiClientFactory: ApiClientFactory,
 	public actual val socketConnectionFactory: SocketConnectionFactory,
+	public actual val minimumServerVersion: ServerVersion,
 ) {
 	public actual class Builder {
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
 		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
 		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpWebsocketSession)
+		public var minimumServerVersion: ServerVersion = Jellyfin.minimumVersion
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
 			clientInfo = clientInfo,
 			deviceInfo = deviceInfo,
 			apiClientFactory = apiClientFactory,
 			socketConnectionFactory = socketConnectionFactory,
+			minimumServerVersion = minimumServerVersion,
 		)
 	}
 


### PR DESCRIPTION
This mostly affects the RecommendedServerDiscovery rejecting servers not meeting the hardcoded minimum server version, but the option value can be used by the client too.
