### PR TITLE
Fallback to manufacturer + model when device name is null

### DIFF
--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/android/AndroidDevice.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/android/AndroidDevice.kt
@@ -6,21 +6,25 @@ import android.os.Build
 import android.provider.Settings
 import org.jellyfin.sdk.model.DeviceInfo
 
-@SuppressLint("HardwareIds")
-public fun androidDevice(context: Context): DeviceInfo {
-	val id = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
-
+private fun Context.getDeviceName(): String {
 	// Use name from device settings
-	val name = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-		Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
-	} else {
-		// Concatenate the name based on manufacturer and model
-		val manufacturer = Build.MANUFACTURER
-		val model = Build.MODEL
-
-		if (model.startsWith(manufacturer) || manufacturer.isBlank()) model
-		else "$manufacturer $model"
+	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+		val name = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
+		if (name != null) return name
 	}
+
+	// Concatenate the name based on manufacturer and model
+	val manufacturer = Build.MANUFACTURER
+	val model = Build.MODEL
+
+	return if (model.startsWith(manufacturer) || manufacturer.isBlank()) model
+	else "$manufacturer $model"
+}
+
+public fun androidDevice(context: Context): DeviceInfo {
+	@SuppressLint("HardwareIds")
+	val id = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+	val name = context.getDeviceName()
 
 	return DeviceInfo(
 		id = id,


### PR DESCRIPTION
Fixes jellyfin/jellyfin-android#794, not backporting since the stable android release uses an outdated SDK anyway.