### PR TITLE
Optimize map building in generator

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ActivityLogApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ActivityLogApi.kt
@@ -9,8 +9,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -36,11 +36,12 @@ public class ActivityLogApi(
 		hasUserId: Boolean? = null,
 	): Response<ActivityLogEntryQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["minDate"] = minDate
-		queryParameters["hasUserId"] = hasUserId
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("minDate", minDate)
+			put("hasUserId", hasUserId)
+		}
 		val data = null
 		val response = api.`get`<ActivityLogEntryQueryResult>("/System/ActivityLog/Entries",
 				pathParameters, queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ApiKeyApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ApiKeyApi.kt
@@ -8,8 +8,8 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -27,8 +27,9 @@ public class ApiKeyApi(
 	 */
 	public suspend fun createKey(app: String): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["app"] = app
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("app", app)
+		}
 		val data = null
 		val response = api.post<Unit>("/Auth/Keys", pathParameters, queryParameters, data)
 		return response
@@ -52,8 +53,9 @@ public class ApiKeyApi(
 	 * @param key The access token to delete.
 	 */
 	public suspend fun revokeKey(key: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["key"] = key
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("key", key)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Auth/Keys/{key}", pathParameters, queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ArtistsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ArtistsApi.kt
@@ -11,9 +11,9 @@ import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -118,39 +118,40 @@ public class ArtistsApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["minCommunityRating"] = minCommunityRating
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["filters"] = filters
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["genres"] = genres
-		queryParameters["genreIds"] = genreIds
-		queryParameters["officialRatings"] = officialRatings
-		queryParameters["tags"] = tags
-		queryParameters["years"] = years
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["person"] = person
-		queryParameters["personIds"] = personIds
-		queryParameters["personTypes"] = personTypes
-		queryParameters["studios"] = studios
-		queryParameters["studioIds"] = studioIds
-		queryParameters["userId"] = userId
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["sortBy"] = sortBy
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(32) {
+			put("minCommunityRating", minCommunityRating)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("searchTerm", searchTerm)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("filters", filters)
+			put("isFavorite", isFavorite)
+			put("mediaTypes", mediaTypes)
+			put("genres", genres)
+			put("genreIds", genreIds)
+			put("officialRatings", officialRatings)
+			put("tags", tags)
+			put("years", years)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("person", person)
+			put("personIds", personIds)
+			put("personTypes", personTypes)
+			put("studios", studios)
+			put("studioIds", studioIds)
+			put("userId", userId)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("sortBy", sortBy)
+			put("sortOrder", sortOrder)
+			put("enableImages", enableImages)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Artists/AlbumArtists", pathParameters,
 				queryParameters, data)
@@ -164,10 +165,12 @@ public class ArtistsApi(
 	 * @param userId Optional. Filter by user id, and attach user data.
 	 */
 	public suspend fun getArtistByName(name: String, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/Artists/{name}", pathParameters, queryParameters, data)
 		return response
@@ -262,39 +265,40 @@ public class ArtistsApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["minCommunityRating"] = minCommunityRating
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["filters"] = filters
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["genres"] = genres
-		queryParameters["genreIds"] = genreIds
-		queryParameters["officialRatings"] = officialRatings
-		queryParameters["tags"] = tags
-		queryParameters["years"] = years
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["person"] = person
-		queryParameters["personIds"] = personIds
-		queryParameters["personTypes"] = personTypes
-		queryParameters["studios"] = studios
-		queryParameters["studioIds"] = studioIds
-		queryParameters["userId"] = userId
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["sortBy"] = sortBy
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(32) {
+			put("minCommunityRating", minCommunityRating)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("searchTerm", searchTerm)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("filters", filters)
+			put("isFavorite", isFavorite)
+			put("mediaTypes", mediaTypes)
+			put("genres", genres)
+			put("genreIds", genreIds)
+			put("officialRatings", officialRatings)
+			put("tags", tags)
+			put("years", years)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("person", person)
+			put("personIds", personIds)
+			put("personTypes", personTypes)
+			put("studios", studios)
+			put("studioIds", studioIds)
+			put("userId", userId)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("sortBy", sortBy)
+			put("sortOrder", sortOrder)
+			put("enableImages", enableImages)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Artists", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
@@ -13,8 +13,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Map
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -145,57 +145,59 @@ public class AudioApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(48) {
+			put("container", container)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/stream", pathParameters,
 				queryParameters, data)
@@ -324,57 +326,59 @@ public class AudioApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(48) {
+			put("container", container)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Audio/{itemId}/stream", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -499,57 +503,59 @@ public class AudioApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(47) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/stream.{container}", pathParameters,
 				queryParameters, data)
@@ -678,57 +684,59 @@ public class AudioApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(47) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters,
 				includeCredentials)
 	}

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ChannelsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ChannelsApi.kt
@@ -11,9 +11,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -45,8 +45,9 @@ public class ChannelsApi(
 	 * @param channelId Channel id.
 	 */
 	public suspend fun getChannelFeatures(channelId: UUID): Response<ChannelFeatures> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["channelId"] = channelId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("channelId", channelId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ChannelFeatures>("/Channels/{channelId}/Features", pathParameters,
@@ -81,17 +82,19 @@ public class ChannelsApi(
 		sortBy: Collection<String>? = emptyList(),
 		fields: Collection<ItemFields>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["channelId"] = channelId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["folderId"] = folderId
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["filters"] = filters
-		queryParameters["sortBy"] = sortBy
-		queryParameters["fields"] = fields
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("channelId", channelId)
+		}
+		val queryParameters = buildMap<String, Any?>(8) {
+			put("folderId", folderId)
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("sortOrder", sortOrder)
+			put("filters", filters)
+			put("sortBy", sortBy)
+			put("fields", fields)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Channels/{channelId}/Items", pathParameters,
 				queryParameters, data)
@@ -118,13 +121,14 @@ public class ChannelsApi(
 		isFavorite: Boolean? = null,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["supportsLatestItems"] = supportsLatestItems
-		queryParameters["supportsMediaDeletion"] = supportsMediaDeletion
-		queryParameters["isFavorite"] = isFavorite
+		val queryParameters = buildMap<String, Any?>(6) {
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("supportsLatestItems", supportsLatestItems)
+			put("supportsMediaDeletion", supportsMediaDeletion)
+			put("isFavorite", isFavorite)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Channels", pathParameters, queryParameters,
 				data)
@@ -151,13 +155,14 @@ public class ChannelsApi(
 		channelIds: Collection<UUID>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["filters"] = filters
-		queryParameters["fields"] = fields
-		queryParameters["channelIds"] = channelIds
+		val queryParameters = buildMap<String, Any?>(6) {
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("filters", filters)
+			put("fields", fields)
+			put("channelIds", channelIds)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Channels/Items/Latest", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/CollectionApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/CollectionApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.delete
@@ -31,10 +31,12 @@ public class CollectionApi(
 	 */
 	public suspend fun addToCollection(collectionId: UUID, ids: Collection<UUID> = emptyList()):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["collectionId"] = collectionId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["ids"] = ids
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("collectionId", collectionId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("ids", ids)
+		}
 		val data = null
 		val response = api.post<Unit>("/Collections/{collectionId}/Items", pathParameters,
 				queryParameters, data)
@@ -56,11 +58,12 @@ public class CollectionApi(
 		isLocked: Boolean? = false,
 	): Response<CollectionCreationResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
-		queryParameters["ids"] = ids
-		queryParameters["parentId"] = parentId
-		queryParameters["isLocked"] = isLocked
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("name", name)
+			put("ids", ids)
+			put("parentId", parentId)
+			put("isLocked", isLocked)
+		}
 		val data = null
 		val response = api.post<CollectionCreationResult>("/Collections", pathParameters, queryParameters,
 				data)
@@ -75,10 +78,12 @@ public class CollectionApi(
 	 */
 	public suspend fun removeFromCollection(collectionId: UUID, ids: Collection<UUID> = emptyList()):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["collectionId"] = collectionId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["ids"] = ids
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("collectionId", collectionId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("ids", ids)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Collections/{collectionId}/Items", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
@@ -10,8 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import kotlinx.serialization.json.JsonElement
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
@@ -54,8 +54,9 @@ public class ConfigurationApi(
 	 * @param key Configuration key.
 	 */
 	public suspend fun getNamedConfiguration(key: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["key"] = key
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("key", key)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/System/Configuration/{key}", pathParameters,
@@ -70,8 +71,9 @@ public class ConfigurationApi(
 	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getNamedConfigurationUrl(key: String, includeCredentials: Boolean = true): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["key"] = key
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("key", key)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/System/Configuration/{key}", pathParameters, queryParameters,
 				includeCredentials)
@@ -103,8 +105,9 @@ public class ConfigurationApi(
 	 * @param key Configuration key.
 	 */
 	public suspend fun updateNamedConfiguration(key: String, `data`: JsonElement): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["key"] = key
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("key", key)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/System/Configuration/{key}", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DashboardApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DashboardApi.kt
@@ -9,8 +9,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -27,8 +27,9 @@ public class DashboardApi(
 	public suspend fun getConfigurationPages(enableInMainMenu: Boolean? = null):
 			Response<List<ConfigurationPageInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["enableInMainMenu"] = enableInMainMenu
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("enableInMainMenu", enableInMainMenu)
+		}
 		val data = null
 		val response = api.`get`<List<ConfigurationPageInfo>>("/web/ConfigurationPages", pathParameters,
 				queryParameters, data)
@@ -42,8 +43,9 @@ public class DashboardApi(
 	 */
 	public suspend fun getDashboardConfigurationPage(name: String? = null): Response<String> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
 		val data = null
 		val response = api.`get`<String>("/web/ConfigurationPage", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
@@ -9,8 +9,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -32,8 +32,9 @@ public class DevicesApi(
 	 */
 	public suspend fun deleteDevice(id: String): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Devices", pathParameters, queryParameters, data)
 		return response
@@ -46,8 +47,9 @@ public class DevicesApi(
 	 */
 	public suspend fun getDeviceInfo(id: String): Response<DeviceInfo> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val data = null
 		val response = api.`get`<DeviceInfo>("/Devices/Info", pathParameters, queryParameters, data)
 		return response
@@ -60,8 +62,9 @@ public class DevicesApi(
 	 */
 	public suspend fun getDeviceOptions(id: String): Response<DeviceOptions> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val data = null
 		val response = api.`get`<DeviceOptions>("/Devices/Options", pathParameters, queryParameters, data)
 		return response
@@ -76,9 +79,10 @@ public class DevicesApi(
 	public suspend fun getDevices(supportsSync: Boolean? = null, userId: UUID? = null):
 			Response<DeviceInfoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["supportsSync"] = supportsSync
-		queryParameters["userId"] = userId
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("supportsSync", supportsSync)
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<DeviceInfoQueryResult>("/Devices", pathParameters, queryParameters, data)
 		return response
@@ -91,8 +95,9 @@ public class DevicesApi(
 	 */
 	public suspend fun updateDeviceOptions(id: String, `data`: DeviceOptionsDto): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val response = api.post<Unit>("/Devices/Options", pathParameters, queryParameters, data)
 		return response
 	}

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DisplayPreferencesApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DisplayPreferencesApi.kt
@@ -8,7 +8,7 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.Unit
-import kotlin.collections.mutableMapOf
+import kotlin.collections.buildMap
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -32,11 +32,13 @@ public class DisplayPreferencesApi(
 		userId: UUID = api.userId ?: throw MissingUserIdException(),
 		client: String,
 	): Response<DisplayPreferencesDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["displayPreferencesId"] = displayPreferencesId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["client"] = client
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("displayPreferencesId", displayPreferencesId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("client", client)
+		}
 		val data = null
 		val response = api.`get`<DisplayPreferencesDto>("/DisplayPreferences/{displayPreferencesId}",
 				pathParameters, queryParameters, data)
@@ -56,11 +58,13 @@ public class DisplayPreferencesApi(
 		client: String,
 		`data`: DisplayPreferencesDto,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["displayPreferencesId"] = displayPreferencesId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["client"] = client
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("displayPreferencesId", displayPreferencesId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("client", client)
+		}
 		val response = api.post<Unit>("/DisplayPreferences/{displayPreferencesId}", pathParameters,
 				queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaApi.kt
@@ -9,8 +9,8 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -38,8 +38,9 @@ public class DlnaApi(
 	 * @param profileId Profile id.
 	 */
 	public suspend fun deleteProfile(profileId: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["profileId"] = profileId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("profileId", profileId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Dlna/Profiles/{profileId}", pathParameters, queryParameters,
@@ -65,8 +66,9 @@ public class DlnaApi(
 	 * @param profileId Profile Id.
 	 */
 	public suspend fun getProfile(profileId: String): Response<DeviceProfile> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["profileId"] = profileId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("profileId", profileId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<DeviceProfile>("/Dlna/Profiles/{profileId}", pathParameters,
@@ -93,8 +95,9 @@ public class DlnaApi(
 	 */
 	public suspend fun updateProfile(profileId: String, `data`: DeviceProfile? = null):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["profileId"] = profileId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("profileId", profileId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Dlna/Profiles/{profileId}", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaServerApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DlnaServerApi.kt
@@ -9,8 +9,8 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -25,8 +25,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getConnectionManager(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/ConnectionManager", pathParameters,
@@ -40,8 +41,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getConnectionManager2(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/ConnectionManager/ConnectionManager",
@@ -55,8 +57,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getConnectionManager3(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/ConnectionManager/ConnectionManager.xml",
@@ -70,8 +73,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getContentDirectory(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/ContentDirectory", pathParameters,
@@ -85,8 +89,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getContentDirectory2(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/ContentDirectory/ContentDirectory",
@@ -100,8 +105,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getContentDirectory3(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/ContentDirectory/ContentDirectory.xml",
@@ -115,8 +121,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getDescriptionXml(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/description", pathParameters, queryParameters,
@@ -130,8 +137,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getDescriptionXml2(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/description.xml", pathParameters,
@@ -145,8 +153,9 @@ public class DlnaServerApi(
 	 * @param fileName The icon filename.
 	 */
 	public suspend fun getIcon(fileName: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["fileName"] = fileName
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("fileName", fileName)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Dlna/icons/{fileName}", pathParameters,
@@ -161,8 +170,9 @@ public class DlnaServerApi(
 	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getIconUrl(fileName: String, includeCredentials: Boolean = false): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["fileName"] = fileName
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("fileName", fileName)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Dlna/icons/{fileName}", pathParameters, queryParameters,
 				includeCredentials)
@@ -175,9 +185,10 @@ public class DlnaServerApi(
 	 * @param fileName The icon filename.
 	 */
 	public suspend fun getIconId(serverId: String, fileName: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
-		pathParameters["fileName"] = fileName
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("serverId", serverId)
+			put("fileName", fileName)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Dlna/{serverId}/icons/{fileName}", pathParameters,
@@ -197,9 +208,10 @@ public class DlnaServerApi(
 		fileName: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
-		pathParameters["fileName"] = fileName
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("serverId", serverId)
+			put("fileName", fileName)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Dlna/{serverId}/icons/{fileName}", pathParameters, queryParameters,
 				includeCredentials)
@@ -211,8 +223,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getMediaReceiverRegistrar(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/MediaReceiverRegistrar", pathParameters,
@@ -226,8 +239,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getMediaReceiverRegistrar2(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Dlna/{serverId}/MediaReceiverRegistrar/MediaReceiverRegistrar",
@@ -241,8 +255,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun getMediaReceiverRegistrar3(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response =
@@ -257,8 +272,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun processConnectionManagerControlRequest(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<String>("/Dlna/{serverId}/ConnectionManager/Control", pathParameters,
@@ -272,8 +288,9 @@ public class DlnaServerApi(
 	 * @param serverId Server UUID.
 	 */
 	public suspend fun processContentDirectoryControlRequest(serverId: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<String>("/Dlna/{serverId}/ContentDirectory/Control", pathParameters,
@@ -288,8 +305,9 @@ public class DlnaServerApi(
 	 */
 	public suspend fun processMediaReceiverRegistrarControlRequest(serverId: String):
 			Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["serverId"] = serverId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("serverId", serverId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<String>("/Dlna/{serverId}/MediaReceiverRegistrar/Control", pathParameters,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
@@ -13,8 +13,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Map
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -155,62 +155,64 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
-		pathParameters["segmentId"] = segmentId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["runtimeTicks"] = runtimeTicks
-		queryParameters["actualSegmentLengthTicks"] = actualSegmentLengthTicks
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+			put("segmentId", segmentId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(50) {
+			put("runtimeTicks", runtimeTicks)
+			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response =
 				api.`get`<ByteReadChannel>("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}",
@@ -350,62 +352,64 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
-		pathParameters["segmentId"] = segmentId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["runtimeTicks"] = runtimeTicks
-		queryParameters["actualSegmentLengthTicks"] = actualSegmentLengthTicks
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+			put("segmentId", segmentId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(50) {
+			put("runtimeTicks", runtimeTicks)
+			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -543,63 +547,65 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
-		pathParameters["segmentId"] = segmentId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["runtimeTicks"] = runtimeTicks
-		queryParameters["actualSegmentLengthTicks"] = actualSegmentLengthTicks
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+			put("segmentId", segmentId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(51) {
+			put("runtimeTicks", runtimeTicks)
+			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response =
 				api.`get`<ByteReadChannel>("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}",
@@ -742,63 +748,65 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
-		pathParameters["segmentId"] = segmentId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["runtimeTicks"] = runtimeTicks
-		queryParameters["actualSegmentLengthTicks"] = actualSegmentLengthTicks
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+			put("segmentId", segmentId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(51) {
+			put("runtimeTicks", runtimeTicks)
+			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -929,60 +937,62 @@ public class DynamicHlsApi(
 		maxHeight: Int? = null,
 		enableSubtitlesInManifest: Boolean? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["enableSubtitlesInManifest"] = enableSubtitlesInManifest
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(51) {
+			put("container", container)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("enableSubtitlesInManifest", enableSubtitlesInManifest)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/live.m3u8", pathParameters,
 				queryParameters, data)
@@ -1117,60 +1127,62 @@ public class DynamicHlsApi(
 		enableSubtitlesInManifest: Boolean? = null,
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["enableSubtitlesInManifest"] = enableSubtitlesInManifest
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(51) {
+			put("container", container)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("enableSubtitlesInManifest", enableSubtitlesInManifest)
+		}
 		return api.createUrl("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -1297,58 +1309,60 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAdaptiveBitrateStreaming: Boolean? = true,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
-		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(49) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+			put("enableAdaptiveBitrateStreaming", enableAdaptiveBitrateStreaming)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/master.m3u8", pathParameters,
 				queryParameters, data)
@@ -1479,58 +1493,60 @@ public class DynamicHlsApi(
 		enableAdaptiveBitrateStreaming: Boolean? = true,
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
-		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(49) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+			put("enableAdaptiveBitrateStreaming", enableAdaptiveBitrateStreaming)
+		}
 		return api.createUrl("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -1659,59 +1675,61 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAdaptiveBitrateStreaming: Boolean? = true,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
-		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(50) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+			put("enableAdaptiveBitrateStreaming", enableAdaptiveBitrateStreaming)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/master.m3u8", pathParameters,
 				queryParameters, data)
@@ -1844,59 +1862,61 @@ public class DynamicHlsApi(
 		enableAdaptiveBitrateStreaming: Boolean? = true,
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
-		queryParameters["enableAdaptiveBitrateStreaming"] = enableAdaptiveBitrateStreaming
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(50) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+			put("enableAdaptiveBitrateStreaming", enableAdaptiveBitrateStreaming)
+		}
 		return api.createUrl("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -2020,57 +2040,59 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(48) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/main.m3u8", pathParameters,
 				queryParameters, data)
@@ -2198,57 +2220,59 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(48) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -2375,58 +2399,60 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(49) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/main.m3u8", pathParameters,
 				queryParameters, data)
@@ -2557,58 +2583,60 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(49) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters,
 				includeCredentials)
 	}

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/EnvironmentApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/EnvironmentApi.kt
@@ -11,8 +11,8 @@ import kotlin.Deprecated
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -50,10 +50,11 @@ public class EnvironmentApi(
 		includeDirectories: Boolean? = false,
 	): Response<List<FileSystemEntryInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["path"] = path
-		queryParameters["includeFiles"] = includeFiles
-		queryParameters["includeDirectories"] = includeDirectories
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("path", path)
+			put("includeFiles", includeFiles)
+			put("includeDirectories", includeDirectories)
+		}
 		val data = null
 		val response = api.`get`<List<FileSystemEntryInfo>>("/Environment/DirectoryContents",
 				pathParameters, queryParameters, data)
@@ -92,8 +93,9 @@ public class EnvironmentApi(
 	 */
 	public suspend fun getParentPath(path: String): Response<String> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["path"] = path
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("path", path)
+		}
 		val data = null
 		val response = api.`get`<String>("/Environment/ParentPath", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/FilterApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/FilterApi.kt
@@ -9,9 +9,9 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -52,17 +52,18 @@ public class FilterApi(
 		recursive: Boolean? = null,
 	): Response<QueryFilters> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["parentId"] = parentId
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["isAiring"] = isAiring
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSports"] = isSports
-		queryParameters["isKids"] = isKids
-		queryParameters["isNews"] = isNews
-		queryParameters["isSeries"] = isSeries
-		queryParameters["recursive"] = recursive
+		val queryParameters = buildMap<String, Any?>(10) {
+			put("userId", userId)
+			put("parentId", parentId)
+			put("includeItemTypes", includeItemTypes)
+			put("isAiring", isAiring)
+			put("isMovie", isMovie)
+			put("isSports", isSports)
+			put("isKids", isKids)
+			put("isNews", isNews)
+			put("isSeries", isSeries)
+			put("recursive", recursive)
+		}
 		val data = null
 		val response = api.`get`<QueryFilters>("/Items/Filters2", pathParameters, queryParameters, data)
 		return response
@@ -84,11 +85,12 @@ public class FilterApi(
 		mediaTypes: Collection<String>? = emptyList(),
 	): Response<QueryFiltersLegacy> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["parentId"] = parentId
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["mediaTypes"] = mediaTypes
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("userId", userId)
+			put("parentId", parentId)
+			put("includeItemTypes", includeItemTypes)
+			put("mediaTypes", mediaTypes)
+		}
 		val data = null
 		val response = api.`get`<QueryFiltersLegacy>("/Items/Filters", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/GenresApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/GenresApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -34,10 +34,12 @@ public class GenresApi(
 	 * @param userId The user id.
 	 */
 	public suspend fun getGenre(genreName: String, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["genreName"] = genreName
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("genreName", genreName)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/Genres/{genreName}", pathParameters, queryParameters,
 				data)
@@ -94,25 +96,26 @@ public class GenresApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["userId"] = userId
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["sortBy"] = sortBy
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(18) {
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("searchTerm", searchTerm)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("isFavorite", isFavorite)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("userId", userId)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("sortBy", sortBy)
+			put("sortOrder", sortOrder)
+			put("enableImages", enableImages)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Genres", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
@@ -10,8 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -28,9 +28,10 @@ public class HlsSegmentApi(
 	 */
 	public suspend fun getHlsAudioSegmentLegacyAac(itemId: String, segmentId: String):
 			Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["segmentId"] = segmentId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("segmentId", segmentId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/hls/{segmentId}/stream.aac",
@@ -50,9 +51,10 @@ public class HlsSegmentApi(
 		segmentId: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["segmentId"] = segmentId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("segmentId", segmentId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Audio/{itemId}/hls/{segmentId}/stream.aac", pathParameters,
 				queryParameters, includeCredentials)
@@ -66,9 +68,10 @@ public class HlsSegmentApi(
 	 */
 	public suspend fun getHlsAudioSegmentLegacyMp3(itemId: String, segmentId: String):
 			Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["segmentId"] = segmentId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("segmentId", segmentId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/hls/{segmentId}/stream.mp3",
@@ -88,9 +91,10 @@ public class HlsSegmentApi(
 		segmentId: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["segmentId"] = segmentId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("segmentId", segmentId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Audio/{itemId}/hls/{segmentId}/stream.mp3", pathParameters,
 				queryParameters, includeCredentials)
@@ -104,9 +108,10 @@ public class HlsSegmentApi(
 	 */
 	public suspend fun getHlsPlaylistLegacy(itemId: String, playlistId: String):
 			Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/hls/{playlistId}/stream.m3u8",
@@ -126,9 +131,10 @@ public class HlsSegmentApi(
 		playlistId: String,
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Videos/{itemId}/hls/{playlistId}/stream.m3u8", pathParameters,
 				queryParameters, includeCredentials)
@@ -148,11 +154,12 @@ public class HlsSegmentApi(
 		segmentId: String,
 		segmentContainer: String,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
-		pathParameters["segmentId"] = segmentId
-		pathParameters["segmentContainer"] = segmentContainer
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+			put("segmentId", segmentId)
+			put("segmentContainer", segmentContainer)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response =
@@ -177,11 +184,12 @@ public class HlsSegmentApi(
 		segmentContainer: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["playlistId"] = playlistId
-		pathParameters["segmentId"] = segmentId
-		pathParameters["segmentContainer"] = segmentContainer
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("itemId", itemId)
+			put("playlistId", playlistId)
+			put("segmentId", segmentId)
+			put("segmentContainer", segmentContainer)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Videos/{itemId}/hls/{playlistId}/{segmentId}.{segmentContainer}",
 				pathParameters, queryParameters, includeCredentials)
@@ -196,9 +204,10 @@ public class HlsSegmentApi(
 	 */
 	public suspend fun stopEncodingProcess(deviceId: String, playSessionId: String): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["deviceId"] = deviceId
-		queryParameters["playSessionId"] = playSessionId
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("deviceId", deviceId)
+			put("playSessionId", playSessionId)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Videos/ActiveEncodings", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
@@ -15,8 +15,8 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import kotlin.require
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
@@ -55,11 +55,13 @@ public class ImageApi(
 		imageType: ImageType,
 		imageIndex: Int? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Items/{itemId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -78,10 +80,11 @@ public class ImageApi(
 		imageType: ImageType,
 		imageIndex: Int,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters,
@@ -101,11 +104,13 @@ public class ImageApi(
 		imageType: ImageType,
 		index: Int? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["index"] = index
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("index", index)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Users/{userId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -124,10 +129,11 @@ public class ImageApi(
 		imageType: ImageType,
 		index: Int,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		pathParameters["index"] = index
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("userId", userId)
+			put("imageType", imageType)
+			put("index", index)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Users/{userId}/Images/{imageType}/{index}", pathParameters,
@@ -179,26 +185,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Artists/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -251,26 +259,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Artists/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -323,27 +333,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Artists/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -400,27 +412,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Artists/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -469,26 +483,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Genres/{name}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -541,26 +557,28 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Genres/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -609,26 +627,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Genres/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -681,26 +701,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Genres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -753,27 +775,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Genres/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -830,27 +854,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Genres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -903,27 +929,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Genres/{name}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -980,27 +1008,29 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Genres/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -1049,26 +1079,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -1121,26 +1153,28 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Items/{itemId}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -1189,26 +1223,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["maxWidth"] = maxWidth
-		pathParameters["maxHeight"] = maxHeight
-		pathParameters["tag"] = tag
-		pathParameters["format"] = format
-		pathParameters["percentPlayed"] = percentPlayed
-		pathParameters["unplayedCount"] = unplayedCount
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(9) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("tag", tag)
+			put("format", format)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(9) {
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response =
 				api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
@@ -1262,26 +1298,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["maxWidth"] = maxWidth
-		pathParameters["maxHeight"] = maxHeight
-		pathParameters["tag"] = tag
-		pathParameters["format"] = format
-		pathParameters["percentPlayed"] = percentPlayed
-		pathParameters["unplayedCount"] = unplayedCount
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(9) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("tag", tag)
+			put("format", format)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(9) {
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
 				pathParameters, queryParameters, includeCredentials)
 	}
@@ -1334,27 +1372,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["maxWidth"] = maxWidth
-		pathParameters["maxHeight"] = maxHeight
-		pathParameters["tag"] = tag
-		pathParameters["format"] = format
-		pathParameters["percentPlayed"] = percentPlayed
-		pathParameters["unplayedCount"] = unplayedCount
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(9) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("tag", tag)
+			put("format", format)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(10) {
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response =
 				api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
@@ -1412,27 +1452,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["maxWidth"] = maxWidth
-		pathParameters["maxHeight"] = maxHeight
-		pathParameters["tag"] = tag
-		pathParameters["format"] = format
-		pathParameters["percentPlayed"] = percentPlayed
-		pathParameters["unplayedCount"] = unplayedCount
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(9) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("tag", tag)
+			put("format", format)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(10) {
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}",
 				pathParameters, queryParameters, includeCredentials)
 	}
@@ -1481,26 +1523,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -1553,26 +1597,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -1625,27 +1671,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("cropWhitespace", cropWhitespace)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -1702,27 +1750,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("cropWhitespace", cropWhitespace)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -1775,27 +1825,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("cropWhitespace", cropWhitespace)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -1852,27 +1904,29 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["tag"] = tag
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["format"] = format
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("tag", tag)
+			put("cropWhitespace", cropWhitespace)
+			put("format", format)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Items/{itemId}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -1883,8 +1937,9 @@ public class ImageApi(
 	 * @param itemId Item id.
 	 */
 	public suspend fun getItemImageInfos(itemId: UUID): Response<List<ImageInfo>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<List<ImageInfo>>("/Items/{itemId}/Images", pathParameters,
@@ -1936,26 +1991,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/MusicGenres/{name}/Images/{imageType}",
 				pathParameters, queryParameters, data)
@@ -2008,26 +2065,28 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/MusicGenres/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -2076,26 +2135,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/MusicGenres/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -2148,26 +2209,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/MusicGenres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -2220,27 +2283,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/MusicGenres/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -2297,27 +2362,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/MusicGenres/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -2370,27 +2437,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/MusicGenres/{name}/Images/{imageType}",
 				pathParameters, queryParameters, data)
@@ -2447,27 +2516,29 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/MusicGenres/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -2516,26 +2587,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Persons/{name}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -2588,26 +2661,28 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Persons/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -2656,26 +2731,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Persons/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -2728,26 +2805,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Persons/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -2800,27 +2879,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Persons/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -2877,27 +2958,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Persons/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -2950,27 +3033,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Persons/{name}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -3027,27 +3112,29 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Persons/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -3083,20 +3170,21 @@ public class ImageApi(
 		quality: Int? = 90,
 	): Response<ByteReadChannel> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
 		require(quality in 0..100) { "Parameter \"quality\" must be in range 0..100 (inclusive)." }
-		queryParameters["quality"] = quality
+		val queryParameters = buildMap<String, Any?>(12) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("quality", quality)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Branding/Splashscreen", pathParameters,
 				queryParameters, data)
@@ -3136,20 +3224,21 @@ public class ImageApi(
 		includeCredentials: Boolean = false,
 	): String {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
 		require(quality in 0..100) { "Parameter \"quality\" must be in range 0..100 (inclusive)." }
-		queryParameters["quality"] = quality
+		val queryParameters = buildMap<String, Any?>(12) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("width", width)
+			put("height", height)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("quality", quality)
+		}
 		return api.createUrl("/Branding/Splashscreen", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -3198,26 +3287,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Studios/{name}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -3270,26 +3361,28 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Studios/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -3338,26 +3431,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Studios/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -3410,26 +3505,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Studios/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -3482,27 +3579,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Studios/{name}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -3559,27 +3658,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Studios/{name}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -3632,27 +3733,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Studios/{name}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -3709,27 +3812,29 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Studios/{name}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -3778,26 +3883,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Users/{userId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -3850,26 +3957,28 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Users/{userId}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -3918,26 +4027,28 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("userId", userId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Users/{userId}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -3990,26 +4101,28 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("userId", userId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Users/{userId}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -4062,27 +4175,29 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("userId", userId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Users/{userId}/Images/{imageType}/{imageIndex}",
 				pathParameters, queryParameters, data)
@@ -4139,27 +4254,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("userId", userId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+		}
 		return api.createUrl("/Users/{userId}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, includeCredentials)
 	}
@@ -4212,27 +4329,29 @@ public class ImageApi(
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Users/{userId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -4289,27 +4408,29 @@ public class ImageApi(
 		imageIndex: Int? = null,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tag"] = tag
-		queryParameters["format"] = format
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["percentPlayed"] = percentPlayed
-		queryParameters["unplayedCount"] = unplayedCount
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["quality"] = quality
-		queryParameters["fillWidth"] = fillWidth
-		queryParameters["fillHeight"] = fillHeight
-		queryParameters["cropWhitespace"] = cropWhitespace
-		queryParameters["addPlayedIndicator"] = addPlayedIndicator
-		queryParameters["blur"] = blur
-		queryParameters["backgroundColor"] = backgroundColor
-		queryParameters["foregroundLayer"] = foregroundLayer
-		queryParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("tag", tag)
+			put("format", format)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("percentPlayed", percentPlayed)
+			put("unplayedCount", unplayedCount)
+			put("width", width)
+			put("height", height)
+			put("quality", quality)
+			put("fillWidth", fillWidth)
+			put("fillHeight", fillHeight)
+			put("cropWhitespace", cropWhitespace)
+			put("addPlayedIndicator", addPlayedIndicator)
+			put("blur", blur)
+			put("backgroundColor", backgroundColor)
+			put("foregroundLayer", foregroundLayer)
+			put("imageIndex", imageIndex)
+		}
 		return api.createUrl("/Users/{userId}/Images/{imageType}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -4327,11 +4448,13 @@ public class ImageApi(
 		index: Int? = null,
 		`data`: ByteArray,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["index"] = index
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("imageType", imageType)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("index", index)
+		}
 		val response = api.post<Unit>("/Users/{userId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
 		return response
@@ -4350,10 +4473,11 @@ public class ImageApi(
 		index: Int,
 		`data`: ByteArray,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["imageType"] = imageType
-		pathParameters["index"] = index
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("userId", userId)
+			put("imageType", imageType)
+			put("index", index)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Users/{userId}/Images/{imageType}/{index}", pathParameters,
 				queryParameters, data)
@@ -4371,9 +4495,10 @@ public class ImageApi(
 		imageType: ImageType,
 		`data`: ByteArray,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Items/{itemId}/Images/{imageType}", pathParameters,
 				queryParameters, data)
@@ -4393,10 +4518,11 @@ public class ImageApi(
 		imageIndex: Int,
 		`data`: ByteArray,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters,
 				queryParameters, data)
@@ -4417,12 +4543,14 @@ public class ImageApi(
 		imageIndex: Int,
 		newIndex: Int,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["imageType"] = imageType
-		pathParameters["imageIndex"] = imageIndex
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["newIndex"] = newIndex
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("imageType", imageType)
+			put("imageIndex", imageIndex)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("newIndex", newIndex)
+		}
 		val data = null
 		val response = api.post<Unit>("/Items/{itemId}/Images/{imageType}/{imageIndex}/Index",
 				pathParameters, queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageByNameApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageByNameApi.kt
@@ -10,8 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -27,9 +27,10 @@ public class ImageByNameApi(
 	 * @param type Image Type (primary, backdrop, logo, etc).
 	 */
 	public suspend fun getGeneralImage(name: String, type: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["type"] = type
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("type", type)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Images/General/{name}/{type}", pathParameters,
@@ -49,9 +50,10 @@ public class ImageByNameApi(
 		type: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		pathParameters["type"] = type
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("type", type)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Images/General/{name}/{type}", pathParameters, queryParameters,
 				includeCredentials)
@@ -76,9 +78,10 @@ public class ImageByNameApi(
 	 * @param name The name of the image.
 	 */
 	public suspend fun getMediaInfoImage(theme: String, name: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["theme"] = theme
-		pathParameters["name"] = name
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("theme", theme)
+			put("name", name)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Images/MediaInfo/{theme}/{name}", pathParameters,
@@ -98,9 +101,10 @@ public class ImageByNameApi(
 		name: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["theme"] = theme
-		pathParameters["name"] = name
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("theme", theme)
+			put("name", name)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Images/MediaInfo/{theme}/{name}", pathParameters, queryParameters,
 				includeCredentials)
@@ -125,9 +129,10 @@ public class ImageByNameApi(
 	 * @param name The name of the image.
 	 */
 	public suspend fun getRatingImage(theme: String, name: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["theme"] = theme
-		pathParameters["name"] = name
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("theme", theme)
+			put("name", name)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Images/Ratings/{theme}/{name}", pathParameters,
@@ -147,9 +152,10 @@ public class ImageByNameApi(
 		name: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["theme"] = theme
-		pathParameters["name"] = name
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("theme", theme)
+			put("name", name)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Images/Ratings/{theme}/{name}", pathParameters, queryParameters,
 				includeCredentials)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/InstantMixApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/InstantMixApi.kt
@@ -11,9 +11,9 @@ import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -47,16 +47,18 @@ public class InstantMixApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["id"] = id
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Albums/{id}/InstantMix", pathParameters,
 				queryParameters, data)
@@ -85,16 +87,18 @@ public class InstantMixApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["id"] = id
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Artists/{id}/InstantMix", pathParameters,
 				queryParameters, data)
@@ -125,15 +129,16 @@ public class InstantMixApi(
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val queryParameters = buildMap<String, Any?>(8) {
+			put("id", id)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Artists/InstantMix", pathParameters,
 				queryParameters, data)
@@ -162,16 +167,18 @@ public class InstantMixApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["id"] = id
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Items/{id}/InstantMix", pathParameters,
 				queryParameters, data)
@@ -201,15 +208,16 @@ public class InstantMixApi(
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val queryParameters = buildMap<String, Any?>(8) {
+			put("id", id)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/MusicGenres/InstantMix", pathParameters,
 				queryParameters, data)
@@ -238,16 +246,18 @@ public class InstantMixApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/MusicGenres/{name}/InstantMix", pathParameters,
 				queryParameters, data)
@@ -276,16 +286,18 @@ public class InstantMixApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["id"] = id
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Playlists/{id}/InstantMix", pathParameters,
 				queryParameters, data)
@@ -314,16 +326,18 @@ public class InstantMixApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["id"] = id
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Songs/{id}/InstantMix", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemLookupApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemLookupApi.kt
@@ -10,8 +10,8 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -43,10 +43,12 @@ public class ItemLookupApi(
 		replaceAllImages: Boolean? = true,
 		`data`: RemoteSearchResult,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["replaceAllImages"] = replaceAllImages
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("replaceAllImages", replaceAllImages)
+		}
 		val response = api.post<Unit>("/Items/RemoteSearch/Apply/{itemId}", pathParameters,
 				queryParameters, data)
 		return response
@@ -82,8 +84,9 @@ public class ItemLookupApi(
 	 * @param itemId Item id.
 	 */
 	public suspend fun getExternalIdInfos(itemId: UUID): Response<List<ExternalIdInfo>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<List<ExternalIdInfo>>("/Items/{itemId}/ExternalIdInfos", pathParameters,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemRefreshApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemRefreshApi.kt
@@ -9,7 +9,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
-import kotlin.collections.mutableMapOf
+import kotlin.collections.buildMap
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.post
@@ -37,13 +37,15 @@ public class ItemRefreshApi(
 		replaceAllMetadata: Boolean? = false,
 		replaceAllImages: Boolean? = false,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["metadataRefreshMode"] = metadataRefreshMode
-		queryParameters["imageRefreshMode"] = imageRefreshMode
-		queryParameters["replaceAllMetadata"] = replaceAllMetadata
-		queryParameters["replaceAllImages"] = replaceAllImages
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("metadataRefreshMode", metadataRefreshMode)
+			put("imageRefreshMode", imageRefreshMode)
+			put("replaceAllMetadata", replaceAllMetadata)
+			put("replaceAllImages", replaceAllImages)
+		}
 		val data = null
 		val response = api.post<Unit>("/Items/{itemId}/Refresh", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemUpdateApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemUpdateApi.kt
@@ -8,8 +8,8 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -27,8 +27,9 @@ public class ItemUpdateApi(
 	 * @param itemId The item id.
 	 */
 	public suspend fun getMetadataEditorInfo(itemId: UUID): Response<MetadataEditorInfo> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<MetadataEditorInfo>("/Items/{itemId}/MetadataEditor", pathParameters,
@@ -42,8 +43,9 @@ public class ItemUpdateApi(
 	 * @param itemId The item id.
 	 */
 	public suspend fun updateItem(itemId: UUID, `data`: BaseItemDto): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Items/{itemId}", pathParameters, queryParameters, data)
 		return response
@@ -57,10 +59,12 @@ public class ItemUpdateApi(
 	 */
 	public suspend fun updateItemContentType(itemId: UUID, contentType: String? = null):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["contentType"] = contentType
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("contentType", contentType)
+		}
 		val data = null
 		val response = api.post<Unit>("/Items/{itemId}/ContentType", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemsApi.kt
@@ -11,9 +11,9 @@ import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -250,92 +250,93 @@ public class ItemsApi(
 		enableImages: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["maxOfficialRating"] = maxOfficialRating
-		queryParameters["hasThemeSong"] = hasThemeSong
-		queryParameters["hasThemeVideo"] = hasThemeVideo
-		queryParameters["hasSubtitles"] = hasSubtitles
-		queryParameters["hasSpecialFeature"] = hasSpecialFeature
-		queryParameters["hasTrailer"] = hasTrailer
-		queryParameters["adjacentTo"] = adjacentTo
-		queryParameters["parentIndexNumber"] = parentIndexNumber
-		queryParameters["hasParentalRating"] = hasParentalRating
-		queryParameters["isHd"] = isHd
-		queryParameters["is4K"] = is4k
-		queryParameters["locationTypes"] = locationTypes
-		queryParameters["excludeLocationTypes"] = excludeLocationTypes
-		queryParameters["isMissing"] = isMissing
-		queryParameters["isUnaired"] = isUnaired
-		queryParameters["minCommunityRating"] = minCommunityRating
-		queryParameters["minCriticRating"] = minCriticRating
-		queryParameters["minPremiereDate"] = minPremiereDate
-		queryParameters["minDateLastSaved"] = minDateLastSaved
-		queryParameters["minDateLastSavedForUser"] = minDateLastSavedForUser
-		queryParameters["maxPremiereDate"] = maxPremiereDate
-		queryParameters["hasOverview"] = hasOverview
-		queryParameters["hasImdbId"] = hasImdbId
-		queryParameters["hasTmdbId"] = hasTmdbId
-		queryParameters["hasTvdbId"] = hasTvdbId
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isNews"] = isNews
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["excludeItemIds"] = excludeItemIds
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["recursive"] = recursive
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["filters"] = filters
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["imageTypes"] = imageTypes
-		queryParameters["sortBy"] = sortBy
-		queryParameters["isPlayed"] = isPlayed
-		queryParameters["genres"] = genres
-		queryParameters["officialRatings"] = officialRatings
-		queryParameters["tags"] = tags
-		queryParameters["years"] = years
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["person"] = person
-		queryParameters["personIds"] = personIds
-		queryParameters["personTypes"] = personTypes
-		queryParameters["studios"] = studios
-		queryParameters["artists"] = artists
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["artistIds"] = artistIds
-		queryParameters["albumArtistIds"] = albumArtistIds
-		queryParameters["contributingArtistIds"] = contributingArtistIds
-		queryParameters["albums"] = albums
-		queryParameters["albumIds"] = albumIds
-		queryParameters["ids"] = ids
-		queryParameters["videoTypes"] = videoTypes
-		queryParameters["minOfficialRating"] = minOfficialRating
-		queryParameters["isLocked"] = isLocked
-		queryParameters["isPlaceHolder"] = isPlaceHolder
-		queryParameters["hasOfficialRating"] = hasOfficialRating
-		queryParameters["collapseBoxSetItems"] = collapseBoxSetItems
-		queryParameters["minWidth"] = minWidth
-		queryParameters["minHeight"] = minHeight
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["is3D"] = is3d
-		queryParameters["seriesStatus"] = seriesStatus
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["studioIds"] = studioIds
-		queryParameters["genreIds"] = genreIds
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
-		queryParameters["enableImages"] = enableImages
+		val queryParameters = buildMap<String, Any?>(85) {
+			put("userId", userId)
+			put("maxOfficialRating", maxOfficialRating)
+			put("hasThemeSong", hasThemeSong)
+			put("hasThemeVideo", hasThemeVideo)
+			put("hasSubtitles", hasSubtitles)
+			put("hasSpecialFeature", hasSpecialFeature)
+			put("hasTrailer", hasTrailer)
+			put("adjacentTo", adjacentTo)
+			put("parentIndexNumber", parentIndexNumber)
+			put("hasParentalRating", hasParentalRating)
+			put("isHd", isHd)
+			put("is4K", is4k)
+			put("locationTypes", locationTypes)
+			put("excludeLocationTypes", excludeLocationTypes)
+			put("isMissing", isMissing)
+			put("isUnaired", isUnaired)
+			put("minCommunityRating", minCommunityRating)
+			put("minCriticRating", minCriticRating)
+			put("minPremiereDate", minPremiereDate)
+			put("minDateLastSaved", minDateLastSaved)
+			put("minDateLastSavedForUser", minDateLastSavedForUser)
+			put("maxPremiereDate", maxPremiereDate)
+			put("hasOverview", hasOverview)
+			put("hasImdbId", hasImdbId)
+			put("hasTmdbId", hasTmdbId)
+			put("hasTvdbId", hasTvdbId)
+			put("isMovie", isMovie)
+			put("isSeries", isSeries)
+			put("isNews", isNews)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("excludeItemIds", excludeItemIds)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("recursive", recursive)
+			put("searchTerm", searchTerm)
+			put("sortOrder", sortOrder)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("filters", filters)
+			put("isFavorite", isFavorite)
+			put("mediaTypes", mediaTypes)
+			put("imageTypes", imageTypes)
+			put("sortBy", sortBy)
+			put("isPlayed", isPlayed)
+			put("genres", genres)
+			put("officialRatings", officialRatings)
+			put("tags", tags)
+			put("years", years)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("person", person)
+			put("personIds", personIds)
+			put("personTypes", personTypes)
+			put("studios", studios)
+			put("artists", artists)
+			put("excludeArtistIds", excludeArtistIds)
+			put("artistIds", artistIds)
+			put("albumArtistIds", albumArtistIds)
+			put("contributingArtistIds", contributingArtistIds)
+			put("albums", albums)
+			put("albumIds", albumIds)
+			put("ids", ids)
+			put("videoTypes", videoTypes)
+			put("minOfficialRating", minOfficialRating)
+			put("isLocked", isLocked)
+			put("isPlaceHolder", isPlaceHolder)
+			put("hasOfficialRating", hasOfficialRating)
+			put("collapseBoxSetItems", collapseBoxSetItems)
+			put("minWidth", minWidth)
+			put("minHeight", minHeight)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("is3D", is3d)
+			put("seriesStatus", seriesStatus)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("studioIds", studioIds)
+			put("genreIds", genreIds)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+			put("enableImages", enableImages)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Items", pathParameters, queryParameters, data)
 		return response
@@ -557,93 +558,95 @@ public class ItemsApi(
 		enableTotalRecordCount: Boolean? = true,
 		enableImages: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["maxOfficialRating"] = maxOfficialRating
-		queryParameters["hasThemeSong"] = hasThemeSong
-		queryParameters["hasThemeVideo"] = hasThemeVideo
-		queryParameters["hasSubtitles"] = hasSubtitles
-		queryParameters["hasSpecialFeature"] = hasSpecialFeature
-		queryParameters["hasTrailer"] = hasTrailer
-		queryParameters["adjacentTo"] = adjacentTo
-		queryParameters["parentIndexNumber"] = parentIndexNumber
-		queryParameters["hasParentalRating"] = hasParentalRating
-		queryParameters["isHd"] = isHd
-		queryParameters["is4K"] = is4k
-		queryParameters["locationTypes"] = locationTypes
-		queryParameters["excludeLocationTypes"] = excludeLocationTypes
-		queryParameters["isMissing"] = isMissing
-		queryParameters["isUnaired"] = isUnaired
-		queryParameters["minCommunityRating"] = minCommunityRating
-		queryParameters["minCriticRating"] = minCriticRating
-		queryParameters["minPremiereDate"] = minPremiereDate
-		queryParameters["minDateLastSaved"] = minDateLastSaved
-		queryParameters["minDateLastSavedForUser"] = minDateLastSavedForUser
-		queryParameters["maxPremiereDate"] = maxPremiereDate
-		queryParameters["hasOverview"] = hasOverview
-		queryParameters["hasImdbId"] = hasImdbId
-		queryParameters["hasTmdbId"] = hasTmdbId
-		queryParameters["hasTvdbId"] = hasTvdbId
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isNews"] = isNews
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["excludeItemIds"] = excludeItemIds
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["recursive"] = recursive
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["filters"] = filters
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["imageTypes"] = imageTypes
-		queryParameters["sortBy"] = sortBy
-		queryParameters["isPlayed"] = isPlayed
-		queryParameters["genres"] = genres
-		queryParameters["officialRatings"] = officialRatings
-		queryParameters["tags"] = tags
-		queryParameters["years"] = years
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["person"] = person
-		queryParameters["personIds"] = personIds
-		queryParameters["personTypes"] = personTypes
-		queryParameters["studios"] = studios
-		queryParameters["artists"] = artists
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["artistIds"] = artistIds
-		queryParameters["albumArtistIds"] = albumArtistIds
-		queryParameters["contributingArtistIds"] = contributingArtistIds
-		queryParameters["albums"] = albums
-		queryParameters["albumIds"] = albumIds
-		queryParameters["ids"] = ids
-		queryParameters["videoTypes"] = videoTypes
-		queryParameters["minOfficialRating"] = minOfficialRating
-		queryParameters["isLocked"] = isLocked
-		queryParameters["isPlaceHolder"] = isPlaceHolder
-		queryParameters["hasOfficialRating"] = hasOfficialRating
-		queryParameters["collapseBoxSetItems"] = collapseBoxSetItems
-		queryParameters["minWidth"] = minWidth
-		queryParameters["minHeight"] = minHeight
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["is3D"] = is3d
-		queryParameters["seriesStatus"] = seriesStatus
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["studioIds"] = studioIds
-		queryParameters["genreIds"] = genreIds
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
-		queryParameters["enableImages"] = enableImages
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
+		val queryParameters = buildMap<String, Any?>(84) {
+			put("maxOfficialRating", maxOfficialRating)
+			put("hasThemeSong", hasThemeSong)
+			put("hasThemeVideo", hasThemeVideo)
+			put("hasSubtitles", hasSubtitles)
+			put("hasSpecialFeature", hasSpecialFeature)
+			put("hasTrailer", hasTrailer)
+			put("adjacentTo", adjacentTo)
+			put("parentIndexNumber", parentIndexNumber)
+			put("hasParentalRating", hasParentalRating)
+			put("isHd", isHd)
+			put("is4K", is4k)
+			put("locationTypes", locationTypes)
+			put("excludeLocationTypes", excludeLocationTypes)
+			put("isMissing", isMissing)
+			put("isUnaired", isUnaired)
+			put("minCommunityRating", minCommunityRating)
+			put("minCriticRating", minCriticRating)
+			put("minPremiereDate", minPremiereDate)
+			put("minDateLastSaved", minDateLastSaved)
+			put("minDateLastSavedForUser", minDateLastSavedForUser)
+			put("maxPremiereDate", maxPremiereDate)
+			put("hasOverview", hasOverview)
+			put("hasImdbId", hasImdbId)
+			put("hasTmdbId", hasTmdbId)
+			put("hasTvdbId", hasTvdbId)
+			put("isMovie", isMovie)
+			put("isSeries", isSeries)
+			put("isNews", isNews)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("excludeItemIds", excludeItemIds)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("recursive", recursive)
+			put("searchTerm", searchTerm)
+			put("sortOrder", sortOrder)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("filters", filters)
+			put("isFavorite", isFavorite)
+			put("mediaTypes", mediaTypes)
+			put("imageTypes", imageTypes)
+			put("sortBy", sortBy)
+			put("isPlayed", isPlayed)
+			put("genres", genres)
+			put("officialRatings", officialRatings)
+			put("tags", tags)
+			put("years", years)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("person", person)
+			put("personIds", personIds)
+			put("personTypes", personTypes)
+			put("studios", studios)
+			put("artists", artists)
+			put("excludeArtistIds", excludeArtistIds)
+			put("artistIds", artistIds)
+			put("albumArtistIds", albumArtistIds)
+			put("contributingArtistIds", contributingArtistIds)
+			put("albums", albums)
+			put("albumIds", albumIds)
+			put("ids", ids)
+			put("videoTypes", videoTypes)
+			put("minOfficialRating", minOfficialRating)
+			put("isLocked", isLocked)
+			put("isPlaceHolder", isPlaceHolder)
+			put("hasOfficialRating", hasOfficialRating)
+			put("collapseBoxSetItems", collapseBoxSetItems)
+			put("minWidth", minWidth)
+			put("minHeight", minHeight)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("is3D", is3d)
+			put("seriesStatus", seriesStatus)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("studioIds", studioIds)
+			put("genreIds", genreIds)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+			put("enableImages", enableImages)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Users/{userId}/Items", pathParameters,
 				queryParameters, data)
@@ -692,23 +695,25 @@ public class ItemsApi(
 		enableImages: Boolean? = true,
 		excludeActiveSessions: Boolean? = false,
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
-		queryParameters["enableImages"] = enableImages
-		queryParameters["excludeActiveSessions"] = excludeActiveSessions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
+		val queryParameters = buildMap<String, Any?>(14) {
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("searchTerm", searchTerm)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("mediaTypes", mediaTypes)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+			put("enableImages", enableImages)
+			put("excludeActiveSessions", excludeActiveSessions)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Users/{userId}/Items/Resume", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
@@ -14,9 +14,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -41,8 +41,9 @@ public class LibraryApi(
 	 * @param itemId The item id.
 	 */
 	public suspend fun deleteItem(itemId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Items/{itemId}", pathParameters, queryParameters, data)
@@ -56,8 +57,9 @@ public class LibraryApi(
 	 */
 	public suspend fun deleteItems(ids: Collection<UUID>? = emptyList()): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["ids"] = ids
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("ids", ids)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Items", pathParameters, queryParameters, data)
 		return response
@@ -70,10 +72,12 @@ public class LibraryApi(
 	 * @param userId Optional. Filter by user id, and attach user data.
 	 */
 	public suspend fun getAncestors(itemId: UUID, userId: UUID? = null): Response<List<BaseItemDto>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<List<BaseItemDto>>("/Items/{itemId}/Ancestors", pathParameters,
 				queryParameters, data)
@@ -85,8 +89,9 @@ public class LibraryApi(
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
 	public suspend fun getCriticReviews(itemId: String): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Items/{itemId}/CriticReviews", pathParameters,
@@ -100,8 +105,9 @@ public class LibraryApi(
 	 * @param itemId The item id.
 	 */
 	public suspend fun getDownload(itemId: UUID): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Download", pathParameters,
@@ -116,8 +122,9 @@ public class LibraryApi(
 	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getDownloadUrl(itemId: UUID, includeCredentials: Boolean = false): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Items/{itemId}/Download", pathParameters, queryParameters,
 				includeCredentials)
@@ -129,8 +136,9 @@ public class LibraryApi(
 	 * @param itemId The item id.
 	 */
 	public suspend fun getFile(itemId: UUID): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/File", pathParameters, queryParameters,
@@ -145,8 +153,9 @@ public class LibraryApi(
 	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getFileUrl(itemId: UUID, includeCredentials: Boolean = true): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Items/{itemId}/File", pathParameters, queryParameters, includeCredentials)
 	}
@@ -160,9 +169,10 @@ public class LibraryApi(
 	public suspend fun getItemCounts(userId: UUID? = null, isFavorite: Boolean? = null):
 			Response<ItemCounts> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["isFavorite"] = isFavorite
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("isFavorite", isFavorite)
+		}
 		val data = null
 		val response = api.`get`<ItemCounts>("/Items/Counts", pathParameters, queryParameters, data)
 		return response
@@ -177,9 +187,10 @@ public class LibraryApi(
 	public suspend fun getLibraryOptionsInfo(libraryContentType: String? = null, isNewLibrary: Boolean?
 			= false): Response<LibraryOptionsResultDto> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["libraryContentType"] = libraryContentType
-		queryParameters["isNewLibrary"] = isNewLibrary
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("libraryContentType", libraryContentType)
+			put("isNewLibrary", isNewLibrary)
+		}
 		val data = null
 		val response = api.`get`<LibraryOptionsResultDto>("/Libraries/AvailableOptions", pathParameters,
 				queryParameters, data)
@@ -193,8 +204,9 @@ public class LibraryApi(
 	 */
 	public suspend fun getMediaFolders(isHidden: Boolean? = null): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["isHidden"] = isHidden
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("isHidden", isHidden)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Library/MediaFolders", pathParameters,
 				queryParameters, data)
@@ -232,13 +244,15 @@ public class LibraryApi(
 		limit: Int? = null,
 		fields: Collection<ItemFields>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("excludeArtistIds", excludeArtistIds)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Albums/{itemId}/Similar", pathParameters,
 				queryParameters, data)
@@ -264,13 +278,15 @@ public class LibraryApi(
 		limit: Int? = null,
 		fields: Collection<ItemFields>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("excludeArtistIds", excludeArtistIds)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Artists/{itemId}/Similar", pathParameters,
 				queryParameters, data)
@@ -296,13 +312,15 @@ public class LibraryApi(
 		limit: Int? = null,
 		fields: Collection<ItemFields>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("excludeArtistIds", excludeArtistIds)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Items/{itemId}/Similar", pathParameters,
 				queryParameters, data)
@@ -328,13 +346,15 @@ public class LibraryApi(
 		limit: Int? = null,
 		fields: Collection<ItemFields>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("excludeArtistIds", excludeArtistIds)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Movies/{itemId}/Similar", pathParameters,
 				queryParameters, data)
@@ -360,13 +380,15 @@ public class LibraryApi(
 		limit: Int? = null,
 		fields: Collection<ItemFields>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("excludeArtistIds", excludeArtistIds)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Shows/{itemId}/Similar", pathParameters,
 				queryParameters, data)
@@ -392,13 +414,15 @@ public class LibraryApi(
 		limit: Int? = null,
 		fields: Collection<ItemFields>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("excludeArtistIds", excludeArtistIds)
+			put("userId", userId)
+			put("limit", limit)
+			put("fields", fields)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Trailers/{itemId}/Similar", pathParameters,
 				queryParameters, data)
@@ -418,11 +442,13 @@ public class LibraryApi(
 		userId: UUID? = null,
 		inheritFromParent: Boolean? = false,
 	): Response<AllThemeMediaResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["inheritFromParent"] = inheritFromParent
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("inheritFromParent", inheritFromParent)
+		}
 		val data = null
 		val response = api.`get`<AllThemeMediaResult>("/Items/{itemId}/ThemeMedia", pathParameters,
 				queryParameters, data)
@@ -442,11 +468,13 @@ public class LibraryApi(
 		userId: UUID? = null,
 		inheritFromParent: Boolean? = false,
 	): Response<ThemeMediaResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["inheritFromParent"] = inheritFromParent
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("inheritFromParent", inheritFromParent)
+		}
 		val data = null
 		val response = api.`get`<ThemeMediaResult>("/Items/{itemId}/ThemeSongs", pathParameters,
 				queryParameters, data)
@@ -466,11 +494,13 @@ public class LibraryApi(
 		userId: UUID? = null,
 		inheritFromParent: Boolean? = false,
 	): Response<ThemeMediaResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["inheritFromParent"] = inheritFromParent
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("inheritFromParent", inheritFromParent)
+		}
 		val data = null
 		val response = api.`get`<ThemeMediaResult>("/Items/{itemId}/ThemeVideos", pathParameters,
 				queryParameters, data)
@@ -486,9 +516,10 @@ public class LibraryApi(
 	public suspend fun postAddedMovies(tmdbId: String? = null, imdbId: String? = null):
 			Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tmdbId"] = tmdbId
-		queryParameters["imdbId"] = imdbId
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("tmdbId", tmdbId)
+			put("imdbId", imdbId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Library/Movies/Added", pathParameters, queryParameters, data)
 		return response
@@ -501,8 +532,9 @@ public class LibraryApi(
 	 */
 	public suspend fun postAddedSeries(tvdbId: String? = null): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tvdbId"] = tvdbId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("tvdbId", tvdbId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Library/Series/Added", pathParameters, queryParameters, data)
 		return response
@@ -527,9 +559,10 @@ public class LibraryApi(
 	public suspend fun postUpdatedMovies(tmdbId: String? = null, imdbId: String? = null):
 			Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tmdbId"] = tmdbId
-		queryParameters["imdbId"] = imdbId
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("tmdbId", tmdbId)
+			put("imdbId", imdbId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Library/Movies/Updated", pathParameters, queryParameters, data)
 		return response
@@ -542,8 +575,9 @@ public class LibraryApi(
 	 */
 	public suspend fun postUpdatedSeries(tvdbId: String? = null): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["tvdbId"] = tvdbId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("tvdbId", tvdbId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Library/Series/Updated", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryStructureApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryStructureApi.kt
@@ -11,9 +11,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -37,8 +37,9 @@ public class LibraryStructureApi(
 	public suspend fun addMediaPath(refreshLibrary: Boolean? = false, `data`: MediaPathDto):
 			Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["refreshLibrary"] = refreshLibrary
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("refreshLibrary", refreshLibrary)
+		}
 		val response = api.post<Unit>("/Library/VirtualFolders/Paths", pathParameters, queryParameters,
 				data)
 		return response
@@ -60,11 +61,12 @@ public class LibraryStructureApi(
 		`data`: AddVirtualFolderDto? = null,
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
-		queryParameters["collectionType"] = collectionType
-		queryParameters["paths"] = paths
-		queryParameters["refreshLibrary"] = refreshLibrary
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("name", name)
+			put("collectionType", collectionType)
+			put("paths", paths)
+			put("refreshLibrary", refreshLibrary)
+		}
 		val response = api.post<Unit>("/Library/VirtualFolders", pathParameters, queryParameters, data)
 		return response
 	}
@@ -94,10 +96,11 @@ public class LibraryStructureApi(
 		refreshLibrary: Boolean? = false,
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
-		queryParameters["path"] = path
-		queryParameters["refreshLibrary"] = refreshLibrary
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("path", path)
+			put("refreshLibrary", refreshLibrary)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Library/VirtualFolders/Paths", pathParameters, queryParameters,
 				data)
@@ -113,9 +116,10 @@ public class LibraryStructureApi(
 	public suspend fun removeVirtualFolder(name: String? = null, refreshLibrary: Boolean? = false):
 			Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
-		queryParameters["refreshLibrary"] = refreshLibrary
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("name", name)
+			put("refreshLibrary", refreshLibrary)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Library/VirtualFolders", pathParameters, queryParameters, data)
 		return response
@@ -134,10 +138,11 @@ public class LibraryStructureApi(
 		refreshLibrary: Boolean? = false,
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
-		queryParameters["newName"] = newName
-		queryParameters["refreshLibrary"] = refreshLibrary
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("name", name)
+			put("newName", newName)
+			put("refreshLibrary", refreshLibrary)
+		}
 		val data = null
 		val response = api.post<Unit>("/Library/VirtualFolders/Name", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
@@ -14,9 +14,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -62,10 +62,11 @@ public class LiveTvApi(
 		`data`: ListingsProviderInfo? = null,
 	): Response<ListingsProviderInfo> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["pw"] = pw
-		queryParameters["validateListings"] = validateListings
-		queryParameters["validateLogin"] = validateLogin
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("pw", pw)
+			put("validateListings", validateListings)
+			put("validateLogin", validateLogin)
+		}
 		val response = api.post<ListingsProviderInfo>("/LiveTv/ListingProviders", pathParameters,
 				queryParameters, data)
 		return response
@@ -88,8 +89,9 @@ public class LiveTvApi(
 	 * @param timerId Timer id.
 	 */
 	public suspend fun cancelSeriesTimer(timerId: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["timerId"] = timerId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("timerId", timerId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/LiveTv/SeriesTimers/{timerId}", pathParameters, queryParameters,
@@ -103,8 +105,9 @@ public class LiveTvApi(
 	 * @param timerId Timer id.
 	 */
 	public suspend fun cancelTimer(timerId: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["timerId"] = timerId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("timerId", timerId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/LiveTv/Timers/{timerId}", pathParameters, queryParameters, data)
@@ -138,8 +141,9 @@ public class LiveTvApi(
 	 */
 	public suspend fun deleteListingProvider(id: String? = null): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val data = null
 		val response = api.delete<Unit>("/LiveTv/ListingProviders", pathParameters, queryParameters, data)
 		return response
@@ -151,8 +155,9 @@ public class LiveTvApi(
 	 * @param recordingId Recording id.
 	 */
 	public suspend fun deleteRecording(recordingId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["recordingId"] = recordingId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("recordingId", recordingId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/LiveTv/Recordings/{recordingId}", pathParameters,
@@ -167,8 +172,9 @@ public class LiveTvApi(
 	 */
 	public suspend fun deleteTunerHost(id: String? = null): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val data = null
 		val response = api.delete<Unit>("/LiveTv/TunerHosts", pathParameters, queryParameters, data)
 		return response
@@ -182,8 +188,9 @@ public class LiveTvApi(
 	public suspend fun discoverTuners(newDevicesOnly: Boolean? = false):
 			Response<List<TunerHostInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["newDevicesOnly"] = newDevicesOnly
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("newDevicesOnly", newDevicesOnly)
+		}
 		val data = null
 		val response = api.`get`<List<TunerHostInfo>>("/LiveTv/Tuners/Discover", pathParameters,
 				queryParameters, data)
@@ -198,8 +205,9 @@ public class LiveTvApi(
 	public suspend fun discvoverTuners(newDevicesOnly: Boolean? = false):
 			Response<List<TunerHostInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["newDevicesOnly"] = newDevicesOnly
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("newDevicesOnly", newDevicesOnly)
+		}
 		val data = null
 		val response = api.`get`<List<TunerHostInfo>>("/LiveTv/Tuners/Discvover", pathParameters,
 				queryParameters, data)
@@ -213,10 +221,12 @@ public class LiveTvApi(
 	 * @param userId Optional. Attach user data.
 	 */
 	public suspend fun getChannel(channelId: UUID, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["channelId"] = channelId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("channelId", channelId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/LiveTv/Channels/{channelId}", pathParameters,
 				queryParameters, data)
@@ -231,8 +241,9 @@ public class LiveTvApi(
 	public suspend fun getChannelMappingOptions(providerId: String? = null):
 			Response<ChannelMappingOptionsDto> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["providerId"] = providerId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("providerId", providerId)
+		}
 		val data = null
 		val response = api.`get`<ChannelMappingOptionsDto>("/LiveTv/ChannelMappingOptions",
 				pathParameters, queryParameters, data)
@@ -258,8 +269,9 @@ public class LiveTvApi(
 	 */
 	public suspend fun getDefaultTimer(programId: String? = null): Response<SeriesTimerInfoDto> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["programId"] = programId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("programId", programId)
+		}
 		val data = null
 		val response = api.`get`<SeriesTimerInfoDto>("/LiveTv/Timers/Defaults", pathParameters,
 				queryParameters, data)
@@ -292,11 +304,12 @@ public class LiveTvApi(
 		country: String? = null,
 	): Response<List<NameIdPair>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
-		queryParameters["type"] = type
-		queryParameters["location"] = location
-		queryParameters["country"] = country
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("id", id)
+			put("type", type)
+			put("location", location)
+			put("country", country)
+		}
 		val data = null
 		val response = api.`get`<List<NameIdPair>>("/LiveTv/ListingProviders/Lineups", pathParameters,
 				queryParameters, data)
@@ -309,8 +322,9 @@ public class LiveTvApi(
 	 * @param recordingId Recording id.
 	 */
 	public suspend fun getLiveRecordingFile(recordingId: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["recordingId"] = recordingId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("recordingId", recordingId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/LiveTv/LiveRecordings/{recordingId}/stream",
@@ -326,8 +340,9 @@ public class LiveTvApi(
 	 */
 	public fun getLiveRecordingFileUrl(recordingId: String, includeCredentials: Boolean = false):
 			String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["recordingId"] = recordingId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("recordingId", recordingId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/LiveTv/LiveRecordings/{recordingId}/stream", pathParameters,
 				queryParameters, includeCredentials)
@@ -341,9 +356,10 @@ public class LiveTvApi(
 	 */
 	public suspend fun getLiveStreamFile(streamId: String, container: String):
 			Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["streamId"] = streamId
-		pathParameters["container"] = container
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("streamId", streamId)
+			put("container", container)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/LiveTv/LiveStreamFiles/{streamId}/stream.{container}",
@@ -363,9 +379,10 @@ public class LiveTvApi(
 		container: String,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["streamId"] = streamId
-		pathParameters["container"] = container
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("streamId", streamId)
+			put("container", container)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/LiveTv/LiveStreamFiles/{streamId}/stream.{container}", pathParameters,
 				queryParameters, includeCredentials)
@@ -422,28 +439,29 @@ public class LiveTvApi(
 		addCurrentProgram: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["type"] = type
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isNews"] = isNews
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["limit"] = limit
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["isLiked"] = isLiked
-		queryParameters["isDisliked"] = isDisliked
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["fields"] = fields
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["sortBy"] = sortBy
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["enableFavoriteSorting"] = enableFavoriteSorting
-		queryParameters["addCurrentProgram"] = addCurrentProgram
+		val queryParameters = buildMap<String, Any?>(21) {
+			put("type", type)
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("isMovie", isMovie)
+			put("isSeries", isSeries)
+			put("isNews", isNews)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("limit", limit)
+			put("isFavorite", isFavorite)
+			put("isLiked", isLiked)
+			put("isDisliked", isDisliked)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("fields", fields)
+			put("enableUserData", enableUserData)
+			put("sortBy", sortBy)
+			put("sortOrder", sortOrder)
+			put("enableFavoriteSorting", enableFavoriteSorting)
+			put("addCurrentProgram", addCurrentProgram)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/LiveTv/Channels", pathParameters,
 				queryParameters, data)
@@ -524,34 +542,35 @@ public class LiveTvApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["channelIds"] = channelIds
-		queryParameters["userId"] = userId
-		queryParameters["minStartDate"] = minStartDate
-		queryParameters["hasAired"] = hasAired
-		queryParameters["isAiring"] = isAiring
-		queryParameters["maxStartDate"] = maxStartDate
-		queryParameters["minEndDate"] = minEndDate
-		queryParameters["maxEndDate"] = maxEndDate
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isNews"] = isNews
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["sortBy"] = sortBy
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["genres"] = genres
-		queryParameters["genreIds"] = genreIds
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["seriesTimerId"] = seriesTimerId
-		queryParameters["librarySeriesId"] = librarySeriesId
-		queryParameters["fields"] = fields
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(27) {
+			put("channelIds", channelIds)
+			put("userId", userId)
+			put("minStartDate", minStartDate)
+			put("hasAired", hasAired)
+			put("isAiring", isAiring)
+			put("maxStartDate", maxStartDate)
+			put("minEndDate", minEndDate)
+			put("maxEndDate", maxEndDate)
+			put("isMovie", isMovie)
+			put("isSeries", isSeries)
+			put("isNews", isNews)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("sortBy", sortBy)
+			put("sortOrder", sortOrder)
+			put("genres", genres)
+			put("genreIds", genreIds)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("enableUserData", enableUserData)
+			put("seriesTimerId", seriesTimerId)
+			put("librarySeriesId", librarySeriesId)
+			put("fields", fields)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/LiveTv/Programs", pathParameters,
 				queryParameters, data)
@@ -565,10 +584,12 @@ public class LiveTvApi(
 	 * @param userId Optional. Attach user data.
 	 */
 	public suspend fun getProgram(programId: String, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["programId"] = programId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("programId", programId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/LiveTv/Programs/{programId}", pathParameters,
 				queryParameters, data)
@@ -625,23 +646,24 @@ public class LiveTvApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["limit"] = limit
-		queryParameters["isAiring"] = isAiring
-		queryParameters["hasAired"] = hasAired
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isNews"] = isNews
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["genreIds"] = genreIds
-		queryParameters["fields"] = fields
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(16) {
+			put("userId", userId)
+			put("limit", limit)
+			put("isAiring", isAiring)
+			put("hasAired", hasAired)
+			put("isSeries", isSeries)
+			put("isMovie", isMovie)
+			put("isNews", isNews)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("genreIds", genreIds)
+			put("fields", fields)
+			put("enableUserData", enableUserData)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/LiveTv/Programs/Recommended", pathParameters,
 				queryParameters, data)
@@ -655,10 +677,12 @@ public class LiveTvApi(
 	 * @param userId Optional. Attach user data.
 	 */
 	public suspend fun getRecording(recordingId: UUID, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["recordingId"] = recordingId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("recordingId", recordingId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/LiveTv/Recordings/{recordingId}", pathParameters,
 				queryParameters, data)
@@ -672,8 +696,9 @@ public class LiveTvApi(
 	 */
 	public suspend fun getRecordingFolders(userId: UUID? = null): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/LiveTv/Recordings/Folders", pathParameters,
 				queryParameters, data)
@@ -687,8 +712,9 @@ public class LiveTvApi(
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
 	public suspend fun getRecordingGroup(groupId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["groupId"] = groupId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("groupId", groupId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<Unit>("/LiveTv/Recordings/Groups/{groupId}", pathParameters,
@@ -704,8 +730,9 @@ public class LiveTvApi(
 	@Deprecated("This member is deprecated and may be removed in the future")
 	public suspend fun getRecordingGroups(userId: UUID? = null): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/LiveTv/Recordings/Groups", pathParameters,
 				queryParameters, data)
@@ -758,26 +785,27 @@ public class LiveTvApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["channelId"] = channelId
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["status"] = status
-		queryParameters["isInProgress"] = isInProgress
-		queryParameters["seriesTimerId"] = seriesTimerId
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["fields"] = fields
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["isNews"] = isNews
-		queryParameters["isLibraryItem"] = isLibraryItem
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(19) {
+			put("channelId", channelId)
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("status", status)
+			put("isInProgress", isInProgress)
+			put("seriesTimerId", seriesTimerId)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("fields", fields)
+			put("enableUserData", enableUserData)
+			put("isMovie", isMovie)
+			put("isSeries", isSeries)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("isNews", isNews)
+			put("isLibraryItem", isLibraryItem)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/LiveTv/Recordings", pathParameters,
 				queryParameters, data)
@@ -821,21 +849,22 @@ public class LiveTvApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["channelId"] = channelId
-		queryParameters["userId"] = userId
-		queryParameters["groupId"] = groupId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["status"] = status
-		queryParameters["isInProgress"] = isInProgress
-		queryParameters["seriesTimerId"] = seriesTimerId
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["fields"] = fields
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(14) {
+			put("channelId", channelId)
+			put("userId", userId)
+			put("groupId", groupId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("status", status)
+			put("isInProgress", isInProgress)
+			put("seriesTimerId", seriesTimerId)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("fields", fields)
+			put("enableUserData", enableUserData)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/LiveTv/Recordings/Series", pathParameters,
 				queryParameters, data)
@@ -872,8 +901,9 @@ public class LiveTvApi(
 	 * @param timerId Timer id.
 	 */
 	public suspend fun getSeriesTimer(timerId: String): Response<SeriesTimerInfoDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["timerId"] = timerId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("timerId", timerId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<SeriesTimerInfoDto>("/LiveTv/SeriesTimers/{timerId}", pathParameters,
@@ -890,9 +920,10 @@ public class LiveTvApi(
 	public suspend fun getSeriesTimers(sortBy: String? = null, sortOrder: SortOrder? = null):
 			Response<SeriesTimerInfoDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["sortBy"] = sortBy
-		queryParameters["sortOrder"] = sortOrder
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("sortBy", sortBy)
+			put("sortOrder", sortOrder)
+		}
 		val data = null
 		val response = api.`get`<SeriesTimerInfoDtoQueryResult>("/LiveTv/SeriesTimers", pathParameters,
 				queryParameters, data)
@@ -905,8 +936,9 @@ public class LiveTvApi(
 	 * @param timerId Timer id.
 	 */
 	public suspend fun getTimer(timerId: String): Response<TimerInfoDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["timerId"] = timerId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("timerId", timerId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<TimerInfoDto>("/LiveTv/Timers/{timerId}", pathParameters,
@@ -929,11 +961,12 @@ public class LiveTvApi(
 		isScheduled: Boolean? = null,
 	): Response<TimerInfoDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["channelId"] = channelId
-		queryParameters["seriesTimerId"] = seriesTimerId
-		queryParameters["isActive"] = isActive
-		queryParameters["isScheduled"] = isScheduled
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("channelId", channelId)
+			put("seriesTimerId", seriesTimerId)
+			put("isActive", isActive)
+			put("isScheduled", isScheduled)
+		}
 		val data = null
 		val response = api.`get`<TimerInfoDtoQueryResult>("/LiveTv/Timers", pathParameters,
 				queryParameters, data)
@@ -958,8 +991,9 @@ public class LiveTvApi(
 	 * @param tunerId Tuner id.
 	 */
 	public suspend fun resetTuner(tunerId: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["tunerId"] = tunerId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("tunerId", tunerId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/LiveTv/Tuners/{tunerId}/Reset", pathParameters, queryParameters,
@@ -985,8 +1019,9 @@ public class LiveTvApi(
 	 */
 	public suspend fun updateSeriesTimer(timerId: String, `data`: SeriesTimerInfoDto? = null):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["timerId"] = timerId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("timerId", timerId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/LiveTv/SeriesTimers/{timerId}", pathParameters, queryParameters,
 				data)
@@ -999,8 +1034,9 @@ public class LiveTvApi(
 	 * @param timerId Timer id.
 	 */
 	public suspend fun updateTimer(timerId: String, `data`: TimerInfoDto? = null): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["timerId"] = timerId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("timerId", timerId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/LiveTv/Timers/{timerId}", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
@@ -13,8 +13,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import kotlin.require
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
@@ -37,8 +37,9 @@ public class MediaInfoApi(
 	 */
 	public suspend fun closeLiveStream(liveStreamId: String): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["liveStreamId"] = liveStreamId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("liveStreamId", liveStreamId)
+		}
 		val data = null
 		val response = api.post<Unit>("/LiveStreams/Close", pathParameters, queryParameters, data)
 		return response
@@ -51,9 +52,10 @@ public class MediaInfoApi(
 	 */
 	public suspend fun getBitrateTestBytes(size: Int? = 102400): Response<ByteReadChannel> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
 		require(size in 1..100000000) { "Parameter \"size\" must be in range 1..100000000 (inclusive)." }
-		queryParameters["size"] = size
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("size", size)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Playback/BitrateTest", pathParameters,
 				queryParameters, data)
@@ -69,9 +71,10 @@ public class MediaInfoApi(
 	public fun getBitrateTestBytesUrl(size: Int? = 102400, includeCredentials: Boolean = true):
 			String {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
 		require(size in 1..100000000) { "Parameter \"size\" must be in range 1..100000000 (inclusive)." }
-		queryParameters["size"] = size
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("size", size)
+		}
 		return api.createUrl("/Playback/BitrateTest", pathParameters, queryParameters, includeCredentials)
 	}
 
@@ -83,10 +86,12 @@ public class MediaInfoApi(
 	 */
 	public suspend fun getPlaybackInfo(itemId: UUID, userId: UUID = api.userId ?: throw
 			MissingUserIdException()): Response<PlaybackInfoResponse> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<PlaybackInfoResponse>("/Items/{itemId}/PlaybackInfo", pathParameters,
 				queryParameters, data)
@@ -102,8 +107,9 @@ public class MediaInfoApi(
 	 */
 	public suspend fun getPostedPlaybackInfo(itemId: UUID, `data`: PlaybackInfoDto? = null):
 			Response<PlaybackInfoResponse> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<PlaybackInfoResponse>("/Items/{itemId}/PlaybackInfo", pathParameters,
 				queryParameters, data)
@@ -150,23 +156,25 @@ public class MediaInfoApi(
 		allowAudioStreamCopy: Boolean? = null,
 		`data`: PlaybackInfoDto? = null,
 	): Response<PlaybackInfoResponse> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["autoOpenLiveStream"] = autoOpenLiveStream
-		queryParameters["enableDirectPlay"] = enableDirectPlay
-		queryParameters["enableDirectStream"] = enableDirectStream
-		queryParameters["enableTranscoding"] = enableTranscoding
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(14) {
+			put("userId", userId)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("startTimeTicks", startTimeTicks)
+			put("audioStreamIndex", audioStreamIndex)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("maxAudioChannels", maxAudioChannels)
+			put("mediaSourceId", mediaSourceId)
+			put("liveStreamId", liveStreamId)
+			put("autoOpenLiveStream", autoOpenLiveStream)
+			put("enableDirectPlay", enableDirectPlay)
+			put("enableDirectStream", enableDirectStream)
+			put("enableTranscoding", enableTranscoding)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+		}
 		val response = api.post<PlaybackInfoResponse>("/Items/{itemId}/PlaybackInfo", pathParameters,
 				queryParameters, data)
 		return response
@@ -202,18 +210,19 @@ public class MediaInfoApi(
 		`data`: OpenLiveStreamDto? = null,
 	): Response<LiveStreamResponse> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["openToken"] = openToken
-		queryParameters["userId"] = userId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["itemId"] = itemId
-		queryParameters["enableDirectPlay"] = enableDirectPlay
-		queryParameters["enableDirectStream"] = enableDirectStream
+		val queryParameters = buildMap<String, Any?>(11) {
+			put("openToken", openToken)
+			put("userId", userId)
+			put("playSessionId", playSessionId)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("startTimeTicks", startTimeTicks)
+			put("audioStreamIndex", audioStreamIndex)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("maxAudioChannels", maxAudioChannels)
+			put("itemId", itemId)
+			put("enableDirectPlay", enableDirectPlay)
+			put("enableDirectStream", enableDirectStream)
+		}
 		val response = api.post<LiveStreamResponse>("/LiveStreams/Open", pathParameters, queryParameters,
 				data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MoviesApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MoviesApi.kt
@@ -10,9 +10,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -41,12 +41,13 @@ public class MoviesApi(
 		itemLimit: Int? = 8,
 	): Response<List<RecommendationDto>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["categoryLimit"] = categoryLimit
-		queryParameters["itemLimit"] = itemLimit
+		val queryParameters = buildMap<String, Any?>(5) {
+			put("userId", userId)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("categoryLimit", categoryLimit)
+			put("itemLimit", itemLimit)
+		}
 		val data = null
 		val response = api.`get`<List<RecommendationDto>>("/Movies/Recommendations", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MusicGenresApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MusicGenresApi.kt
@@ -11,9 +11,9 @@ import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -35,10 +35,12 @@ public class MusicGenresApi(
 	 * @param userId Optional. Filter by user id, and attach user data.
 	 */
 	public suspend fun getMusicGenre(genreName: String, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["genreName"] = genreName
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("genreName", genreName)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/MusicGenres/{genreName}", pathParameters, queryParameters,
 				data)
@@ -96,25 +98,26 @@ public class MusicGenresApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["userId"] = userId
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["sortBy"] = sortBy
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(18) {
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("searchTerm", searchTerm)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("isFavorite", isFavorite)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("userId", userId)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("sortBy", sortBy)
+			put("sortOrder", sortOrder)
+			put("enableImages", enableImages)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/MusicGenres", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/NotificationsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/NotificationsApi.kt
@@ -9,8 +9,8 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -64,8 +64,9 @@ public class NotificationsApi(
 	 */
 	public suspend fun getNotifications(userId: String = api.userId?.toString() ?: throw
 			MissingUserIdException()): Response<NotificationResultDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<NotificationResultDto>("/Notifications/{userId}", pathParameters,
@@ -78,8 +79,9 @@ public class NotificationsApi(
 	 */
 	public suspend fun getNotificationsSummary(userId: String = api.userId?.toString() ?: throw
 			MissingUserIdException()): Response<NotificationsSummaryDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<NotificationsSummaryDto>("/Notifications/{userId}/Summary",
@@ -92,8 +94,9 @@ public class NotificationsApi(
 	 */
 	public suspend fun setRead(userId: String = api.userId?.toString() ?: throw
 			MissingUserIdException()): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Notifications/{userId}/Read", pathParameters, queryParameters,
@@ -106,8 +109,9 @@ public class NotificationsApi(
 	 */
 	public suspend fun setUnread(userId: String = api.userId?.toString() ?: throw
 			MissingUserIdException()): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Notifications/{userId}/Unread", pathParameters, queryParameters,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PackageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PackageApi.kt
@@ -9,8 +9,8 @@ import kotlin.Any
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -29,8 +29,9 @@ public class PackageApi(
 	 * @param packageId Installation Id.
 	 */
 	public suspend fun cancelPackageInstallation(packageId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["packageId"] = packageId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("packageId", packageId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Packages/Installing/{packageId}", pathParameters,
@@ -46,10 +47,12 @@ public class PackageApi(
 	 */
 	public suspend fun getPackageInfo(name: String, assemblyGuid: UUID? = null):
 			Response<PackageInfo> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["assemblyGuid"] = assemblyGuid
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("assemblyGuid", assemblyGuid)
+		}
 		val data = null
 		val response = api.`get`<PackageInfo>("/Packages/{name}", pathParameters, queryParameters, data)
 		return response
@@ -92,12 +95,14 @@ public class PackageApi(
 		version: String? = null,
 		repositoryUrl: String? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["assemblyGuid"] = assemblyGuid
-		queryParameters["version"] = version
-		queryParameters["repositoryUrl"] = repositoryUrl
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("assemblyGuid", assemblyGuid)
+			put("version", version)
+			put("repositoryUrl", repositoryUrl)
+		}
 		val data = null
 		val response = api.post<Unit>("/Packages/Installed/{name}", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PersonsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PersonsApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -33,10 +33,12 @@ public class PersonsApi(
 	 * @param userId Optional. Filter by user id, and attach user data.
 	 */
 	public suspend fun getPerson(name: String, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/Persons/{name}", pathParameters, queryParameters, data)
 		return response
@@ -79,20 +81,21 @@ public class PersonsApi(
 		enableImages: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["limit"] = limit
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["fields"] = fields
-		queryParameters["filters"] = filters
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["excludePersonTypes"] = excludePersonTypes
-		queryParameters["personTypes"] = personTypes
-		queryParameters["appearsInItemId"] = appearsInItemId
-		queryParameters["userId"] = userId
-		queryParameters["enableImages"] = enableImages
+		val queryParameters = buildMap<String, Any?>(13) {
+			put("limit", limit)
+			put("searchTerm", searchTerm)
+			put("fields", fields)
+			put("filters", filters)
+			put("isFavorite", isFavorite)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("excludePersonTypes", excludePersonTypes)
+			put("personTypes", personTypes)
+			put("appearsInItemId", appearsInItemId)
+			put("userId", userId)
+			put("enableImages", enableImages)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Persons", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlayStateApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlayStateApi.kt
@@ -11,8 +11,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -42,11 +42,13 @@ public class PlayStateApi(
 		itemId: UUID,
 		datePlayed: DateTime? = null,
 	): Response<UserItemDataDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["datePlayed"] = datePlayed
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("datePlayed", datePlayed)
+		}
 		val data = null
 		val response = api.post<UserItemDataDto>("/Users/{userId}/PlayedItems/{itemId}", pathParameters,
 				queryParameters, data)
@@ -61,9 +63,10 @@ public class PlayStateApi(
 	 */
 	public suspend fun markUnplayedItem(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			itemId: UUID): Response<UserItemDataDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<UserItemDataDto>("/Users/{userId}/PlayedItems/{itemId}", pathParameters,
@@ -103,21 +106,23 @@ public class PlayStateApi(
 		isPaused: Boolean? = false,
 		isMuted: Boolean? = false,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["positionTicks"] = positionTicks
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["volumeLevel"] = volumeLevel
-		queryParameters["playMethod"] = playMethod
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["repeatMode"] = repeatMode
-		queryParameters["isPaused"] = isPaused
-		queryParameters["isMuted"] = isMuted
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(11) {
+			put("mediaSourceId", mediaSourceId)
+			put("positionTicks", positionTicks)
+			put("audioStreamIndex", audioStreamIndex)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("volumeLevel", volumeLevel)
+			put("playMethod", playMethod)
+			put("liveStreamId", liveStreamId)
+			put("playSessionId", playSessionId)
+			put("repeatMode", repeatMode)
+			put("isPaused", isPaused)
+			put("isMuted", isMuted)
+		}
 		val data = null
 		val response = api.post<Unit>("/Users/{userId}/PlayingItems/{itemId}/Progress", pathParameters,
 				queryParameters, data)
@@ -148,17 +153,19 @@ public class PlayStateApi(
 		playSessionId: String? = null,
 		canSeek: Boolean? = false,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["playMethod"] = playMethod
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["canSeek"] = canSeek
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("mediaSourceId", mediaSourceId)
+			put("audioStreamIndex", audioStreamIndex)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("playMethod", playMethod)
+			put("liveStreamId", liveStreamId)
+			put("playSessionId", playSessionId)
+			put("canSeek", canSeek)
+		}
 		val data = null
 		val response = api.post<Unit>("/Users/{userId}/PlayingItems/{itemId}", pathParameters,
 				queryParameters, data)
@@ -186,15 +193,17 @@ public class PlayStateApi(
 		liveStreamId: String? = null,
 		playSessionId: String? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["nextMediaType"] = nextMediaType
-		queryParameters["positionTicks"] = positionTicks
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["playSessionId"] = playSessionId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(5) {
+			put("mediaSourceId", mediaSourceId)
+			put("nextMediaType", nextMediaType)
+			put("positionTicks", positionTicks)
+			put("liveStreamId", liveStreamId)
+			put("playSessionId", playSessionId)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Users/{userId}/PlayingItems/{itemId}", pathParameters,
 				queryParameters, data)
@@ -208,8 +217,9 @@ public class PlayStateApi(
 	 */
 	public suspend fun pingPlaybackSession(playSessionId: String): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["playSessionId"] = playSessionId
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("playSessionId", playSessionId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Sessions/Playing/Ping", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlaylistsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PlaylistsApi.kt
@@ -12,9 +12,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -43,11 +43,13 @@ public class PlaylistsApi(
 		ids: Collection<UUID>? = emptyList(),
 		userId: UUID? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["playlistId"] = playlistId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["ids"] = ids
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("playlistId", playlistId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("ids", ids)
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Playlists/{playlistId}/Items", pathParameters, queryParameters,
 				data)
@@ -87,11 +89,12 @@ public class PlaylistsApi(
 		`data`: CreatePlaylistDto? = null,
 	): Response<PlaylistCreationResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
-		queryParameters["ids"] = ids
-		queryParameters["userId"] = userId
-		queryParameters["mediaType"] = mediaType
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("name", name)
+			put("ids", ids)
+			put("userId", userId)
+			put("mediaType", mediaType)
+		}
 		val response = api.post<PlaylistCreationResult>("/Playlists", pathParameters, queryParameters,
 				data)
 		return response
@@ -122,17 +125,19 @@ public class PlaylistsApi(
 		imageTypeLimit: Int? = null,
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["playlistId"] = playlistId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("playlistId", playlistId)
+		}
+		val queryParameters = buildMap<String, Any?>(8) {
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("fields", fields)
+			put("enableImages", enableImages)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Playlists/{playlistId}/Items", pathParameters,
 				queryParameters, data)
@@ -151,10 +156,11 @@ public class PlaylistsApi(
 		itemId: String,
 		newIndex: Int,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["playlistId"] = playlistId
-		pathParameters["itemId"] = itemId
-		pathParameters["newIndex"] = newIndex
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("playlistId", playlistId)
+			put("itemId", itemId)
+			put("newIndex", newIndex)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Playlists/{playlistId}/Items/{itemId}/Move/{newIndex}",
@@ -170,10 +176,12 @@ public class PlaylistsApi(
 	 */
 	public suspend fun removeFromPlaylist(playlistId: String, entryIds: Collection<String>? =
 			emptyList()): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["playlistId"] = playlistId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["entryIds"] = entryIds
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("playlistId", playlistId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("entryIds", entryIds)
+		}
 		val data = null
 		val response = api.delete<Unit>("/Playlists/{playlistId}/Items", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
@@ -12,8 +12,8 @@ import kotlin.Deprecated
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -33,9 +33,10 @@ public class PluginsApi(
 	 * @param version Plugin version.
 	 */
 	public suspend fun disablePlugin(pluginId: UUID, version: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
-		pathParameters["version"] = version
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("pluginId", pluginId)
+			put("version", version)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Plugins/{pluginId}/{version}/Disable", pathParameters,
@@ -50,9 +51,10 @@ public class PluginsApi(
 	 * @param version Plugin version.
 	 */
 	public suspend fun enablePlugin(pluginId: UUID, version: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
-		pathParameters["version"] = version
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("pluginId", pluginId)
+			put("version", version)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Plugins/{pluginId}/{version}/Enable", pathParameters,
@@ -66,8 +68,9 @@ public class PluginsApi(
 	 * @param pluginId Plugin id.
 	 */
 	public suspend fun getPluginConfiguration(pluginId: UUID): Response<BasePluginConfiguration> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("pluginId", pluginId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<BasePluginConfiguration>("/Plugins/{pluginId}/Configuration",
@@ -82,9 +85,10 @@ public class PluginsApi(
 	 * @param version Plugin version.
 	 */
 	public suspend fun getPluginImage(pluginId: UUID, version: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
-		pathParameters["version"] = version
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("pluginId", pluginId)
+			put("version", version)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Plugins/{pluginId}/{version}/Image", pathParameters,
@@ -104,9 +108,10 @@ public class PluginsApi(
 		version: String,
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
-		pathParameters["version"] = version
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("pluginId", pluginId)
+			put("version", version)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Plugins/{pluginId}/{version}/Image", pathParameters, queryParameters,
 				includeCredentials)
@@ -118,8 +123,9 @@ public class PluginsApi(
 	 * @param pluginId Plugin id.
 	 */
 	public suspend fun getPluginManifest(pluginId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("pluginId", pluginId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Plugins/{pluginId}/Manifest", pathParameters, queryParameters,
@@ -145,8 +151,9 @@ public class PluginsApi(
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
 	public suspend fun uninstallPlugin(pluginId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("pluginId", pluginId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Plugins/{pluginId}", pathParameters, queryParameters, data)
@@ -160,9 +167,10 @@ public class PluginsApi(
 	 * @param version Plugin version.
 	 */
 	public suspend fun uninstallPluginByVersion(pluginId: UUID, version: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
-		pathParameters["version"] = version
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("pluginId", pluginId)
+			put("version", version)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Plugins/{pluginId}/{version}", pathParameters, queryParameters,
@@ -176,8 +184,9 @@ public class PluginsApi(
 	 * @param pluginId Plugin id.
 	 */
 	public suspend fun updatePluginConfiguration(pluginId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["pluginId"] = pluginId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("pluginId", pluginId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Plugins/{pluginId}/Configuration", pathParameters,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/QuickConnectApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/QuickConnectApi.kt
@@ -8,8 +8,8 @@ package org.jellyfin.sdk.api.operations
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -26,8 +26,9 @@ public class QuickConnectApi(
 	 */
 	public suspend fun authorize(code: String): Response<Boolean> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["code"] = code
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("code", code)
+		}
 		val data = null
 		val response = api.post<Boolean>("/QuickConnect/Authorize", pathParameters, queryParameters, data)
 		return response
@@ -40,8 +41,9 @@ public class QuickConnectApi(
 	 */
 	public suspend fun connect(secret: String): Response<QuickConnectResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["secret"] = secret
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("secret", secret)
+		}
 		val data = null
 		val response = api.`get`<QuickConnectResult>("/QuickConnect/Connect", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/RemoteImageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/RemoteImageApi.kt
@@ -11,8 +11,8 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -37,11 +37,13 @@ public class RemoteImageApi(
 		type: ImageType,
 		imageUrl: String? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["type"] = type
-		queryParameters["imageUrl"] = imageUrl
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("type", type)
+			put("imageUrl", imageUrl)
+		}
 		val data = null
 		val response = api.post<Unit>("/Items/{itemId}/RemoteImages/Download", pathParameters,
 				queryParameters, data)
@@ -54,8 +56,9 @@ public class RemoteImageApi(
 	 * @param itemId Item Id.
 	 */
 	public suspend fun getRemoteImageProviders(itemId: UUID): Response<List<ImageProviderInfo>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<List<ImageProviderInfo>>("/Items/{itemId}/RemoteImages/Providers",
@@ -82,14 +85,16 @@ public class RemoteImageApi(
 		providerName: String? = null,
 		includeAllLanguages: Boolean? = false,
 	): Response<RemoteImageResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["type"] = type
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["providerName"] = providerName
-		queryParameters["includeAllLanguages"] = includeAllLanguages
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(5) {
+			put("type", type)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("providerName", providerName)
+			put("includeAllLanguages", includeAllLanguages)
+		}
 		val data = null
 		val response = api.`get`<RemoteImageResult>("/Items/{itemId}/RemoteImages", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ScheduledTasksApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ScheduledTasksApi.kt
@@ -10,8 +10,8 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -29,8 +29,9 @@ public class ScheduledTasksApi(
 	 * @param taskId Task Id.
 	 */
 	public suspend fun getTask(taskId: String): Response<TaskInfo> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["taskId"] = taskId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("taskId", taskId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<TaskInfo>("/ScheduledTasks/{taskId}", pathParameters, queryParameters,
@@ -47,9 +48,10 @@ public class ScheduledTasksApi(
 	public suspend fun getTasks(isHidden: Boolean? = null, isEnabled: Boolean? = null):
 			Response<List<TaskInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["isHidden"] = isHidden
-		queryParameters["isEnabled"] = isEnabled
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("isHidden", isHidden)
+			put("isEnabled", isEnabled)
+		}
 		val data = null
 		val response = api.`get`<List<TaskInfo>>("/ScheduledTasks", pathParameters, queryParameters, data)
 		return response
@@ -61,8 +63,9 @@ public class ScheduledTasksApi(
 	 * @param taskId Task Id.
 	 */
 	public suspend fun startTask(taskId: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["taskId"] = taskId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("taskId", taskId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/ScheduledTasks/Running/{taskId}", pathParameters, queryParameters,
@@ -76,8 +79,9 @@ public class ScheduledTasksApi(
 	 * @param taskId Task Id.
 	 */
 	public suspend fun stopTask(taskId: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["taskId"] = taskId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("taskId", taskId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/ScheduledTasks/Running/{taskId}", pathParameters,
@@ -91,8 +95,9 @@ public class ScheduledTasksApi(
 	 * @param taskId Task Id.
 	 */
 	public suspend fun updateTask(taskId: String, `data`: List<TaskTriggerInfo>): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["taskId"] = taskId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("taskId", taskId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/ScheduledTasks/{taskId}/Triggers", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SearchApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SearchApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -71,25 +71,26 @@ public class SearchApi(
 		includeArtists: Boolean? = true,
 	): Response<SearchHintResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["userId"] = userId
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["parentId"] = parentId
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isNews"] = isNews
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["includePeople"] = includePeople
-		queryParameters["includeMedia"] = includeMedia
-		queryParameters["includeGenres"] = includeGenres
-		queryParameters["includeStudios"] = includeStudios
-		queryParameters["includeArtists"] = includeArtists
+		val queryParameters = buildMap<String, Any?>(18) {
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("userId", userId)
+			put("searchTerm", searchTerm)
+			put("includeItemTypes", includeItemTypes)
+			put("excludeItemTypes", excludeItemTypes)
+			put("mediaTypes", mediaTypes)
+			put("parentId", parentId)
+			put("isMovie", isMovie)
+			put("isSeries", isSeries)
+			put("isNews", isNews)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("includePeople", includePeople)
+			put("includeMedia", includeMedia)
+			put("includeGenres", includeGenres)
+			put("includeStudios", includeStudios)
+			put("includeArtists", includeArtists)
+		}
 		val data = null
 		val response = api.`get`<SearchHintResult>("/Search/Hints", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SessionApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SessionApi.kt
@@ -13,9 +13,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -44,9 +44,10 @@ public class SessionApi(
 	 */
 	public suspend fun addUserToSession(sessionId: String, userId: UUID = api.userId ?: throw
 			MissingUserIdException()): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("sessionId", sessionId)
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Sessions/{sessionId}/User/{userId}", pathParameters,
@@ -68,12 +69,14 @@ public class SessionApi(
 		itemId: String,
 		itemName: String,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["itemType"] = itemType
-		queryParameters["itemId"] = itemId
-		queryParameters["itemName"] = itemName
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("sessionId", sessionId)
+		}
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("itemType", itemType)
+			put("itemId", itemId)
+			put("itemName", itemName)
+		}
 		val data = null
 		val response = api.post<Unit>("/Sessions/{sessionId}/Viewing", pathParameters, queryParameters,
 				data)
@@ -117,10 +120,11 @@ public class SessionApi(
 		activeWithinSeconds: Int? = null,
 	): Response<List<SessionInfo>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["controllableByUserId"] = controllableByUserId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["activeWithinSeconds"] = activeWithinSeconds
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("controllableByUserId", controllableByUserId)
+			put("deviceId", deviceId)
+			put("activeWithinSeconds", activeWithinSeconds)
+		}
 		val data = null
 		val response = api.`get`<List<SessionInfo>>("/Sessions", pathParameters, queryParameters, data)
 		return response
@@ -149,16 +153,18 @@ public class SessionApi(
 		subtitleStreamIndex: Int? = null,
 		startIndex: Int? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["playCommand"] = playCommand
-		queryParameters["itemIds"] = itemIds
-		queryParameters["startPositionTicks"] = startPositionTicks
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["startIndex"] = startIndex
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("sessionId", sessionId)
+		}
+		val queryParameters = buildMap<String, Any?>(7) {
+			put("playCommand", playCommand)
+			put("itemIds", itemIds)
+			put("startPositionTicks", startPositionTicks)
+			put("mediaSourceId", mediaSourceId)
+			put("audioStreamIndex", audioStreamIndex)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("startIndex", startIndex)
+		}
 		val data = null
 		val response = api.post<Unit>("/Sessions/{sessionId}/Playing", pathParameters, queryParameters,
 				data)
@@ -185,13 +191,14 @@ public class SessionApi(
 		supportsPersistentIdentifier: Boolean? = true,
 	): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
-		queryParameters["playableMediaTypes"] = playableMediaTypes
-		queryParameters["supportedCommands"] = supportedCommands
-		queryParameters["supportsMediaControl"] = supportsMediaControl
-		queryParameters["supportsSync"] = supportsSync
-		queryParameters["supportsPersistentIdentifier"] = supportsPersistentIdentifier
+		val queryParameters = buildMap<String, Any?>(6) {
+			put("id", id)
+			put("playableMediaTypes", playableMediaTypes)
+			put("supportedCommands", supportedCommands)
+			put("supportsMediaControl", supportsMediaControl)
+			put("supportsSync", supportsSync)
+			put("supportsPersistentIdentifier", supportsPersistentIdentifier)
+		}
 		val data = null
 		val response = api.post<Unit>("/Sessions/Capabilities", pathParameters, queryParameters, data)
 		return response
@@ -205,8 +212,9 @@ public class SessionApi(
 	public suspend fun postFullCapabilities(id: String? = null, `data`: ClientCapabilitiesDto):
 			Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["id"] = id
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val response = api.post<Unit>("/Sessions/Capabilities/Full", pathParameters, queryParameters,
 				data)
 		return response
@@ -220,9 +228,10 @@ public class SessionApi(
 	 */
 	public suspend fun removeUserFromSession(sessionId: String, userId: UUID = api.userId ?: throw
 			MissingUserIdException()): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("sessionId", sessionId)
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Sessions/{sessionId}/User/{userId}", pathParameters,
@@ -249,9 +258,10 @@ public class SessionApi(
 	 */
 	public suspend fun reportViewing(sessionId: String? = null, itemId: String): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["sessionId"] = sessionId
-		queryParameters["itemId"] = itemId
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("sessionId", sessionId)
+			put("itemId", itemId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Sessions/Viewing", pathParameters, queryParameters, data)
 		return response
@@ -264,8 +274,9 @@ public class SessionApi(
 	 */
 	public suspend fun sendFullGeneralCommand(sessionId: String, `data`: GeneralCommand):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("sessionId", sessionId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Sessions/{sessionId}/Command", pathParameters, queryParameters,
 				data)
@@ -280,9 +291,10 @@ public class SessionApi(
 	 */
 	public suspend fun sendGeneralCommand(sessionId: String, command: GeneralCommandType):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
-		pathParameters["command"] = command
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("sessionId", sessionId)
+			put("command", command)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Sessions/{sessionId}/Command/{command}", pathParameters,
@@ -296,8 +308,9 @@ public class SessionApi(
 	 * @param sessionId The session id.
 	 */
 	public suspend fun sendMessageCommand(sessionId: String, `data`: MessageCommand): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("sessionId", sessionId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Sessions/{sessionId}/Message", pathParameters, queryParameters,
 				data)
@@ -318,12 +331,14 @@ public class SessionApi(
 		seekPositionTicks: Long? = null,
 		controllingUserId: String? = null,
 	): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
-		pathParameters["command"] = command
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["seekPositionTicks"] = seekPositionTicks
-		queryParameters["controllingUserId"] = controllingUserId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("sessionId", sessionId)
+			put("command", command)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("seekPositionTicks", seekPositionTicks)
+			put("controllingUserId", controllingUserId)
+		}
 		val data = null
 		val response = api.post<Unit>("/Sessions/{sessionId}/Playing/{command}", pathParameters,
 				queryParameters, data)
@@ -338,9 +353,10 @@ public class SessionApi(
 	 */
 	public suspend fun sendSystemCommand(sessionId: String, command: GeneralCommandType):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["sessionId"] = sessionId
-		pathParameters["command"] = command
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("sessionId", sessionId)
+			put("command", command)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Sessions/{sessionId}/System/{command}", pathParameters,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/StudiosApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/StudiosApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -33,10 +33,12 @@ public class StudiosApi(
 	 * @param userId Optional. Filter by user id, and attach user data.
 	 */
 	public suspend fun getStudio(name: String, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/Studios/{name}", pathParameters, queryParameters, data)
 		return response
@@ -90,24 +92,25 @@ public class StudiosApi(
 		enableTotalRecordCount: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["userId"] = userId
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["enableImages"] = enableImages
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("searchTerm", searchTerm)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("isFavorite", isFavorite)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("userId", userId)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("enableImages", enableImages)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Studios", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
@@ -14,8 +14,8 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -36,9 +36,10 @@ public class SubtitleApi(
 	 * @param index The index of the subtitle file.
 	 */
 	public suspend fun deleteSubtitle(itemId: UUID, index: Int): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["index"] = index
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("index", index)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Videos/{itemId}/Subtitles/{index}", pathParameters,
@@ -53,9 +54,10 @@ public class SubtitleApi(
 	 * @param subtitleId The subtitle id.
 	 */
 	public suspend fun downloadRemoteSubtitles(itemId: UUID, subtitleId: String): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["subtitleId"] = subtitleId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("subtitleId", subtitleId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<Unit>("/Items/{itemId}/RemoteSearch/Subtitles/{subtitleId}",
@@ -69,8 +71,9 @@ public class SubtitleApi(
 	 * @param name The name of the fallback font file to get.
 	 */
 	public suspend fun getFallbackFont(name: String): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/FallbackFont/Fonts/{name}", pathParameters,
@@ -85,8 +88,9 @@ public class SubtitleApi(
 	 * @param includeCredentials Add the access token to the url to make an authenticated request.
 	 */
 	public fun getFallbackFontUrl(name: String, includeCredentials: Boolean = true): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["name"] = name
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/FallbackFont/Fonts/{name}", pathParameters, queryParameters,
 				includeCredentials)
@@ -110,8 +114,9 @@ public class SubtitleApi(
 	 * @param id The item id.
 	 */
 	public suspend fun getRemoteSubtitles(id: String): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["id"] = id
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("id", id)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<String>("/Providers/Subtitles/Subtitles/{id}", pathParameters,
@@ -141,16 +146,18 @@ public class SubtitleApi(
 		addVttTimeMap: Boolean? = false,
 		startPositionTicks: Long? = 0,
 	): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["routeItemId"] = routeItemId
-		pathParameters["routeMediaSourceId"] = routeMediaSourceId
-		pathParameters["routeIndex"] = routeIndex
-		pathParameters["routeFormat"] = routeFormat
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["endPositionTicks"] = endPositionTicks
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["addVttTimeMap"] = addVttTimeMap
-		queryParameters["startPositionTicks"] = startPositionTicks
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("routeItemId", routeItemId)
+			put("routeMediaSourceId", routeMediaSourceId)
+			put("routeIndex", routeIndex)
+			put("routeFormat", routeFormat)
+		}
+		val queryParameters = buildMap<String, Any?>(4) {
+			put("endPositionTicks", endPositionTicks)
+			put("copyTimestamps", copyTimestamps)
+			put("addVttTimeMap", addVttTimeMap)
+			put("startPositionTicks", startPositionTicks)
+		}
 		val data = null
 		val response =
 				api.`get`<String>("/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/Stream.{routeFormat}",
@@ -189,20 +196,22 @@ public class SubtitleApi(
 		addVttTimeMap: Boolean? = false,
 		startPositionTicks: Long? = 0,
 	): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["routeItemId"] = routeItemId
-		pathParameters["routeMediaSourceId"] = routeMediaSourceId
-		pathParameters["routeIndex"] = routeIndex
-		pathParameters["routeFormat"] = routeFormat
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["itemId"] = itemId
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["index"] = index
-		queryParameters["format"] = format
-		queryParameters["endPositionTicks"] = endPositionTicks
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["addVttTimeMap"] = addVttTimeMap
-		queryParameters["startPositionTicks"] = startPositionTicks
+		val pathParameters = buildMap<String, Any?>(4) {
+			put("routeItemId", routeItemId)
+			put("routeMediaSourceId", routeMediaSourceId)
+			put("routeIndex", routeIndex)
+			put("routeFormat", routeFormat)
+		}
+		val queryParameters = buildMap<String, Any?>(8) {
+			put("itemId", itemId)
+			put("mediaSourceId", mediaSourceId)
+			put("index", index)
+			put("format", format)
+			put("endPositionTicks", endPositionTicks)
+			put("copyTimestamps", copyTimestamps)
+			put("addVttTimeMap", addVttTimeMap)
+			put("startPositionTicks", startPositionTicks)
+		}
 		val data = null
 		val response =
 				api.`get`<String>("/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/Stream.{routeFormat}",
@@ -224,12 +233,14 @@ public class SubtitleApi(
 		mediaSourceId: String,
 		segmentLength: Int,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["index"] = index
-		pathParameters["mediaSourceId"] = mediaSourceId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["segmentLength"] = segmentLength
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("index", index)
+			put("mediaSourceId", mediaSourceId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("segmentLength", segmentLength)
+		}
 		val data = null
 		val response =
 				api.`get`<ByteReadChannel>("/Videos/{itemId}/{mediaSourceId}/Subtitles/{index}/subtitles.m3u8",
@@ -253,12 +264,14 @@ public class SubtitleApi(
 		segmentLength: Int,
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["index"] = index
-		pathParameters["mediaSourceId"] = mediaSourceId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["segmentLength"] = segmentLength
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("itemId", itemId)
+			put("index", index)
+			put("mediaSourceId", mediaSourceId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("segmentLength", segmentLength)
+		}
 		return api.createUrl("/Videos/{itemId}/{mediaSourceId}/Subtitles/{index}/subtitles.m3u8",
 				pathParameters, queryParameters, includeCredentials)
 	}
@@ -285,16 +298,18 @@ public class SubtitleApi(
 		copyTimestamps: Boolean? = false,
 		addVttTimeMap: Boolean? = false,
 	): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["routeItemId"] = routeItemId
-		pathParameters["routeMediaSourceId"] = routeMediaSourceId
-		pathParameters["routeIndex"] = routeIndex
-		pathParameters["routeStartPositionTicks"] = routeStartPositionTicks
-		pathParameters["routeFormat"] = routeFormat
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["endPositionTicks"] = endPositionTicks
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["addVttTimeMap"] = addVttTimeMap
+		val pathParameters = buildMap<String, Any?>(5) {
+			put("routeItemId", routeItemId)
+			put("routeMediaSourceId", routeMediaSourceId)
+			put("routeIndex", routeIndex)
+			put("routeStartPositionTicks", routeStartPositionTicks)
+			put("routeFormat", routeFormat)
+		}
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("endPositionTicks", endPositionTicks)
+			put("copyTimestamps", copyTimestamps)
+			put("addVttTimeMap", addVttTimeMap)
+		}
 		val data = null
 		val response =
 				api.`get`<String>("/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeStartPositionTicks}/Stream.{routeFormat}",
@@ -335,21 +350,23 @@ public class SubtitleApi(
 		copyTimestamps: Boolean? = false,
 		addVttTimeMap: Boolean? = false,
 	): Response<String> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["routeItemId"] = routeItemId
-		pathParameters["routeMediaSourceId"] = routeMediaSourceId
-		pathParameters["routeIndex"] = routeIndex
-		pathParameters["routeStartPositionTicks"] = routeStartPositionTicks
-		pathParameters["routeFormat"] = routeFormat
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["itemId"] = itemId
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["index"] = index
-		queryParameters["startPositionTicks"] = startPositionTicks
-		queryParameters["format"] = format
-		queryParameters["endPositionTicks"] = endPositionTicks
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["addVttTimeMap"] = addVttTimeMap
+		val pathParameters = buildMap<String, Any?>(5) {
+			put("routeItemId", routeItemId)
+			put("routeMediaSourceId", routeMediaSourceId)
+			put("routeIndex", routeIndex)
+			put("routeStartPositionTicks", routeStartPositionTicks)
+			put("routeFormat", routeFormat)
+		}
+		val queryParameters = buildMap<String, Any?>(8) {
+			put("itemId", itemId)
+			put("mediaSourceId", mediaSourceId)
+			put("index", index)
+			put("startPositionTicks", startPositionTicks)
+			put("format", format)
+			put("endPositionTicks", endPositionTicks)
+			put("copyTimestamps", copyTimestamps)
+			put("addVttTimeMap", addVttTimeMap)
+		}
 		val data = null
 		val response =
 				api.`get`<String>("/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeStartPositionTicks}/Stream.{routeFormat}",
@@ -369,11 +386,13 @@ public class SubtitleApi(
 		language: String,
 		isPerfectMatch: Boolean? = null,
 	): Response<List<RemoteSubtitleInfo>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["language"] = language
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["isPerfectMatch"] = isPerfectMatch
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("language", language)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("isPerfectMatch", isPerfectMatch)
+		}
 		val data = null
 		val response =
 				api.`get`<List<RemoteSubtitleInfo>>("/Items/{itemId}/RemoteSearch/Subtitles/{language}",
@@ -387,8 +406,9 @@ public class SubtitleApi(
 	 * @param itemId The item the subtitle belongs to.
 	 */
 	public suspend fun uploadSubtitle(itemId: UUID, `data`: UploadSubtitleDto): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Videos/{itemId}/Subtitles", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SuggestionsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SuggestionsApi.kt
@@ -10,8 +10,8 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -41,14 +41,16 @@ public class SuggestionsApi(
 		limit: Int? = null,
 		enableTotalRecordCount: Boolean? = false,
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["mediaType"] = mediaType
-		queryParameters["type"] = type
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
+		val queryParameters = buildMap<String, Any?>(5) {
+			put("mediaType", mediaType)
+			put("type", type)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Users/{userId}/Suggestions", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SystemApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SystemApi.kt
@@ -10,8 +10,8 @@ import kotlin.Deprecated
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -43,8 +43,9 @@ public class SystemApi(
 	 */
 	public suspend fun getLogFile(name: String): Response<String> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["name"] = name
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("name", name)
+		}
 		val data = null
 		val response = api.`get`<String>("/System/Logs/Log", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TrailersApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TrailersApi.kt
@@ -11,9 +11,9 @@ import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -246,91 +246,92 @@ public class TrailersApi(
 		enableImages: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["maxOfficialRating"] = maxOfficialRating
-		queryParameters["hasThemeSong"] = hasThemeSong
-		queryParameters["hasThemeVideo"] = hasThemeVideo
-		queryParameters["hasSubtitles"] = hasSubtitles
-		queryParameters["hasSpecialFeature"] = hasSpecialFeature
-		queryParameters["hasTrailer"] = hasTrailer
-		queryParameters["adjacentTo"] = adjacentTo
-		queryParameters["parentIndexNumber"] = parentIndexNumber
-		queryParameters["hasParentalRating"] = hasParentalRating
-		queryParameters["isHd"] = isHd
-		queryParameters["is4K"] = is4k
-		queryParameters["locationTypes"] = locationTypes
-		queryParameters["excludeLocationTypes"] = excludeLocationTypes
-		queryParameters["isMissing"] = isMissing
-		queryParameters["isUnaired"] = isUnaired
-		queryParameters["minCommunityRating"] = minCommunityRating
-		queryParameters["minCriticRating"] = minCriticRating
-		queryParameters["minPremiereDate"] = minPremiereDate
-		queryParameters["minDateLastSaved"] = minDateLastSaved
-		queryParameters["minDateLastSavedForUser"] = minDateLastSavedForUser
-		queryParameters["maxPremiereDate"] = maxPremiereDate
-		queryParameters["hasOverview"] = hasOverview
-		queryParameters["hasImdbId"] = hasImdbId
-		queryParameters["hasTmdbId"] = hasTmdbId
-		queryParameters["hasTvdbId"] = hasTvdbId
-		queryParameters["isMovie"] = isMovie
-		queryParameters["isSeries"] = isSeries
-		queryParameters["isNews"] = isNews
-		queryParameters["isKids"] = isKids
-		queryParameters["isSports"] = isSports
-		queryParameters["excludeItemIds"] = excludeItemIds
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["recursive"] = recursive
-		queryParameters["searchTerm"] = searchTerm
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["filters"] = filters
-		queryParameters["isFavorite"] = isFavorite
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["imageTypes"] = imageTypes
-		queryParameters["sortBy"] = sortBy
-		queryParameters["isPlayed"] = isPlayed
-		queryParameters["genres"] = genres
-		queryParameters["officialRatings"] = officialRatings
-		queryParameters["tags"] = tags
-		queryParameters["years"] = years
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["person"] = person
-		queryParameters["personIds"] = personIds
-		queryParameters["personTypes"] = personTypes
-		queryParameters["studios"] = studios
-		queryParameters["artists"] = artists
-		queryParameters["excludeArtistIds"] = excludeArtistIds
-		queryParameters["artistIds"] = artistIds
-		queryParameters["albumArtistIds"] = albumArtistIds
-		queryParameters["contributingArtistIds"] = contributingArtistIds
-		queryParameters["albums"] = albums
-		queryParameters["albumIds"] = albumIds
-		queryParameters["ids"] = ids
-		queryParameters["videoTypes"] = videoTypes
-		queryParameters["minOfficialRating"] = minOfficialRating
-		queryParameters["isLocked"] = isLocked
-		queryParameters["isPlaceHolder"] = isPlaceHolder
-		queryParameters["hasOfficialRating"] = hasOfficialRating
-		queryParameters["collapseBoxSetItems"] = collapseBoxSetItems
-		queryParameters["minWidth"] = minWidth
-		queryParameters["minHeight"] = minHeight
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["is3D"] = is3d
-		queryParameters["seriesStatus"] = seriesStatus
-		queryParameters["nameStartsWithOrGreater"] = nameStartsWithOrGreater
-		queryParameters["nameStartsWith"] = nameStartsWith
-		queryParameters["nameLessThan"] = nameLessThan
-		queryParameters["studioIds"] = studioIds
-		queryParameters["genreIds"] = genreIds
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
-		queryParameters["enableImages"] = enableImages
+		val queryParameters = buildMap<String, Any?>(84) {
+			put("userId", userId)
+			put("maxOfficialRating", maxOfficialRating)
+			put("hasThemeSong", hasThemeSong)
+			put("hasThemeVideo", hasThemeVideo)
+			put("hasSubtitles", hasSubtitles)
+			put("hasSpecialFeature", hasSpecialFeature)
+			put("hasTrailer", hasTrailer)
+			put("adjacentTo", adjacentTo)
+			put("parentIndexNumber", parentIndexNumber)
+			put("hasParentalRating", hasParentalRating)
+			put("isHd", isHd)
+			put("is4K", is4k)
+			put("locationTypes", locationTypes)
+			put("excludeLocationTypes", excludeLocationTypes)
+			put("isMissing", isMissing)
+			put("isUnaired", isUnaired)
+			put("minCommunityRating", minCommunityRating)
+			put("minCriticRating", minCriticRating)
+			put("minPremiereDate", minPremiereDate)
+			put("minDateLastSaved", minDateLastSaved)
+			put("minDateLastSavedForUser", minDateLastSavedForUser)
+			put("maxPremiereDate", maxPremiereDate)
+			put("hasOverview", hasOverview)
+			put("hasImdbId", hasImdbId)
+			put("hasTmdbId", hasTmdbId)
+			put("hasTvdbId", hasTvdbId)
+			put("isMovie", isMovie)
+			put("isSeries", isSeries)
+			put("isNews", isNews)
+			put("isKids", isKids)
+			put("isSports", isSports)
+			put("excludeItemIds", excludeItemIds)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("recursive", recursive)
+			put("searchTerm", searchTerm)
+			put("sortOrder", sortOrder)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("filters", filters)
+			put("isFavorite", isFavorite)
+			put("mediaTypes", mediaTypes)
+			put("imageTypes", imageTypes)
+			put("sortBy", sortBy)
+			put("isPlayed", isPlayed)
+			put("genres", genres)
+			put("officialRatings", officialRatings)
+			put("tags", tags)
+			put("years", years)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("person", person)
+			put("personIds", personIds)
+			put("personTypes", personTypes)
+			put("studios", studios)
+			put("artists", artists)
+			put("excludeArtistIds", excludeArtistIds)
+			put("artistIds", artistIds)
+			put("albumArtistIds", albumArtistIds)
+			put("contributingArtistIds", contributingArtistIds)
+			put("albums", albums)
+			put("albumIds", albumIds)
+			put("ids", ids)
+			put("videoTypes", videoTypes)
+			put("minOfficialRating", minOfficialRating)
+			put("isLocked", isLocked)
+			put("isPlaceHolder", isPlaceHolder)
+			put("hasOfficialRating", hasOfficialRating)
+			put("collapseBoxSetItems", collapseBoxSetItems)
+			put("minWidth", minWidth)
+			put("minHeight", minHeight)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("is3D", is3d)
+			put("seriesStatus", seriesStatus)
+			put("nameStartsWithOrGreater", nameStartsWithOrGreater)
+			put("nameStartsWith", nameStartsWith)
+			put("nameLessThan", nameLessThan)
+			put("studioIds", studioIds)
+			put("genreIds", genreIds)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+			put("enableImages", enableImages)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Trailers", pathParameters, queryParameters,
 				data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TvShowsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TvShowsApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -67,23 +67,25 @@ public class TvShowsApi(
 		enableUserData: Boolean? = null,
 		sortBy: String? = null,
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["seriesId"] = seriesId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["fields"] = fields
-		queryParameters["season"] = season
-		queryParameters["seasonId"] = seasonId
-		queryParameters["isMissing"] = isMissing
-		queryParameters["adjacentTo"] = adjacentTo
-		queryParameters["startItemId"] = startItemId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["sortBy"] = sortBy
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("seriesId", seriesId)
+		}
+		val queryParameters = buildMap<String, Any?>(14) {
+			put("userId", userId)
+			put("fields", fields)
+			put("season", season)
+			put("seasonId", seasonId)
+			put("isMissing", isMissing)
+			put("adjacentTo", adjacentTo)
+			put("startItemId", startItemId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("enableUserData", enableUserData)
+			put("sortBy", sortBy)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Shows/{seriesId}/Episodes", pathParameters,
 				queryParameters, data)
@@ -127,21 +129,22 @@ public class TvShowsApi(
 		enableRewatching: Boolean? = false,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["seriesId"] = seriesId
-		queryParameters["parentId"] = parentId
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["nextUpDateCutoff"] = nextUpDateCutoff
-		queryParameters["enableTotalRecordCount"] = enableTotalRecordCount
-		queryParameters["disableFirstEpisode"] = disableFirstEpisode
-		queryParameters["enableRewatching"] = enableRewatching
+		val queryParameters = buildMap<String, Any?>(14) {
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("fields", fields)
+			put("seriesId", seriesId)
+			put("parentId", parentId)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("enableUserData", enableUserData)
+			put("nextUpDateCutoff", nextUpDateCutoff)
+			put("enableTotalRecordCount", enableTotalRecordCount)
+			put("disableFirstEpisode", disableFirstEpisode)
+			put("enableRewatching", enableRewatching)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Shows/NextUp", pathParameters, queryParameters,
 				data)
@@ -177,18 +180,20 @@ public class TvShowsApi(
 		enableImageTypes: Collection<ImageType>? = emptyList(),
 		enableUserData: Boolean? = null,
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["seriesId"] = seriesId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["fields"] = fields
-		queryParameters["isSpecialSeason"] = isSpecialSeason
-		queryParameters["isMissing"] = isMissing
-		queryParameters["adjacentTo"] = adjacentTo
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["enableUserData"] = enableUserData
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("seriesId", seriesId)
+		}
+		val queryParameters = buildMap<String, Any?>(9) {
+			put("userId", userId)
+			put("fields", fields)
+			put("isSpecialSeason", isSpecialSeason)
+			put("isMissing", isMissing)
+			put("adjacentTo", adjacentTo)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("enableUserData", enableUserData)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Shows/{seriesId}/Seasons", pathParameters,
 				queryParameters, data)
@@ -222,16 +227,17 @@ public class TvShowsApi(
 		enableUserData: Boolean? = null,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["fields"] = fields
-		queryParameters["parentId"] = parentId
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["enableUserData"] = enableUserData
+		val queryParameters = buildMap<String, Any?>(9) {
+			put("userId", userId)
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("fields", fields)
+			put("parentId", parentId)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("enableUserData", enableUserData)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Shows/Upcoming", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
@@ -12,8 +12,8 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -66,26 +66,28 @@ public class UniversalAudioApi(
 		breakOnNonKeyFrames: Boolean? = false,
 		enableRedirection: Boolean? = true,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["userId"] = userId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["transcodingAudioChannels"] = transcodingAudioChannels
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["transcodingContainer"] = transcodingContainer
-		queryParameters["transcodingProtocol"] = transcodingProtocol
-		queryParameters["maxAudioSampleRate"] = maxAudioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["enableRemoteMedia"] = enableRemoteMedia
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["enableRedirection"] = enableRedirection
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("container", container)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("userId", userId)
+			put("audioCodec", audioCodec)
+			put("maxAudioChannels", maxAudioChannels)
+			put("transcodingAudioChannels", transcodingAudioChannels)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("startTimeTicks", startTimeTicks)
+			put("transcodingContainer", transcodingContainer)
+			put("transcodingProtocol", transcodingProtocol)
+			put("maxAudioSampleRate", maxAudioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("enableRemoteMedia", enableRemoteMedia)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("enableRedirection", enableRedirection)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/universal", pathParameters,
 				queryParameters, data)
@@ -138,26 +140,28 @@ public class UniversalAudioApi(
 		enableRedirection: Boolean? = true,
 		includeCredentials: Boolean = true,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["userId"] = userId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["transcodingAudioChannels"] = transcodingAudioChannels
-		queryParameters["maxStreamingBitrate"] = maxStreamingBitrate
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["transcodingContainer"] = transcodingContainer
-		queryParameters["transcodingProtocol"] = transcodingProtocol
-		queryParameters["maxAudioSampleRate"] = maxAudioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["enableRemoteMedia"] = enableRemoteMedia
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["enableRedirection"] = enableRedirection
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(17) {
+			put("container", container)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("userId", userId)
+			put("audioCodec", audioCodec)
+			put("maxAudioChannels", maxAudioChannels)
+			put("transcodingAudioChannels", transcodingAudioChannels)
+			put("maxStreamingBitrate", maxStreamingBitrate)
+			put("audioBitRate", audioBitRate)
+			put("startTimeTicks", startTimeTicks)
+			put("transcodingContainer", transcodingContainer)
+			put("transcodingProtocol", transcodingProtocol)
+			put("maxAudioSampleRate", maxAudioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("enableRemoteMedia", enableRemoteMedia)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("enableRedirection", enableRedirection)
+		}
 		return api.createUrl("/Audio/{itemId}/universal", pathParameters, queryParameters,
 				includeCredentials)
 	}

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserApi.kt
@@ -10,8 +10,8 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -48,11 +48,13 @@ public class UserApi(
 		pw: String,
 		password: String? = null,
 	): Response<AuthenticationResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["pw"] = pw
-		queryParameters["password"] = password
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("pw", pw)
+			put("password", password)
+		}
 		val data = null
 		val response = api.post<AuthenticationResult>("/Users/{userId}/Authenticate", pathParameters,
 				queryParameters, data)
@@ -100,8 +102,9 @@ public class UserApi(
 	 */
 	public suspend fun deleteUser(userId: UUID = api.userId ?: throw MissingUserIdException()):
 			Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Users/{userId}", pathParameters, queryParameters, data)
@@ -159,8 +162,9 @@ public class UserApi(
 	 */
 	public suspend fun getUserById(userId: UUID = api.userId ?: throw MissingUserIdException()):
 			Response<UserDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<UserDto>("/Users/{userId}", pathParameters, queryParameters, data)
@@ -176,9 +180,10 @@ public class UserApi(
 	public suspend fun getUsers(isHidden: Boolean? = null, isDisabled: Boolean? = null):
 			Response<List<UserDto>> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["isHidden"] = isHidden
-		queryParameters["isDisabled"] = isDisabled
+		val queryParameters = buildMap<String, Any?>(2) {
+			put("isHidden", isHidden)
+			put("isDisabled", isDisabled)
+		}
 		val data = null
 		val response = api.`get`<List<UserDto>>("/Users", pathParameters, queryParameters, data)
 		return response
@@ -191,8 +196,9 @@ public class UserApi(
 	 */
 	public suspend fun updateUser(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			`data`: UserDto): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Users/{userId}", pathParameters, queryParameters, data)
 		return response
@@ -205,8 +211,9 @@ public class UserApi(
 	 */
 	public suspend fun updateUserConfiguration(userId: UUID = api.userId ?: throw
 			MissingUserIdException(), `data`: UserConfiguration): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Users/{userId}/Configuration", pathParameters, queryParameters,
 				data)
@@ -220,8 +227,9 @@ public class UserApi(
 	 */
 	public suspend fun updateUserEasyPassword(userId: UUID = api.userId ?: throw
 			MissingUserIdException(), `data`: UpdateUserEasyPassword): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Users/{userId}/EasyPassword", pathParameters, queryParameters,
 				data)
@@ -235,8 +243,9 @@ public class UserApi(
 	 */
 	public suspend fun updateUserPassword(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			`data`: UpdateUserPassword): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Users/{userId}/Password", pathParameters, queryParameters, data)
 		return response
@@ -249,8 +258,9 @@ public class UserApi(
 	 */
 	public suspend fun updateUserPolicy(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			`data`: UserPolicy): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Users/{userId}/Policy", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserLibraryApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserLibraryApi.kt
@@ -11,9 +11,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -39,9 +39,10 @@ public class UserLibraryApi(
 	 */
 	public suspend fun deleteUserItemRating(userId: UUID = api.userId ?: throw
 			MissingUserIdException(), itemId: UUID): Response<UserItemDataDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<UserItemDataDto>("/Users/{userId}/Items/{itemId}/Rating",
@@ -57,9 +58,10 @@ public class UserLibraryApi(
 	 */
 	public suspend fun getIntros(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			itemId: UUID): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Users/{userId}/Items/{itemId}/Intros",
@@ -75,9 +77,10 @@ public class UserLibraryApi(
 	 */
 	public suspend fun getItem(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			itemId: UUID): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<BaseItemDto>("/Users/{userId}/Items/{itemId}", pathParameters,
@@ -115,19 +118,21 @@ public class UserLibraryApi(
 		limit: Int? = 20,
 		groupItems: Boolean? = true,
 	): Response<List<BaseItemDto>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["isPlayed"] = isPlayed
-		queryParameters["enableImages"] = enableImages
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["limit"] = limit
-		queryParameters["groupItems"] = groupItems
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
+		val queryParameters = buildMap<String, Any?>(10) {
+			put("parentId", parentId)
+			put("fields", fields)
+			put("includeItemTypes", includeItemTypes)
+			put("isPlayed", isPlayed)
+			put("enableImages", enableImages)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("enableUserData", enableUserData)
+			put("limit", limit)
+			put("groupItems", groupItems)
+		}
 		val data = null
 		val response = api.`get`<List<BaseItemDto>>("/Users/{userId}/Items/Latest", pathParameters,
 				queryParameters, data)
@@ -142,9 +147,10 @@ public class UserLibraryApi(
 	 */
 	public suspend fun getLocalTrailers(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			itemId: UUID): Response<List<BaseItemDto>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<List<BaseItemDto>>("/Users/{userId}/Items/{itemId}/LocalTrailers",
@@ -159,8 +165,9 @@ public class UserLibraryApi(
 	 */
 	public suspend fun getRootFolder(userId: UUID = api.userId ?: throw MissingUserIdException()):
 			Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<BaseItemDto>("/Users/{userId}/Items/Root", pathParameters,
@@ -176,9 +183,10 @@ public class UserLibraryApi(
 	 */
 	public suspend fun getSpecialFeatures(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			itemId: UUID): Response<List<BaseItemDto>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<List<BaseItemDto>>("/Users/{userId}/Items/{itemId}/SpecialFeatures",
@@ -194,9 +202,10 @@ public class UserLibraryApi(
 	 */
 	public suspend fun markFavoriteItem(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			itemId: UUID): Response<UserItemDataDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.post<UserItemDataDto>("/Users/{userId}/FavoriteItems/{itemId}", pathParameters,
@@ -212,9 +221,10 @@ public class UserLibraryApi(
 	 */
 	public suspend fun unmarkFavoriteItem(userId: UUID = api.userId ?: throw MissingUserIdException(),
 			itemId: UUID): Response<UserItemDataDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<UserItemDataDto>("/Users/{userId}/FavoriteItems/{itemId}",
@@ -236,11 +246,13 @@ public class UserLibraryApi(
 		itemId: UUID,
 		likes: Boolean? = null,
 	): Response<UserItemDataDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["likes"] = likes
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("userId", userId)
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("likes", likes)
+		}
 		val data = null
 		val response = api.post<UserItemDataDto>("/Users/{userId}/Items/{itemId}/Rating", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserViewsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UserViewsApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.List
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.exception.MissingUserIdException
@@ -31,8 +31,9 @@ public class UserViewsApi(
 	 */
 	public suspend fun getGroupingOptions(userId: UUID = api.userId ?: throw MissingUserIdException()):
 			Response<List<SpecialViewOptionDto>> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<List<SpecialViewOptionDto>>("/Users/{userId}/GroupingOptions",
@@ -55,12 +56,14 @@ public class UserViewsApi(
 		presetViews: Collection<String>? = emptyList(),
 		includeHidden: Boolean? = false,
 	): Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["userId"] = userId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["includeExternalContent"] = includeExternalContent
-		queryParameters["presetViews"] = presetViews
-		queryParameters["includeHidden"] = includeHidden
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
+		val queryParameters = buildMap<String, Any?>(3) {
+			put("includeExternalContent", includeExternalContent)
+			put("presetViews", presetViews)
+			put("includeHidden", includeHidden)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Users/{userId}/Views", pathParameters,
 				queryParameters, data)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
@@ -10,8 +10,8 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
+import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -32,10 +32,11 @@ public class VideoAttachmentsApi(
 		mediaSourceId: String,
 		index: Int,
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["videoId"] = videoId
-		pathParameters["mediaSourceId"] = mediaSourceId
-		pathParameters["index"] = index
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("videoId", videoId)
+			put("mediaSourceId", mediaSourceId)
+			put("index", index)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Videos/{videoId}/{mediaSourceId}/Attachments/{index}",
@@ -57,10 +58,11 @@ public class VideoAttachmentsApi(
 		index: Int,
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["videoId"] = videoId
-		pathParameters["mediaSourceId"] = mediaSourceId
-		pathParameters["index"] = index
+		val pathParameters = buildMap<String, Any?>(3) {
+			put("videoId", videoId)
+			put("mediaSourceId", mediaSourceId)
+			put("index", index)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		return api.createUrl("/Videos/{videoId}/{mediaSourceId}/Attachments/{index}", pathParameters,
 				queryParameters, includeCredentials)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
@@ -15,9 +15,9 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.Map
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -37,8 +37,9 @@ public class VideosApi(
 	 * @param itemId The item id.
 	 */
 	public suspend fun deleteAlternateSources(itemId: UUID): Response<Unit> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
 		val response = api.delete<Unit>("/Videos/{itemId}/AlternateSources", pathParameters,
@@ -54,10 +55,12 @@ public class VideosApi(
 	 */
 	public suspend fun getAdditionalPart(itemId: UUID, userId: UUID? = null):
 			Response<BaseItemDtoQueryResult> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Videos/{itemId}/AdditionalParts",
 				pathParameters, queryParameters, data)
@@ -189,59 +192,61 @@ public class VideosApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(50) {
+			put("container", container)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/stream", pathParameters,
 				queryParameters, data)
@@ -375,59 +380,61 @@ public class VideosApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["container"] = container
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("itemId", itemId)
+		}
+		val queryParameters = buildMap<String, Any?>(50) {
+			put("container", container)
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Videos/{itemId}/stream", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -557,59 +564,61 @@ public class VideosApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 	): Response<ByteReadChannel> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(49) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		val data = null
 		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/stream.{container}", pathParameters,
 				queryParameters, data)
@@ -743,59 +752,61 @@ public class VideosApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		includeCredentials: Boolean = false,
 	): String {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["itemId"] = itemId
-		pathParameters["container"] = container
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["static"] = static
-		queryParameters["params"] = params
-		queryParameters["tag"] = tag
-		queryParameters["deviceProfileId"] = deviceProfileId
-		queryParameters["playSessionId"] = playSessionId
-		queryParameters["segmentContainer"] = segmentContainer
-		queryParameters["segmentLength"] = segmentLength
-		queryParameters["minSegments"] = minSegments
-		queryParameters["mediaSourceId"] = mediaSourceId
-		queryParameters["deviceId"] = deviceId
-		queryParameters["audioCodec"] = audioCodec
-		queryParameters["enableAutoStreamCopy"] = enableAutoStreamCopy
-		queryParameters["allowVideoStreamCopy"] = allowVideoStreamCopy
-		queryParameters["allowAudioStreamCopy"] = allowAudioStreamCopy
-		queryParameters["breakOnNonKeyFrames"] = breakOnNonKeyFrames
-		queryParameters["audioSampleRate"] = audioSampleRate
-		queryParameters["maxAudioBitDepth"] = maxAudioBitDepth
-		queryParameters["audioBitRate"] = audioBitRate
-		queryParameters["audioChannels"] = audioChannels
-		queryParameters["maxAudioChannels"] = maxAudioChannels
-		queryParameters["profile"] = profile
-		queryParameters["level"] = level
-		queryParameters["framerate"] = framerate
-		queryParameters["maxFramerate"] = maxFramerate
-		queryParameters["copyTimestamps"] = copyTimestamps
-		queryParameters["startTimeTicks"] = startTimeTicks
-		queryParameters["width"] = width
-		queryParameters["height"] = height
-		queryParameters["maxWidth"] = maxWidth
-		queryParameters["maxHeight"] = maxHeight
-		queryParameters["videoBitRate"] = videoBitRate
-		queryParameters["subtitleStreamIndex"] = subtitleStreamIndex
-		queryParameters["subtitleMethod"] = subtitleMethod
-		queryParameters["maxRefFrames"] = maxRefFrames
-		queryParameters["maxVideoBitDepth"] = maxVideoBitDepth
-		queryParameters["requireAvc"] = requireAvc
-		queryParameters["deInterlace"] = deInterlace
-		queryParameters["requireNonAnamorphic"] = requireNonAnamorphic
-		queryParameters["transcodingMaxAudioChannels"] = transcodingMaxAudioChannels
-		queryParameters["cpuCoreLimit"] = cpuCoreLimit
-		queryParameters["liveStreamId"] = liveStreamId
-		queryParameters["enableMpegtsM2TsMode"] = enableMpegtsM2TsMode
-		queryParameters["videoCodec"] = videoCodec
-		queryParameters["subtitleCodec"] = subtitleCodec
-		queryParameters["transcodeReasons"] = transcodeReasons
-		queryParameters["audioStreamIndex"] = audioStreamIndex
-		queryParameters["videoStreamIndex"] = videoStreamIndex
-		queryParameters["context"] = context
-		queryParameters["streamOptions"] = streamOptions
+		val pathParameters = buildMap<String, Any?>(2) {
+			put("itemId", itemId)
+			put("container", container)
+		}
+		val queryParameters = buildMap<String, Any?>(49) {
+			put("static", static)
+			put("params", params)
+			put("tag", tag)
+			put("deviceProfileId", deviceProfileId)
+			put("playSessionId", playSessionId)
+			put("segmentContainer", segmentContainer)
+			put("segmentLength", segmentLength)
+			put("minSegments", minSegments)
+			put("mediaSourceId", mediaSourceId)
+			put("deviceId", deviceId)
+			put("audioCodec", audioCodec)
+			put("enableAutoStreamCopy", enableAutoStreamCopy)
+			put("allowVideoStreamCopy", allowVideoStreamCopy)
+			put("allowAudioStreamCopy", allowAudioStreamCopy)
+			put("breakOnNonKeyFrames", breakOnNonKeyFrames)
+			put("audioSampleRate", audioSampleRate)
+			put("maxAudioBitDepth", maxAudioBitDepth)
+			put("audioBitRate", audioBitRate)
+			put("audioChannels", audioChannels)
+			put("maxAudioChannels", maxAudioChannels)
+			put("profile", profile)
+			put("level", level)
+			put("framerate", framerate)
+			put("maxFramerate", maxFramerate)
+			put("copyTimestamps", copyTimestamps)
+			put("startTimeTicks", startTimeTicks)
+			put("width", width)
+			put("height", height)
+			put("maxWidth", maxWidth)
+			put("maxHeight", maxHeight)
+			put("videoBitRate", videoBitRate)
+			put("subtitleStreamIndex", subtitleStreamIndex)
+			put("subtitleMethod", subtitleMethod)
+			put("maxRefFrames", maxRefFrames)
+			put("maxVideoBitDepth", maxVideoBitDepth)
+			put("requireAvc", requireAvc)
+			put("deInterlace", deInterlace)
+			put("requireNonAnamorphic", requireNonAnamorphic)
+			put("transcodingMaxAudioChannels", transcodingMaxAudioChannels)
+			put("cpuCoreLimit", cpuCoreLimit)
+			put("liveStreamId", liveStreamId)
+			put("enableMpegtsM2TsMode", enableMpegtsM2TsMode)
+			put("videoCodec", videoCodec)
+			put("subtitleCodec", subtitleCodec)
+			put("transcodeReasons", transcodeReasons)
+			put("audioStreamIndex", audioStreamIndex)
+			put("videoStreamIndex", videoStreamIndex)
+			put("context", context)
+			put("streamOptions", streamOptions)
+		}
 		return api.createUrl("/Videos/{itemId}/stream.{container}", pathParameters, queryParameters,
 				includeCredentials)
 	}
@@ -807,8 +818,9 @@ public class VideosApi(
 	 */
 	public suspend fun mergeVersions(ids: Collection<UUID> = emptyList()): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["ids"] = ids
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("ids", ids)
+		}
 		val data = null
 		val response = api.post<Unit>("/Videos/MergeVersions", pathParameters, queryParameters, data)
 		return response

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/YearsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/YearsApi.kt
@@ -10,9 +10,9 @@ import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Collection
+import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
-import kotlin.collections.mutableMapOf
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -34,10 +34,12 @@ public class YearsApi(
 	 * @param userId Optional. Filter by user id, and attach user data.
 	 */
 	public suspend fun getYear(year: Int, userId: UUID? = null): Response<BaseItemDto> {
-		val pathParameters = mutableMapOf<String, Any?>()
-		pathParameters["year"] = year
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["userId"] = userId
+		val pathParameters = buildMap<String, Any?>(1) {
+			put("year", year)
+		}
+		val queryParameters = buildMap<String, Any?>(1) {
+			put("userId", userId)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDto>("/Years/{year}", pathParameters, queryParameters, data)
 		return response
@@ -85,22 +87,23 @@ public class YearsApi(
 		enableImages: Boolean? = true,
 	): Response<BaseItemDtoQueryResult> {
 		val pathParameters = emptyMap<String, Any?>()
-		val queryParameters = mutableMapOf<String, Any?>()
-		queryParameters["startIndex"] = startIndex
-		queryParameters["limit"] = limit
-		queryParameters["sortOrder"] = sortOrder
-		queryParameters["parentId"] = parentId
-		queryParameters["fields"] = fields
-		queryParameters["excludeItemTypes"] = excludeItemTypes
-		queryParameters["includeItemTypes"] = includeItemTypes
-		queryParameters["mediaTypes"] = mediaTypes
-		queryParameters["sortBy"] = sortBy
-		queryParameters["enableUserData"] = enableUserData
-		queryParameters["imageTypeLimit"] = imageTypeLimit
-		queryParameters["enableImageTypes"] = enableImageTypes
-		queryParameters["userId"] = userId
-		queryParameters["recursive"] = recursive
-		queryParameters["enableImages"] = enableImages
+		val queryParameters = buildMap<String, Any?>(15) {
+			put("startIndex", startIndex)
+			put("limit", limit)
+			put("sortOrder", sortOrder)
+			put("parentId", parentId)
+			put("fields", fields)
+			put("excludeItemTypes", excludeItemTypes)
+			put("includeItemTypes", includeItemTypes)
+			put("mediaTypes", mediaTypes)
+			put("sortBy", sortBy)
+			put("enableUserData", enableUserData)
+			put("imageTypeLimit", imageTypeLimit)
+			put("enableImageTypes", enableImageTypes)
+			put("userId", userId)
+			put("recursive", recursive)
+			put("enableImages", enableImages)
+		}
 		val data = null
 		val response = api.`get`<BaseItemDtoQueryResult>("/Years", pathParameters, queryParameters, data)
 		return response


### PR DESCRIPTION
Using buildMap {} with capacity set instead of a mutable map should be more efficient as the capacity is known in advance. I didn't benchmark this though.