### PR TITLE
Split openapi generator and api dump tasks to avoid build failure

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -28,8 +28,10 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         uses: gradle/gradle-build-action@356abb47e7664b5505e25d7997a5a522a17c62d9 # tag=v2
-      - name: Run updateApiSpecUnstable and apiDump tasks
-        run: ./gradlew :openapi-generator:updateApiSpecUnstable apiDump
+      - name: Run updateApiSpecUnstable task
+        run: ./gradlew :openapi-generator:updateApiSpecUnstable
+      - name: Run apiDump task
+        run: ./gradlew apiDump
       - name: Commit changes
         run: |
           git config user.name jellyfin-bot

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -26,7 +26,9 @@ jobs:
       - name: Update generated sources and create pull request
         uses: technote-space/create-pr-action@95c1e76dc9b65848afe397ea156666021f2e8243 # tag=v2
         with:
-          EXECUTE_COMMANDS: ./gradlew :openapi-generator:updateApiSpecStable apiDump
+          EXECUTE_COMMANDS: |
+            ./gradlew :openapi-generator:updateApiSpecStable
+            ./gradlew apiDump
           COMMIT_MESSAGE: 'Update generated sources to ${{ env.STABLE_API_VERSION }}'
           COMMIT_NAME: 'jellyfin-bot'
           COMMIT_EMAIL: 'team@jellyfin.org'


### PR DESCRIPTION
I've honestly no idea why the current approach doesn't work (because it should) but while testing in my fork this new approach seemed to work 🤞.