### PR TITLE
Remove catching (too generic) Throwable exceptions

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
@@ -3,7 +3,6 @@ package org.jellyfin.sdk.api.client
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
-import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.exception.InvalidContentException
 import org.jellyfin.sdk.api.client.util.ApiSerializer
 
@@ -15,15 +14,11 @@ public class RawResponse(
 	public suspend inline fun <reified T : Any> createContent(): T {
 		val logger = KotlinLogging.logger {}
 
-		@Suppress("TooGenericExceptionCaught")
 		return try {
 			ApiSerializer.decodeResponseBody(body)
 		} catch (err: SerializationException) {
 			logger.error(err) { "Deserialization failed" }
 			throw InvalidContentException("Deserialization failed", err)
-		} catch (err: Throwable) {
-			logger.error(err) { "Unknown error occurred!" }
-			throw ApiClientException("Unknown error occurred!", err)
 		}
 	}
 

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -17,7 +17,6 @@ import io.ktor.network.sockets.SocketTimeoutException
 import io.ktor.util.toMap
 import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
-import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.exception.InvalidContentException
 import org.jellyfin.sdk.api.client.exception.InvalidStatusException
 import org.jellyfin.sdk.api.client.exception.TimeoutException
@@ -70,7 +69,6 @@ public actual open class KtorClient actual constructor(
 			"$method $safeUrl"
 		}
 
-		@Suppress("TooGenericExceptionCaught")
 		try {
 			val response = client.request<HttpResponse>(url) {
 				this.method = method.asKtorHttpMethod()
@@ -123,9 +121,6 @@ public actual open class KtorClient actual constructor(
 		} catch (err: SerializationException) {
 			logger.error(err) { "Serialization failed" }
 			throw InvalidContentException("Serialization failed", err)
-		} catch (err: Throwable) {
-			logger.error(err) { "Unknown error occurred!" }
-			throw ApiClientException("Unknown error occurred!", err)
 		}
 	}
 

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
@@ -117,7 +117,6 @@ public class RecommendedServerDiscovery constructor(
 
 		val responseTimeStart = currentTimeMillis()
 
-		@Suppress("TooGenericExceptionCaught")
 		val info: Result<Response<PublicSystemInfo>> = try {
 			val response = client.systemApi.getPublicSystemInfo()
 			if (response.status == HTTP_OK) Result.success(response)
@@ -130,9 +129,6 @@ public class RecommendedServerDiscovery constructor(
 			Result.failure(err)
 		} catch (err: InvalidContentException) {
 			logger.debug(err) { "Could not parse response from $address" }
-			Result.failure(err)
-		} catch (err: Throwable) {
-			logger.error(err) { "Could not retrieve public system info for $address" }
 			Result.failure(err)
 		}
 		val responseTime = currentTimeMillis() - responseTimeStart


### PR DESCRIPTION
This fixes the TooGenericExceptionCaught linter issue. We ignored it, but it actually ended up causing issues. When a coroutine is cancelled it often throws a CancellationException. This was caught and converted to an ApiClientException causing coroutine cancellation to stop working. This change removes the places that catch Throwable, and they may throw exceptions now. We'll need to watch this and possibly add new catch branches later.

Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/1909
Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/1889