### PR TITLE
Fix AddressCandidateHelper issues with empty input and invalid ports

### DIFF
--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -45,15 +45,20 @@ public class AddressCandidateHelper(
 			logger.debug { "Input is $input" }
 
 			// Add the input as initial candidate
-			candidates.add(URLBuilder().apply {
-				// Ktor doesn't like urls not starting with a protocol
-				// so we default to a http prefix
-				if (!input.startsWith(PROTOCOL_HTTP) && !input.startsWith(PROTOCOL_HTTPS))
-					takeFrom(PROTOCOL_HTTP + input)
-				else
-					takeFrom(input)
-			}.build())
+			if (input.isNotBlank()) {
+				candidates.add(URLBuilder().apply {
+					// Ktor doesn't like urls not starting with a protocol
+					// so we default to a http prefix
+					if (!input.startsWith(PROTOCOL_HTTP) && !input.startsWith(PROTOCOL_HTTPS))
+						takeFrom(PROTOCOL_HTTP + input)
+					else
+						takeFrom(input)
+				}.build())
+			}
 		} catch (error: URLParserException) {
+			// Input can't be parsed
+			logger.error(error) { "Input $input could not be parsed" }
+		} catch (error: IllegalArgumentException) {
 			// Input can't be parsed
 			logger.error(error) { "Input $input could not be parsed" }
 		}
@@ -88,6 +93,7 @@ public class AddressCandidateHelper(
 					URLProtocol.HTTP -> {
 						candidates.add(it.copy(specifiedPort = JF_HTTP_PORT))
 					}
+
 					URLProtocol.HTTPS -> {
 						candidates.add(it.copy(specifiedPort = JF_HTTP_PORT))
 						candidates.add(it.copy(specifiedPort = JF_HTTPS_PORT))

--- a/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
+++ b/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
@@ -50,9 +50,17 @@ class DiscoveryServiceTests : FunSpec({
 		instance.getAddressCandidates("[0:0:0:0:0:0:0:1]:8096") shouldContain "http://[0:0:0:0:0:0:0:1]:8096"
 	}
 
-	test("getAddressCandidates fails on bad input") {
+	test("getAddressCandidates returns empty on bad input") {
 		val instance = getInstance()
 
+		// Invalid host
 		instance.getAddressCandidates("::").shouldBeEmpty()
+
+		// Empty input
+		instance.getAddressCandidates("").shouldBeEmpty()
+
+		// Port out of range
+		instance.getAddressCandidates("localhost:65536").shouldBeEmpty()
+		instance.getAddressCandidates("localhost:999999").shouldBeEmpty()
 	}
 })


### PR DESCRIPTION
- Empty input returned "http://" as candidate, which obviously is invalid
- Invalid port caused an exception

Both now return 0 candidates, added unit tests to verify.

Fixes #460