### PR TITLE
Support default values in generated models

### DIFF
--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfile.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfile.kt
@@ -86,17 +86,17 @@ public data class DeviceProfile(
 	 * Gets or sets a value indicating whether EnableAlbumArtInDidl.
 	 */
 	@SerialName("EnableAlbumArtInDidl")
-	public val enableAlbumArtInDidl: Boolean,
+	public val enableAlbumArtInDidl: Boolean = false,
 	/**
 	 * Gets or sets a value indicating whether EnableSingleAlbumArtLimit.
 	 */
 	@SerialName("EnableSingleAlbumArtLimit")
-	public val enableSingleAlbumArtLimit: Boolean,
+	public val enableSingleAlbumArtLimit: Boolean = false,
 	/**
 	 * Gets or sets a value indicating whether EnableSingleSubtitleLimit.
 	 */
 	@SerialName("EnableSingleSubtitleLimit")
-	public val enableSingleSubtitleLimit: Boolean,
+	public val enableSingleSubtitleLimit: Boolean = false,
 	/**
 	 * Gets or sets the SupportedMediaTypes.
 	 */
@@ -168,27 +168,27 @@ public data class DeviceProfile(
 	 * Gets or sets the TimelineOffsetSeconds.
 	 */
 	@SerialName("TimelineOffsetSeconds")
-	public val timelineOffsetSeconds: Int,
+	public val timelineOffsetSeconds: Int = 0,
 	/**
 	 * Gets or sets a value indicating whether RequiresPlainVideoItems.
 	 */
 	@SerialName("RequiresPlainVideoItems")
-	public val requiresPlainVideoItems: Boolean,
+	public val requiresPlainVideoItems: Boolean = false,
 	/**
 	 * Gets or sets a value indicating whether RequiresPlainFolders.
 	 */
 	@SerialName("RequiresPlainFolders")
-	public val requiresPlainFolders: Boolean,
+	public val requiresPlainFolders: Boolean = false,
 	/**
 	 * Gets or sets a value indicating whether EnableMSMediaReceiverRegistrar.
 	 */
 	@SerialName("EnableMSMediaReceiverRegistrar")
-	public val enableMsMediaReceiverRegistrar: Boolean,
+	public val enableMsMediaReceiverRegistrar: Boolean = false,
 	/**
 	 * Gets or sets a value indicating whether IgnoreTranscodeByteRangeRequests.
 	 */
 	@SerialName("IgnoreTranscodeByteRangeRequests")
-	public val ignoreTranscodeByteRangeRequests: Boolean,
+	public val ignoreTranscodeByteRangeRequests: Boolean = false,
 	/**
 	 * Gets or sets the XmlRootAttributes.
 	 */

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TranscodingProfile.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TranscodingProfile.kt
@@ -25,25 +25,25 @@ public data class TranscodingProfile(
 	@SerialName("Protocol")
 	public val protocol: String,
 	@SerialName("EstimateContentLength")
-	public val estimateContentLength: Boolean,
+	public val estimateContentLength: Boolean = false,
 	@SerialName("EnableMpegtsM2TsMode")
-	public val enableMpegtsM2TsMode: Boolean,
+	public val enableMpegtsM2TsMode: Boolean = false,
 	@SerialName("TranscodeSeekInfo")
 	public val transcodeSeekInfo: TranscodeSeekInfo,
 	@SerialName("CopyTimestamps")
-	public val copyTimestamps: Boolean,
+	public val copyTimestamps: Boolean = false,
 	@SerialName("Context")
 	public val context: EncodingContext,
 	@SerialName("EnableSubtitlesInManifest")
-	public val enableSubtitlesInManifest: Boolean,
+	public val enableSubtitlesInManifest: Boolean = false,
 	@SerialName("MaxAudioChannels")
 	public val maxAudioChannels: String? = null,
 	@SerialName("MinSegments")
-	public val minSegments: Int,
+	public val minSegments: Int = 0,
 	@SerialName("SegmentLength")
-	public val segmentLength: Int,
+	public val segmentLength: Int = 0,
 	@SerialName("BreakOnNonKeyFrames")
-	public val breakOnNonKeyFrames: Boolean,
+	public val breakOnNonKeyFrames: Boolean = false,
 	@SerialName("Conditions")
 	public val conditions: List<ProfileCondition>,
 )

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/defaultValueExtensions.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/defaultValueExtensions.kt
@@ -1,0 +1,57 @@
+package org.jellyfin.openapi.builder.extra
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.TypeName
+import org.jellyfin.openapi.constants.Types
+import org.jellyfin.openapi.model.ApiServiceOperationParameter
+import org.jellyfin.openapi.model.CustomDefaultValue
+import org.jellyfin.openapi.model.ObjectApiModelProperty
+
+fun ParameterSpec.Builder.defaultValue(
+	type: TypeName,
+	defaultValue: Any?,
+	allowEmptyCollection: Boolean,
+) {
+	// Determine class name without parameters
+	val typeClassName = when (type) {
+		is ClassName -> type
+		is ParameterizedTypeName -> type.rawType
+		else -> null
+	}
+
+	// Set default value
+	when (defaultValue) {
+		is String -> defaultValue("%S", defaultValue)
+		is Int -> defaultValue("%L", defaultValue)
+		is Boolean -> defaultValue("%L", defaultValue)
+		is CustomDefaultValue -> defaultValue(defaultValue.build())
+		// Set value to null by default for nullable values
+		null -> when {
+			typeClassName == Types.COLLECTION && allowEmptyCollection ->
+				defaultValue("%M()", MemberName("kotlin.collections", "emptyList"))
+
+			typeClassName == Types.LIST && allowEmptyCollection ->
+				defaultValue("%M()", MemberName("kotlin.collections", "emptyList"))
+
+			typeClassName == Types.MAP && allowEmptyCollection ->
+				defaultValue("%M()", MemberName("kotlin.collections", "emptyMap"))
+
+			type.isNullable -> defaultValue("%L", "null")
+		}
+	}
+}
+
+fun ParameterSpec.Builder.defaultValue(parameter: ApiServiceOperationParameter) = defaultValue(
+	type = parameter.type,
+	defaultValue = parameter.defaultValue,
+	allowEmptyCollection = true,
+)
+
+fun ParameterSpec.Builder.defaultValue(property: ObjectApiModelProperty) = defaultValue(
+	type = property.type,
+	defaultValue = property.defaultValue,
+	allowEmptyCollection = false,
+)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/defaultValueExtensions.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/defaultValueExtensions.kt
@@ -10,6 +10,7 @@ import org.jellyfin.openapi.model.ApiServiceOperationParameter
 import org.jellyfin.openapi.model.CustomDefaultValue
 import org.jellyfin.openapi.model.ObjectApiModelProperty
 
+@Suppress("ComplexMethod")
 fun ParameterSpec.Builder.defaultValue(
 	type: TypeName,
 	defaultValue: Any?,

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ObjectModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ObjectModelBuilder.kt
@@ -13,6 +13,7 @@ import org.jellyfin.openapi.builder.Builder
 import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
 import org.jellyfin.openapi.builder.extra.DescriptionBuilder
 import org.jellyfin.openapi.builder.extra.TypeSerializerBuilder
+import org.jellyfin.openapi.builder.extra.defaultValue
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
@@ -32,8 +33,7 @@ class ObjectModelBuilder(
 			data.properties.forEach { property ->
 				// Create constructor parameter
 				addParameter(ParameterSpec.builder(property.name, property.type).apply {
-					// Set value to null by default for nullable values
-					if (property.type.isNullable) defaultValue("%L", "null")
+					defaultValue(property)
 				}.build())
 
 				// Create class property

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
@@ -36,6 +36,7 @@ class OpenApiModelBuilder(
 						ObjectApiModelProperty(
 							name = name,
 							originalName = originalName,
+							defaultValue = property.default,
 							type = openApiTypeBuilder.build(ModelTypePath(data.name, name), property),
 							description = property.description,
 							deprecated = property.deprecated == true

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ObjectApiModelProperty.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ObjectApiModelProperty.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.TypeName
 data class ObjectApiModelProperty(
 	val name: String,
 	val originalName: String,
+	val defaultValue: Any?,
 	val type: TypeName,
 	val description: String?,
 	val deprecated: Boolean


### PR DESCRIPTION
Right now this adds a few booleans/numbers to some response models - nothing fancy. This change is a part of #454 though, where we need the default values generated for request models.

The DefaultValueHook is not supported for models right now.