### PR TITLE
Use gradle/gradle-build-action in CI

### DIFF
--- a/.github/workflows/sdk-docs.yaml
+++ b/.github/workflows/sdk-docs.yaml
@@ -18,11 +18,12 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Setup GitHub Pages
         uses: actions/configure-pages@61fd3a3cc1d0a4c8dae3bce7d897863ccdedb25d # tag=v2
       - name: Run dokkaHtmlMultiModule task
-        run: ./gradlew --build-cache --no-daemon --info dokkaHtmlMultiModule
+        run: ./gradlew dokkaHtmlMultiModule
       - name: Upload artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@f4e69017a716d2d729b620cba1f4016257fedec6 # tag=v1

--- a/.github/workflows/sdk-lint.yaml
+++ b/.github/workflows/sdk-lint.yaml
@@ -18,9 +18,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run detekt and lint tasks
-        run: ./gradlew --build-cache --no-daemon --info detekt lint
+        run: ./gradlew detekt lint
       - name: Upload SARIF files
         uses: github/codeql-action/upload-sarif@c7f292ea4f542c473194b33813ccd4c207a6c725 # tag=v2
         if: ${{ always() }}

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -21,6 +21,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Set JELLYFIN_VERSION
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
@@ -28,14 +30,14 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/') }}
         run: echo "JELLYFIN_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
       - name: Run publish task
-        run: ./gradlew --no-daemon --info publish closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publish closeAndReleaseSonatypeStagingRepository
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       - name: Run build and assembleDist tasks
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: ./gradlew --no-daemon --info build assembleDist -x check
+        run: ./gradlew build assembleDist -x check
       - name: Upload release assets
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: alexellis/upload-assets@5586bc227f8525a5e3525e6edf64da5350bfb5b1 # tag=0.3.0

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -23,9 +23,10 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run test task
-        run: ./gradlew --build-cache --no-daemon --info test allTests
+        run: ./gradlew test allTests
 
   validate-binary-compatibility:
     runs-on: ubuntu-20.04
@@ -37,9 +38,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run apiCheck task
-        run: ./gradlew --build-cache --no-daemon --info apiCheck
+        run: ./gradlew apiCheck
 
   verify-openapi-sources:
     runs-on: ubuntu-20.04
@@ -53,7 +55,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run verifySources task
-        run: ./gradlew --build-cache --no-daemon --info verifySources
+        run: ./gradlew verifySources
 

--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -26,9 +26,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run updateApiSpecUnstable and apiDump tasks
-        run: ./gradlew --build-cache --no-daemon --info :openapi-generator:updateApiSpecUnstable apiDump
+        run: ./gradlew :openapi-generator:updateApiSpecUnstable apiDump
       - name: Commit changes
         run: |
           git config user.name jellyfin-bot

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -17,7 +17,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Set STABLE_API_VERSION
         run: |
           VERSION=$(curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json | jq -r .info.version)
@@ -25,7 +26,7 @@ jobs:
       - name: Update generated sources and create pull request
         uses: technote-space/create-pr-action@95c1e76dc9b65848afe397ea156666021f2e8243 # tag=v2
         with:
-          EXECUTE_COMMANDS: ./gradlew --build-cache --no-daemon --info :openapi-generator:updateApiSpecStable apiDump
+          EXECUTE_COMMANDS: ./gradlew :openapi-generator:updateApiSpecStable apiDump
           COMMIT_MESSAGE: 'Update generated sources to ${{ env.STABLE_API_VERSION }}'
           COMMIT_NAME: 'jellyfin-bot'
           COMMIT_EMAIL: 'team@jellyfin.org'


### PR DESCRIPTION
The gradle-build-action is used to setup CI for Gradle usage and contains better caching capabilities compared to the setup java action.

Also make logs less verbose by removing the --info option