### PR TITLE
Support enum defaults, add generator context

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Generator.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/Generator.kt
@@ -29,13 +29,13 @@ class Generator(
 
 		val context = GeneratorContext(openApiSpecification)
 
-		// Generate API
-		openApiApiServicesBuilder.build(context, context.paths)
-		apisBuilder.build(context, context.apiServices)
-
-		// Generate models
+		// Generate intermediate models
 		openApiModelsBuilder.build(context, context.schemas)
+		openApiApiServicesBuilder.build(context, context.paths)
+
+		// Generate code
 		modelsBuilder.build(context, context.models)
+		apisBuilder.build(context, context.apiServices)
 
 		// Add meta files
 		apiClientExtensionsBuilder.build(context, context.apiServices)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
@@ -3,6 +3,7 @@ package org.jellyfin.openapi
 import org.jellyfin.openapi.builder.api.ApiBuilder
 import org.jellyfin.openapi.builder.api.ApiClientExtensionsBuilder
 import org.jellyfin.openapi.builder.api.ApiNameBuilder
+import org.jellyfin.openapi.builder.api.ApisBuilder
 import org.jellyfin.openapi.builder.api.OperationBuilder
 import org.jellyfin.openapi.builder.api.OperationUrlBuilder
 import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
@@ -12,11 +13,13 @@ import org.jellyfin.openapi.builder.extra.TypeSerializerBuilder
 import org.jellyfin.openapi.builder.model.EmptyModelBuilder
 import org.jellyfin.openapi.builder.model.EnumModelBuilder
 import org.jellyfin.openapi.builder.model.ModelBuilder
+import org.jellyfin.openapi.builder.model.ModelsBuilder
 import org.jellyfin.openapi.builder.model.ObjectModelBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiApiServicesBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiConstantsBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiDefaultValueBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiModelBuilder
+import org.jellyfin.openapi.builder.openapi.OpenApiModelsBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiReturnTypeBuilder
 import org.jellyfin.openapi.builder.openapi.OpenApiTypeBuilder
 import org.koin.dsl.module
@@ -27,9 +30,10 @@ val mainModule = module {
 	// OpenAPI
 	single { OpenApiTypeBuilder(getAll()) }
 	single { OpenApiReturnTypeBuilder(get()) }
-	single { OpenApiModelBuilder(get(), get(), get()) }
+	single { OpenApiModelBuilder(get(), get()) }
+	single { OpenApiModelsBuilder(get()) }
 	single { OpenApiApiServicesBuilder(get(), get(), get(), get(), getAll(), getAll()) }
-	single { OpenApiConstantsBuilder() }
+	single { OpenApiConstantsBuilder(get()) }
 	single { OpenApiDefaultValueBuilder() }
 
 	// API
@@ -37,10 +41,12 @@ val mainModule = module {
 	single { OperationBuilder(get(), get()) }
 	single { OperationUrlBuilder(get(), get()) }
 	single { ApiBuilder(get(), get(), getAll()) }
+	single { ApisBuilder(get(), get()) }
 	single { ApiClientExtensionsBuilder(get()) }
 
 	// Models
 	single { ModelBuilder(get(), get(), get()) }
+	single { ModelsBuilder(get(), get()) }
 	single { EmptyModelBuilder(get(), get()) }
 	single { EnumModelBuilder(get(), get()) }
 	single { ObjectModelBuilder(get(), get(), get()) }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/ContextBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/ContextBuilder.kt
@@ -1,0 +1,7 @@
+package org.jellyfin.openapi.builder
+
+import org.jellyfin.openapi.model.GeneratorContext
+
+interface ContextBuilder<T, R> {
+	fun build(context: GeneratorContext, data: T): R
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/ApiClientExtensionsBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/ApiClientExtensionsBuilder.kt
@@ -4,17 +4,18 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
-import org.jellyfin.openapi.builder.Builder
+import org.jellyfin.openapi.builder.ContextBuilder
 import org.jellyfin.openapi.builder.extra.FileSpecBuilder
 import org.jellyfin.openapi.constants.Classes
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.model.ApiService
+import org.jellyfin.openapi.model.GeneratorContext
 
 class ApiClientExtensionsBuilder(
 	private val fileSpecBuilder: FileSpecBuilder,
-) : Builder<Collection<ApiService>, FileSpec> {
-	override fun build(data: Collection<ApiService>): FileSpec {
-		return FileSpec.builder(Packages.API_CLIENT_EXTENSIONS, Classes.API_CLIENT_EXTENSIONS).apply {
+) : ContextBuilder<Collection<ApiService>, Unit> {
+	override fun build(context: GeneratorContext, data: Collection<ApiService>) {
+		context += FileSpec.builder(Packages.API_CLIENT_EXTENSIONS, Classes.API_CLIENT_EXTENSIONS).apply {
 			fileSpecBuilder.buildHeader(this)
 			data.forEach { api -> addProperty(buildExtensionProperty(api)) }
 		}.build()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/ApisBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/ApisBuilder.kt
@@ -1,0 +1,18 @@
+package org.jellyfin.openapi.builder.api
+
+import org.jellyfin.openapi.builder.ContextBuilder
+import org.jellyfin.openapi.builder.extra.FileSpecBuilder
+import org.jellyfin.openapi.model.ApiService
+import org.jellyfin.openapi.model.GeneratorContext
+
+class ApisBuilder(
+	private val apiBuilder: ApiBuilder,
+	private val fileSpecBuilder: FileSpecBuilder,
+) : ContextBuilder<Collection<ApiService>, Unit> {
+	override fun build(context: GeneratorContext, data: Collection<ApiService>) {
+		for (apiService in data) {
+			val file = apiBuilder.build(apiService)
+			context += fileSpecBuilder.build(file)
+		}
+	}
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/defaultValueExtensions.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/defaultValueExtensions.kt
@@ -28,6 +28,7 @@ fun ParameterSpec.Builder.defaultValue(
 		is DefaultValue.String -> defaultValue("%S", defaultValue.value)
 		is DefaultValue.Int -> defaultValue("%L", defaultValue.value)
 		is DefaultValue.Boolean -> defaultValue("%L", defaultValue.value)
+		is DefaultValue.EnumMember -> defaultValue("%T.%L", defaultValue.enumType, defaultValue.memberName)
 		is DefaultValue.CodeBlock -> defaultValue(defaultValue.build())
 		// Set value to null by default for nullable values
 		null -> when {

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ModelsBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ModelsBuilder.kt
@@ -1,0 +1,18 @@
+package org.jellyfin.openapi.builder.model
+
+import org.jellyfin.openapi.builder.ContextBuilder
+import org.jellyfin.openapi.builder.extra.FileSpecBuilder
+import org.jellyfin.openapi.model.ApiModel
+import org.jellyfin.openapi.model.GeneratorContext
+
+class ModelsBuilder(
+	private val modelBuilder: ModelBuilder,
+	private val fileSpecBuilder: FileSpecBuilder,
+) : ContextBuilder<Collection<ApiModel>, Unit> {
+	override fun build(context: GeneratorContext, data: Collection<ApiModel>) {
+		for (model in data) {
+			val file = modelBuilder.build(model)
+			context += fileSpecBuilder.build(file)
+		}
+	}
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
@@ -60,9 +60,14 @@ class OpenApiApiServicesBuilder(
 	/**
 	 * Returns the default value of the first hook that does not return null or use the default from the schema
 	 */
-	private fun buildDefaultValue(path: ApiTypePath, type: TypeName, parameterSpec: Parameter): DefaultValue? =
+	private fun buildDefaultValue(
+		context: GeneratorContext,
+		path: ApiTypePath,
+		type: TypeName,
+		parameterSpec: Parameter,
+	): DefaultValue? =
 		defaultValueHooks.firstNotNullOfOrNull { hook -> hook.onBuildDefaultValue(path, type, parameterSpec) }
-			?: openApiDefaultValueBuilder.build(parameterSpec.schema)
+			?: openApiDefaultValueBuilder.build(context, parameterSpec.schema)
 
 	private fun buildValidation(schema: Schema<*>): ParameterValidation? = when {
 		schema is IntegerSchema && schema.minimum != null && schema.maximum != null -> IntRangeValidation(
@@ -109,6 +114,7 @@ class OpenApiApiServicesBuilder(
 	}
 
 	private fun buildOperation(
+		context: GeneratorContext,
 		operation: Operation,
 		path: String,
 		serviceName: String,
@@ -135,7 +141,7 @@ class OpenApiApiServicesBuilder(
 				name = parameterName,
 				originalName = parameterSpec.name,
 				type = type,
-				defaultValue = buildDefaultValue(parameterTypePath, type, parameterSpec),
+				defaultValue = buildDefaultValue(context, parameterTypePath, type, parameterSpec),
 				description = parameterSpec.description,
 				deprecated = parameterSpec.deprecated == true,
 				validation = buildValidation(parameterSpec.schema),
@@ -193,7 +199,7 @@ class OpenApiApiServicesBuilder(
 					if (serviceName !in operationsSets) operationsSets[serviceName] = mutableSetOf()
 
 					// Add operation
-					operationsSets[serviceName]!!.add(buildOperation(operation, path, serviceName, method))
+					operationsSets[serviceName]!!.add(buildOperation(context, operation, path, serviceName, method))
 				}
 			}
 		}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiConstantsBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiConstantsBuilder.kt
@@ -4,21 +4,28 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import io.swagger.v3.oas.models.info.Info
-import org.jellyfin.openapi.builder.Builder
+import org.jellyfin.openapi.builder.ContextBuilder
+import org.jellyfin.openapi.builder.extra.FileSpecBuilder
 import org.jellyfin.openapi.constants.Classes
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Types
+import org.jellyfin.openapi.model.GeneratorContext
 import org.jellyfin.openapi.model.JellyFile
 
-class OpenApiConstantsBuilder : Builder<Info, JellyFile> {
-	private fun TypeSpec.Builder.addConstant(name: String, value: String): TypeSpec.Builder =
-		addProperty(PropertySpec.builder(name, Types.STRING).initializer("%S", value).addModifiers(KModifier.CONST).build())
+class OpenApiConstantsBuilder(
+	private val fileSpecBuilder: FileSpecBuilder,
+) : ContextBuilder<Info, Unit> {
+	private fun TypeSpec.Builder.addConstant(name: String, value: String): TypeSpec.Builder = addProperty(
+		PropertySpec.builder(name, Types.STRING)
+			.initializer("%S", value)
+			.addModifiers(KModifier.CONST).build()
+	)
 
-	override fun build(data: Info): JellyFile {
+	override fun build(context: GeneratorContext, data: Info) {
 		val typeSpec = TypeSpec.Companion.objectBuilder(Classes.CONSTANTS_OBJECT)
 			.addConstant("apiVersion", data.version)
 			.build()
 
-		return JellyFile(Packages.API_CONSTANTS, emptySet(), typeSpec)
+		context += fileSpecBuilder.build(JellyFile(Packages.API_CONSTANTS, emptySet(), typeSpec))
 	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiDefaultValueBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiDefaultValueBuilder.kt
@@ -1,17 +1,58 @@
 package org.jellyfin.openapi.builder.openapi
 
+import com.squareup.kotlinpoet.ClassName
+import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.media.Schema
+import net.pearx.kasechange.CaseFormat
+import net.pearx.kasechange.toPascalCase
+import net.pearx.kasechange.toScreamingSnakeCase
 import org.jellyfin.openapi.OpenApiGeneratorError
-import org.jellyfin.openapi.builder.Builder
+import org.jellyfin.openapi.builder.ContextBuilder
+import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.model.DefaultValue
+import org.jellyfin.openapi.model.EnumApiModel
+import org.jellyfin.openapi.model.GeneratorContext
 
 @Suppress("TooManyFunctions")
-class OpenApiDefaultValueBuilder : Builder<Schema<Any>, DefaultValue?> {
-	override fun build(data: Schema<Any>): DefaultValue? = when (val schemaDefault = data.default) {
-		is String -> DefaultValue.String(schemaDefault)
-		is Int -> DefaultValue.Int(schemaDefault)
-		is Boolean -> DefaultValue.Boolean(schemaDefault)
-		null -> null
-		else -> throw OpenApiGeneratorError("""Unsupported default value "$schemaDefault".""")
+class OpenApiDefaultValueBuilder : ContextBuilder<Schema<Any>, DefaultValue?> {
+	override fun build(context: GeneratorContext, data: Schema<Any>): DefaultValue? =
+		when (val schemaDefault = data.default) {
+			is String -> getDefaultEnumMember(context, data) ?: DefaultValue.String(schemaDefault)
+			is Int -> DefaultValue.Int(schemaDefault)
+			is Boolean -> DefaultValue.Boolean(schemaDefault)
+			null -> null
+			else -> throw OpenApiGeneratorError("""Unsupported default value "$schemaDefault".""")
+		}
+
+	private fun getDefaultEnumMember(context: GeneratorContext, schema: Schema<Any>): DefaultValue.EnumMember? {
+		val schemaDefault = schema.default
+		if (schemaDefault !is String) return null
+
+		val reference = getSchemaReference(schema) ?: return null
+		val modelName = reference
+			.removePrefix("#/components/schemas/")
+			.toPascalCase(from = CaseFormat.CAPITALIZED_CAMEL)
+
+		val model = context.models.firstOrNull { it.name == modelName }
+		if (model !is EnumApiModel) return null
+		if (model.constants.none { it.equals(schemaDefault, ignoreCase = true) }) return null
+
+		return DefaultValue.EnumMember(
+			enumType = ClassName(Packages.MODEL, model.name),
+			memberName = schemaDefault.toScreamingSnakeCase(from = CaseFormat.CAPITALIZED_CAMEL)
+		)
+	}
+
+	private fun getSchemaReference(schema: Schema<Any>): String? = when {
+		schema is ComposedSchema -> when {
+			// Limited support for anyOf / allOf containing a single item
+			schema.anyOf?.size == 1 -> getSchemaReference(schema.anyOf.first())
+			schema.allOf?.size == 1 -> getSchemaReference(schema.allOf.first())
+			else -> throw OpenApiTypeBuilder.UnknownTypeError(schema.type, schema.format)
+		}
+
+		schema.`$ref` != null -> schema.`$ref`
+
+		else -> null
 	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
@@ -3,19 +3,20 @@ package org.jellyfin.openapi.builder.openapi
 import io.swagger.v3.oas.models.media.Schema
 import net.pearx.kasechange.CaseFormat
 import net.pearx.kasechange.toCamelCase
-import org.jellyfin.openapi.builder.Builder
+import org.jellyfin.openapi.builder.ContextBuilder
 import org.jellyfin.openapi.hooks.ModelTypePath
 import org.jellyfin.openapi.model.ApiModel
 import org.jellyfin.openapi.model.EmptyApiModel
 import org.jellyfin.openapi.model.EnumApiModel
+import org.jellyfin.openapi.model.GeneratorContext
 import org.jellyfin.openapi.model.ObjectApiModel
 import org.jellyfin.openapi.model.ObjectApiModelProperty
 
 class OpenApiModelBuilder(
 	private val openApiTypeBuilder: OpenApiTypeBuilder,
 	private val openApiDefaultValueBuilder: OpenApiDefaultValueBuilder,
-) : Builder<Schema<Any>, ApiModel> {
-	override fun build(data: Schema<Any>): ApiModel = when {
+) : ContextBuilder<Schema<Any>, ApiModel> {
+	override fun build(context: GeneratorContext, data: Schema<Any>): ApiModel = when {
 		// Object
 		data.type == "object" -> when (data.properties.isNullOrEmpty()) {
 			// No properties use the empty model
@@ -34,7 +35,7 @@ class OpenApiModelBuilder(
 					ObjectApiModelProperty(
 						name = name,
 						originalName = originalName,
-						defaultValue = openApiDefaultValueBuilder.build(property),
+						defaultValue = openApiDefaultValueBuilder.build(context, property),
 						type = openApiTypeBuilder.build(ModelTypePath(data.name, name), property),
 						description = property.description,
 						deprecated = property.deprecated == true

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
@@ -4,60 +4,53 @@ import io.swagger.v3.oas.models.media.Schema
 import net.pearx.kasechange.CaseFormat
 import net.pearx.kasechange.toCamelCase
 import org.jellyfin.openapi.builder.Builder
-import org.jellyfin.openapi.builder.model.ModelBuilder
 import org.jellyfin.openapi.hooks.ModelTypePath
+import org.jellyfin.openapi.model.ApiModel
 import org.jellyfin.openapi.model.EmptyApiModel
 import org.jellyfin.openapi.model.EnumApiModel
-import org.jellyfin.openapi.model.JellyFile
 import org.jellyfin.openapi.model.ObjectApiModel
 import org.jellyfin.openapi.model.ObjectApiModelProperty
 
 class OpenApiModelBuilder(
 	private val openApiTypeBuilder: OpenApiTypeBuilder,
-	private val modelBuilder: ModelBuilder,
 	private val openApiDefaultValueBuilder: OpenApiDefaultValueBuilder,
-) : Builder<Schema<Any>, JellyFile> {
-	override fun build(data: Schema<Any>): JellyFile {
-		val model = when {
-			// Object
-			data.type == "object" -> when (data.properties.isNullOrEmpty()) {
-				// No properties use the empty model
-				true -> EmptyApiModel(
-					data.name,
-					data.description,
-					data.deprecated == true
-				)
-				// Otherwise use the object model
-				false -> ObjectApiModel(
-					data.name,
-					data.description,
-					data.deprecated == true,
-					data.properties.map { (originalName, property) ->
-						val name = originalName.toCamelCase(from = CaseFormat.CAPITALIZED_CAMEL)
-						ObjectApiModelProperty(
-							name = name,
-							originalName = originalName,
-							defaultValue = openApiDefaultValueBuilder.build(property),
-							type = openApiTypeBuilder.build(ModelTypePath(data.name, name), property),
-							description = property.description,
-							deprecated = property.deprecated == true
-						)
-					}.toSet()
-				)
-			}
-			// Enum
-			data.enum.isNotEmpty() -> EnumApiModel(
+) : Builder<Schema<Any>, ApiModel> {
+	override fun build(data: Schema<Any>): ApiModel = when {
+		// Object
+		data.type == "object" -> when (data.properties.isNullOrEmpty()) {
+			// No properties use the empty model
+			true -> EmptyApiModel(
+				data.name,
+				data.description,
+				data.deprecated == true
+			)
+			// Otherwise use the object model
+			false -> ObjectApiModel(
 				data.name,
 				data.description,
 				data.deprecated == true,
-				data.enum.orEmpty().map { it.toString() }.toSet()
+				data.properties.map { (originalName, property) ->
+					val name = originalName.toCamelCase(from = CaseFormat.CAPITALIZED_CAMEL)
+					ObjectApiModelProperty(
+						name = name,
+						originalName = originalName,
+						defaultValue = openApiDefaultValueBuilder.build(property),
+						type = openApiTypeBuilder.build(ModelTypePath(data.name, name), property),
+						description = property.description,
+						deprecated = property.deprecated == true
+					)
+				}.toSet()
 			)
-
-			// Unknown type
-			else -> throw NotImplementedError("Unknown top-level type: ${data.type} for ${data.name}")
 		}
+		// Enum
+		data.enum.isNotEmpty() -> EnumApiModel(
+			data.name,
+			data.description,
+			data.deprecated == true,
+			data.enum.orEmpty().map { it.toString() }.toSet()
+		)
 
-		return modelBuilder.build(model)
+		// Unknown type
+		else -> throw NotImplementedError("Unknown top-level type: ${data.type} for ${data.name}")
 	}
 }
-

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelsBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelsBuilder.kt
@@ -1,0 +1,16 @@
+package org.jellyfin.openapi.builder.openapi
+
+import io.swagger.v3.oas.models.media.Schema
+import org.jellyfin.openapi.builder.ContextBuilder
+import org.jellyfin.openapi.model.GeneratorContext
+
+class OpenApiModelsBuilder(
+	private val openApiModelBuilder: OpenApiModelBuilder,
+) : ContextBuilder<Map<String, Schema<Any>>, Unit> {
+	override fun build(context: GeneratorContext, data: Map<String, Schema<Any>>) {
+		for ((name, schema) in data) {
+			if (schema.name == null) schema.name = name
+			context += openApiModelBuilder.build(schema)
+		}
+	}
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelsBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelsBuilder.kt
@@ -10,7 +10,7 @@ class OpenApiModelsBuilder(
 	override fun build(context: GeneratorContext, data: Map<String, Schema<Any>>) {
 		for ((name, schema) in data) {
 			if (schema.name == null) schema.name = name
-			context += openApiModelBuilder.build(schema)
+			context += openApiModelBuilder.build(context, schema)
 		}
 	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/DefaultValue.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/DefaultValue.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.openapi.model
 
+import com.squareup.kotlinpoet.TypeName
+
 sealed interface DefaultValue {
 	@JvmInline
 	value class String(val value: kotlin.String) : DefaultValue
@@ -9,6 +11,8 @@ sealed interface DefaultValue {
 
 	@JvmInline
 	value class Boolean(val value: kotlin.Boolean) : DefaultValue
+
+	data class EnumMember(val enumType: TypeName, val memberName: kotlin.String) : DefaultValue
 
 	/**
 	 * Custom value builder used in hooks.

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/GeneratorContext.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/GeneratorContext.kt
@@ -1,0 +1,41 @@
+package org.jellyfin.openapi.model
+
+import com.squareup.kotlinpoet.FileSpec
+import io.swagger.v3.oas.models.Paths
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.parser.core.models.SwaggerParseResult
+
+class GeneratorContext(
+	openApiSpecification: SwaggerParseResult,
+) {
+	// Phase 1: Parse
+	val schemas: Map<String, Schema<Any>> = openApiSpecification.openAPI.components.schemas
+	val paths: Paths = openApiSpecification.openAPI.paths
+	val info: Info = openApiSpecification.openAPI.info
+
+	// Phase 2: OpenAPI -> Intermediate model
+	private val _models = mutableListOf<ApiModel>()
+	val models: Collection<ApiModel> get() = _models
+
+	private val _apiServices = mutableListOf<ApiService>()
+	val apiServices: Collection<ApiService> get() = _apiServices
+
+	operator fun plusAssign(model: ApiModel) {
+		_models.add(model)
+	}
+
+	operator fun plusAssign(service: ApiService) {
+		_apiServices.add(service)
+	}
+
+	// Phase 3: Intermediate model -> Code
+	private val _files = mutableListOf<FileSpec>()
+	private val files: Collection<FileSpec> get() = _files
+
+	operator fun plusAssign(file: FileSpec) {
+		_files.add(file)
+	}
+
+	fun toGeneratorResult() = GeneratorResult(files.toList())
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/GeneratorResult.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/GeneratorResult.kt
@@ -3,7 +3,5 @@ package org.jellyfin.openapi.model
 import com.squareup.kotlinpoet.FileSpec
 
 data class GeneratorResult(
-	val models: List<FileSpec>,
-	val apis: List<FileSpec>,
-	val constants: FileSpec,
+	val files: List<FileSpec>,
 )


### PR DESCRIPTION
- Add generator context
This is a class containing the generated sources in various phases. The context is passed to various builders that need it to either add or read data from it.

- Add DefaultValue.EnumMember
Required for #463. Allows the default value of a property to be an enum member. This needed a type lookup and that's why we now have the context.