### PR TITLE
Remove READ_EXTERNAL_STORAGE permission

### DIFF
--- a/jellyfin-core/src/androidMain/AndroidManifest.xml
+++ b/jellyfin-core/src/androidMain/AndroidManifest.xml
@@ -4,5 +4,4 @@
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
This permission is left-over from the previous apiclient where it was needed to store credential information.
READ_EXTERNAL_STORAGE permission is no longer used so it can be removed.

Closes #472 