### PR TITLE
Map java.net.ConnectException to TimeoutException

### DIFF
--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -28,6 +28,7 @@ import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.UUID
+import java.net.ConnectException
 import java.net.UnknownHostException
 import io.ktor.http.HttpMethod as KtorHttpMethod
 
@@ -113,6 +114,9 @@ public actual open class KtorClient actual constructor(
 		} catch (err: SocketTimeoutException) {
 			logger.debug(err) { "Socket timed out" }
 			throw TimeoutException("Socket timed out", err)
+		} catch (err: ConnectException) {
+			logger.debug(err) { "Connection failed" }
+			throw TimeoutException("Connection failed", err)
 		} catch (err: NoTransformationFoundException) {
 			logger.error(err) { "Requested model does not exist" }
 			throw InvalidContentException("Requested model does not exist", err)


### PR DESCRIPTION
This exception occurs for me when the server is unreachable, I'm mapping it to `TimeoutException` as it's the general type for network issues.