### PR TITLE
Improve RecommendedServerDiscovery speed significantly

### DIFF
--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -126,7 +126,7 @@ public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
 	public final fun addCommonCandidates ()V
 	public final fun addPortCandidates ()V
 	public final fun addProtocolCandidates ()V
-	public final fun getCandidates ()Ljava/util/List;
+	public final fun getCandidates ()Ljava/util/Collection;
 }
 
 public final class org/jellyfin/sdk/discovery/AddressCandidateHelper$Companion {
@@ -141,11 +141,11 @@ public final class org/jellyfin/sdk/discovery/DiscoveryService {
 	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
 	public final fun discoverLocalServers (II)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun discoverLocalServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;IIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/List;
+	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/Collection;
 	public final fun getRecommendedServers (Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRecommendedServers (Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/LocalServerDiscovery {
@@ -165,8 +165,7 @@ public final class org/jellyfin/sdk/discovery/LocalServerDiscovery$Companion {
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerDiscovery {
 	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
-	public final fun discover (Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun discover (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discover (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerInfo {

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -111,7 +111,7 @@ public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
 	public final fun addCommonCandidates ()V
 	public final fun addPortCandidates ()V
 	public final fun addProtocolCandidates ()V
-	public final fun getCandidates ()Ljava/util/List;
+	public final fun getCandidates ()Ljava/util/Collection;
 }
 
 public final class org/jellyfin/sdk/discovery/AddressCandidateHelper$Companion {
@@ -126,11 +126,11 @@ public final class org/jellyfin/sdk/discovery/DiscoveryService {
 	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
 	public final fun discoverLocalServers (II)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun discoverLocalServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;IIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/List;
+	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/Collection;
 	public final fun getRecommendedServers (Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRecommendedServers (Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/LocalServerDiscovery {
@@ -150,8 +150,7 @@ public final class org/jellyfin/sdk/discovery/LocalServerDiscovery$Companion {
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerDiscovery {
 	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
-	public final fun discover (Ljava/util/List;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun discover (Lkotlinx/coroutines/flow/Flow;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discover (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerInfo {

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -143,7 +143,7 @@ public class AddressCandidateHelper(
 	 * - HTTPS before HTTP
 	 * - Jellyfin ports before protocol default ports
 	 */
-	public fun getCandidates(): List<String> = candidates
+	public fun getCandidates(): Collection<String> = candidates
 		.sortedWith(prioritizeComparator)
 		.map { it.toString() }
 }

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/DiscoveryService.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/DiscoveryService.kt
@@ -24,7 +24,7 @@ public class DiscoveryService constructor(
 	 *
 	 * See [AddressCandidateHelper] for more information.
 	 */
-	public fun getAddressCandidates(input: String): List<String> = AddressCandidateHelper(input).run {
+	public fun getAddressCandidates(input: String): Collection<String> = AddressCandidateHelper(input).run {
 		addCommonCandidates()
 		getCandidates()
 	}
@@ -43,9 +43,9 @@ public class DiscoveryService constructor(
 	 * **Never just use the first result**.
 	 */
 	public suspend fun getRecommendedServers(
-		servers: List<String>,
+		servers: Collection<String>,
 		minimumScore: RecommendedServerInfoScore = RecommendedServerInfoScore.BAD,
-	): Flow<RecommendedServerInfo> = recommendedServerDiscovery.discover(
+	): Collection<RecommendedServerInfo> = recommendedServerDiscovery.discover(
 		servers = servers,
 		minimumScore = minimumScore
 	)
@@ -56,7 +56,7 @@ public class DiscoveryService constructor(
 	public suspend fun getRecommendedServers(
 		input: String,
 		minimumScore: RecommendedServerInfoScore = RecommendedServerInfoScore.BAD,
-	): Flow<RecommendedServerInfo> = getRecommendedServers(
+	): Collection<RecommendedServerInfo> = getRecommendedServers(
 		servers = getAddressCandidates(input),
 		minimumScore = minimumScore
 	)

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
@@ -36,23 +36,23 @@ class Discover(
 		val candidates = jellyfin.discovery.getAddressCandidates(address)
 		println("Found ${candidates.size} candidates")
 
-		jellyfin.discovery.getRecommendedServers(candidates).collect {
+		val servers = jellyfin.discovery.getRecommendedServers(candidates)
+		for (server in servers) {
 			buildString {
-				append(it.address)
+				append(server.address)
 				append(": ")
-				append(it.score.toString())
+				append(server.score.toString())
 				append(" (")
-				append("replied in ${it.responseTime}ms")
+				append("replied in ${server.responseTime}ms")
 				append(", ")
-				if (it.systemInfo.isFailure) append("system information not found")
+				if (server.systemInfo.isFailure) append("system information not found")
 				else append("system information found")
 				append(")")
-				it.issues.forEach {
+				server.issues.forEach {
 					appendLine()
 					append("\t")
 					append(it)
 				}
-
 			}.let(::println)
 		}
 	}

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Ping.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Ping.kt
@@ -3,8 +3,6 @@ package org.jellyfin.sample.cli.command
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import org.jellyfin.sample.cli.serverOption
 import org.jellyfin.sdk.Jellyfin
@@ -36,10 +34,10 @@ class Ping(
 
 	private suspend fun runExtended() {
 		val servers = jellyfin.discovery.getRecommendedServers(server)
-		servers.onEach {
-			println("${it.address}: score=${it.score} duration=${it.responseTime}ms")
-			println("info=${it.systemInfo}")
+		for (server in servers) {
+			println("${server.address}: score=${server.score} duration=${server.responseTime}ms")
+			println("info=${server.systemInfo}")
 			println()
-		}.collect()
+		}
 	}
 }


### PR DESCRIPTION
**Improve RecommendedServerDiscovery speed significantly**

Two changes to make it faster:

1. Lower "server not available" timeout from 5 to 3.5 seconds
2. Query 3 candidates simultaneously using a semaphore

Also removed the flow usage and just use a collection now, the flow didn't make much sense anyway. This doesn't break the ATV app and I expect other clients will be fine too.