### PR TITLE
Use URL encoding for authorization header values

### DIFF
--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilderTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilderTests.kt
@@ -1,16 +1,20 @@
 package org.jellyfin.sdk.api.client.util
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
 import io.kotest.matchers.shouldBe
 
 class AuthorizationHeaderBuilderTests : FunSpec({
 	test("encodeParameter removes special characters") {
-		AuthorizationHeaderBuilder.encodeParameterValue("""test""") shouldBe "test"
-		AuthorizationHeaderBuilder.encodeParameterValue("""test+""") shouldBe "test+"
-		AuthorizationHeaderBuilder.encodeParameterValue("""'test'""") shouldBe "'test'"
-		AuthorizationHeaderBuilder.encodeParameterValue("""今日は""") shouldBe "???"
-		AuthorizationHeaderBuilder.encodeParameterValue("""水母""") shouldBe "??"
-		AuthorizationHeaderBuilder.encodeParameterValue("""ἈᾼᾺΆᾍᾋ""") shouldBe "??????"
+		forAll(
+			row("""test""", "test"),
+			row("""test+""", "test%2B"),
+			row("""'test'""", "%27test%27"),
+			row("""今日は""", "%E4%BB%8A%E6%97%A5%E3%81%AF"),
+			row("""水母""", "%E6%B0%B4%E6%AF%8D"),
+			row("""ἈᾼᾺΆᾍᾋ""", "%E1%BC%88%E1%BE%BC%E1%BE%BA%E1%BE%BB%E1%BE%8D%E1%BE%8B"),
+		) { a, b -> AuthorizationHeaderBuilder.encodeParameterValue(a) shouldBe b }
 	}
 
 	test("buildParameter creates a valid header with access token") {


### PR DESCRIPTION
10.8 finally has proper parsing for the Authorization header (https://github.com/jellyfin/jellyfin/pull/4799) so now we can finally support device names with special characters.

Fixes https://github.com/jellyfin/jellyfin-androidtv/issues/1946