### PR TITLE
Build and deploy Vitepress documentation to GitHub pages

### DIFF
--- a/.github/workflows/sdk-docs.yaml
+++ b/.github/workflows/sdk-docs.yaml
@@ -8,6 +8,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-vitepress:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Create artifact
+        working-directory: ./docs/.vitepress/dist
+        run: zip -v -r ../vitepress.zip *
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: vitepress
+          path: ./docs/.vitepress/vitepress.zip
+
   build-dokka:
     runs-on: ubuntu-20.04
     steps:
@@ -33,18 +56,24 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
+    runs-on: ubuntu-20.04
     permissions:
       pages: write
       id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     needs:
+      - build-vitepress
       - build-dokka
     steps:
       - name: Setup GitHub Pages
         uses: actions/configure-pages@61fd3a3cc1d0a4c8dae3bce7d897863ccdedb25d # tag=v2
+      - name: Download Vitepress artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: vitepress
+          path: ./build/github-pages
       - name: Download Dokka artifact
         uses: actions/download-artifact@v3
         with:
@@ -55,6 +84,7 @@ jobs:
         run: |
           ls -la
           mkdir -p ./dist
+          unzip vitepress.zip -d ./dist
           unzip dokka.zip -d ./dist/dokka
       - name: Upload artifact
         uses: actions/upload-pages-artifact@f4e69017a716d2d729b620cba1f4016257fedec6 # tag=v1

--- a/.github/workflows/sdk-docs.yaml
+++ b/.github/workflows/sdk-docs.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-dokka:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -20,18 +20,18 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-      - name: Setup GitHub Pages
-        uses: actions/configure-pages@61fd3a3cc1d0a4c8dae3bce7d897863ccdedb25d # tag=v2
       - name: Run dokkaHtmlMultiModule task
         run: ./gradlew dokkaHtmlMultiModule
+      - name: Create artifact
+        working-directory: ./build/dokka/htmlMultiModule
+        run: zip -v -r ../../dokka.zip *
       - name: Upload artifact
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@f4e69017a716d2d729b620cba1f4016257fedec6 # tag=v1
+        uses: actions/upload-artifact@v3
         with:
-          path: ./build/dokka/htmlMultiModule
+          name: dokka
+          path: ./build/dokka.zip
 
   deploy:
-    name: Deploy to GitHub Pages
     if: github.event_name != 'pull_request'
     permissions:
       pages: write
@@ -41,8 +41,25 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs:
-      - build
+      - build-dokka
     steps:
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@61fd3a3cc1d0a4c8dae3bce7d897863ccdedb25d # tag=v2
+      - name: Download Dokka artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dokka
+          path: ./build/github-pages
+      - name: Create pages structure
+        working-directory: ./build/github-pages
+        run: |
+          ls -la
+          mkdir -p ./dist
+          unzip dokka.zip -d ./dist/dokka
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@f4e69017a716d2d729b620cba1f4016257fedec6 # tag=v1
+        with:
+          path: ./build/github-pages/dist
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@114f9cc1f8e24d8f64390960ea709a5a19d09b39 # tag=v1

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ java_*.hprof
 
 # Docs
 node_modules
+docs/.vitepress/dist

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -124,7 +124,7 @@ try {
 ### WebSockets
 
 Jellyfin uses WebSockets to communicate events like library changes and activities. This API can be
-used with the SocketApi. Documentation is available in the [docs](/docs) folder.
+used with the SocketApi.
 
 ```kotlin
 val instance = api.ws()
@@ -151,11 +151,6 @@ val candidates = jellyfin.discovery.getAddressCandidates("demo.jellyfin.org/stab
 // Get a flow of potential servers to connect to
 val recommended = jellyfin.discovery.getRecommendedServers(candidates, RecommendedServerInfoScore.GOOD)
 ```
-
-## More examples
-
-We provide a few small projects in the [samples](/samples) folder. The samples are used for testing
-new features and can be used as a basis for your own application.
 
 ## Projects using the SDK
 

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -173,8 +173,8 @@ The following messages types are supported in the SDK.
 - The [observe] command in the [kotlin-cli] sample uses websockets to listen for messages.
 - The [jellyfin-androidtv] app uses websockets for remote media control and realtime data updates.
 
-[observe]: /samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Observe.kt
+[observe]: https://github.com/jellyfin/jellyfin-sdk-kotlin/tree/master/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Observe.kt
 
-[kotlin-cli]: /samples/kotlin-cli/
+[kotlin-cli]: https://github.com/jellyfin/jellyfin-sdk-kotlin/tree/master/samples/kotlin-cli/
 
 [jellyfin-androidtv]: https://github.com/jellyfin/jellyfin-androidtv

--- a/docs/migration/v1.2.md
+++ b/docs/migration/v1.2.md
@@ -6,7 +6,7 @@ changes introduced. Java projects might need some additional work due to the Jav
 ## WebSockets
 
 We've introduced a rewritten WebSocket API to make it easier to receive realtime events from the Jellyfin server.
-Lean more on the [WebSockets](../websockets.md) page. The old WebSocket code is still available but will be removed
+Lean more on the [WebSockets](../guide/websockets.md) page. The old WebSocket code is still available but will be removed
 entirely in v1.3.
 
 ## Java compatibility


### PR DESCRIPTION
Also fixes some dead links (that caused CI to fail 😉) and rewrite the existing sdk-docs workflow.

How it works:
- Build Dokka and Vitepress in their own jobs with no references to GH pages. Upload build output as a zip
- Download artifacts from Dokka and Vitepress and put in a directory, upload as GH Pages artifact and deploy

Considerations:
- Vitepress doesn't like being in a directory by default so we need to add a custom domain or change the configuration