### PR TITLE
Implement DescriptionHook for more advanced description customization

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DevicesApi.kt
@@ -73,8 +73,8 @@ public class DevicesApi(
 	/**
 	 * Get Devices.
 	 *
-	 * @param supportsSync Gets or sets a value indicating whether [supports synchronize].
-	 * @param userId Gets or sets the user identifier.
+	 * @param supportsSync A value indicating whether [supports synchronize].
+	 * @param userId The user identifier.
 	 */
 	public suspend fun getDevices(supportsSync: Boolean? = null, userId: UUID? = null):
 			Response<DeviceInfoQueryResult> {

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AccessSchedule.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AccessSchedule.kt
@@ -21,27 +21,27 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class AccessSchedule(
 	/**
-	 * Gets the id of this instance.
+	 * The id of this instance.
 	 */
 	@SerialName("Id")
 	public val id: Int,
 	/**
-	 * Gets the id of the associated user.
+	 * The id of the associated user.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID,
 	/**
-	 * Gets or sets the day of week.
+	 * The day of week.
 	 */
 	@SerialName("DayOfWeek")
 	public val dayOfWeek: DynamicDayOfWeek,
 	/**
-	 * Gets or sets the start hour.
+	 * The start hour.
 	 */
 	@SerialName("StartHour")
 	public val startHour: Double,
 	/**
-	 * Gets or sets the end hour.
+	 * The end hour.
 	 */
 	@SerialName("EndHour")
 	public val endHour: Double,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ActivityLogEntry.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ActivityLogEntry.kt
@@ -27,53 +27,53 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class ActivityLogEntry(
 	/**
-	 * Gets or sets the identifier.
+	 * The identifier.
 	 */
 	@SerialName("Id")
 	public val id: Long,
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets the overview.
+	 * The overview.
 	 */
 	@SerialName("Overview")
 	public val overview: String? = null,
 	/**
-	 * Gets or sets the short overview.
+	 * The short overview.
 	 */
 	@SerialName("ShortOverview")
 	public val shortOverview: String? = null,
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: String,
 	/**
-	 * Gets or sets the item identifier.
+	 * The item identifier.
 	 */
 	@SerialName("ItemId")
 	public val itemId: String? = null,
 	/**
-	 * Gets or sets the date.
+	 * The date.
 	 */
 	@SerialName("Date")
 	public val date: DateTime,
 	/**
-	 * Gets or sets the user identifier.
+	 * The user identifier.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID,
 	/**
-	 * Gets or sets the user primary image tag.
+	 * The user primary image tag.
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
 	@SerialName("UserPrimaryImageTag")
 	public val userPrimaryImageTag: String? = null,
 	/**
-	 * Gets or sets the log severity.
+	 * The log severity.
 	 */
 	@SerialName("Severity")
 	public val severity: LogLevel,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ActivityLogEntryQueryResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ActivityLogEntryQueryResult.kt
@@ -13,17 +13,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ActivityLogEntryQueryResult(
 	/**
-	 * Gets or sets the items.
+	 * The items.
 	 */
 	@SerialName("Items")
 	public val items: List<ActivityLogEntry>? = null,
 	/**
-	 * Gets or sets the total number of records available.
+	 * The total number of records available.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the index of the first record in Items.
+	 * The index of the first record in Items.
 	 */
 	@SerialName("StartIndex")
 	public val startIndex: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AddVirtualFolderDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AddVirtualFolderDto.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class AddVirtualFolderDto(
 	/**
-	 * Gets or sets library options.
+	 * Library options.
 	 */
 	@SerialName("LibraryOptions")
 	public val libraryOptions: LibraryOptions? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AdminNotificationDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AdminNotificationDto.kt
@@ -15,22 +15,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class AdminNotificationDto(
 	/**
-	 * Gets or sets the notification name.
+	 * The notification name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the notification description.
+	 * The notification description.
 	 */
 	@SerialName("Description")
 	public val description: String? = null,
 	/**
-	 * Gets or sets the notification level.
+	 * The notification level.
 	 */
 	@SerialName("NotificationLevel")
 	public val notificationLevel: NotificationLevel? = null,
 	/**
-	 * Gets or sets the notification url.
+	 * The notification url.
 	 */
 	@SerialName("Url")
 	public val url: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AlbumInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AlbumInfo.kt
@@ -21,37 +21,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class AlbumInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,
@@ -64,12 +64,12 @@ public data class AlbumInfo(
 	@SerialName("IsAutomated")
 	public val isAutomated: Boolean,
 	/**
-	 * Gets or sets the album artist.
+	 * The album artist.
 	 */
 	@SerialName("AlbumArtists")
 	public val albumArtists: List<String>,
 	/**
-	 * Gets or sets the artist provider ids.
+	 * The artist provider ids.
 	 */
 	@SerialName("ArtistProviderIds")
 	public val artistProviderIds: Map<String, String?>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AlbumInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class AlbumInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ArtistInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ArtistInfo.kt
@@ -21,37 +21,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class ArtistInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ArtistInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class ArtistInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AuthenticateUserByName.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AuthenticateUserByName.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class AuthenticateUserByName(
 	/**
-	 * Gets or sets the username.
+	 * The username.
 	 */
 	@SerialName("Username")
 	public val username: String? = null,
 	/**
-	 * Gets or sets the plain text password.
+	 * The plain text password.
 	 */
 	@SerialName("Pw")
 	public val pw: String? = null,
 	/**
-	 * Gets or sets the sha1-hashed password.
+	 * The sha1-hashed password.
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
 	@SerialName("Password")

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AuthenticationInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AuthenticationInfo.kt
@@ -24,52 +24,52 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class AuthenticationInfo(
 	/**
-	 * Gets or sets the identifier.
+	 * The identifier.
 	 */
 	@SerialName("Id")
 	public val id: Long,
 	/**
-	 * Gets or sets the access token.
+	 * The access token.
 	 */
 	@SerialName("AccessToken")
 	public val accessToken: String? = null,
 	/**
-	 * Gets or sets the device identifier.
+	 * The device identifier.
 	 */
 	@SerialName("DeviceId")
 	public val deviceId: String? = null,
 	/**
-	 * Gets or sets the name of the application.
+	 * The name of the application.
 	 */
 	@SerialName("AppName")
 	public val appName: String? = null,
 	/**
-	 * Gets or sets the application version.
+	 * The application version.
 	 */
 	@SerialName("AppVersion")
 	public val appVersion: String? = null,
 	/**
-	 * Gets or sets the name of the device.
+	 * The name of the device.
 	 */
 	@SerialName("DeviceName")
 	public val deviceName: String? = null,
 	/**
-	 * Gets or sets the user identifier.
+	 * The user identifier.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID,
 	/**
-	 * Gets or sets a value indicating whether this instance is active.
+	 * A value indicating whether this instance is active.
 	 */
 	@SerialName("IsActive")
 	public val isActive: Boolean,
 	/**
-	 * Gets or sets the date created.
+	 * The date created.
 	 */
 	@SerialName("DateCreated")
 	public val dateCreated: DateTime,
 	/**
-	 * Gets or sets the date revoked.
+	 * The date revoked.
 	 */
 	@SerialName("DateRevoked")
 	public val dateRevoked: DateTime? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AuthenticationInfoQueryResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/AuthenticationInfoQueryResult.kt
@@ -13,17 +13,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class AuthenticationInfoQueryResult(
 	/**
-	 * Gets or sets the items.
+	 * The items.
 	 */
 	@SerialName("Items")
 	public val items: List<AuthenticationInfo>? = null,
 	/**
-	 * Gets or sets the total number of records available.
+	 * The total number of records available.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the index of the first record in Items.
+	 * The index of the first record in Items.
 	 */
 	@SerialName("StartIndex")
 	public val startIndex: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItem.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItem.kt
@@ -47,7 +47,7 @@ public data class BaseItem(
 	@SerialName("DateLastSaved")
 	public val dateLastSaved: DateTime,
 	/**
-	 * Gets or sets the remote trailers.
+	 * The remote trailers.
 	 */
 	@SerialName("RemoteTrailers")
 	public val remoteTrailers: List<MediaUrl>? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemDto.kt
@@ -33,39 +33,39 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class BaseItemDto(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the server identifier.
+	 * The server identifier.
 	 */
 	@SerialName("ServerId")
 	public val serverId: String? = null,
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets or sets the etag.
+	 * The etag.
 	 */
 	@SerialName("Etag")
 	public val etag: String? = null,
 	/**
-	 * Gets or sets the type of the source.
+	 * The type of the source.
 	 */
 	@SerialName("SourceType")
 	public val sourceType: String? = null,
 	/**
-	 * Gets or sets the playlist item identifier.
+	 * The playlist item identifier.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: String? = null,
 	/**
-	 * Gets or sets the date created.
+	 * The date created.
 	 */
 	@SerialName("DateCreated")
 	public val dateCreated: DateTime? = null,
@@ -90,374 +90,373 @@ public data class BaseItemDto(
 	@SerialName("PreferredMetadataCountryCode")
 	public val preferredMetadataCountryCode: String? = null,
 	/**
-	 * Gets or sets a value indicating whether [supports synchronize].
+	 * A value indicating whether [supports synchronize].
 	 */
 	@SerialName("SupportsSync")
 	public val supportsSync: Boolean? = null,
 	@SerialName("Container")
 	public val container: String? = null,
 	/**
-	 * Gets or sets the name of the sort.
+	 * The name of the sort.
 	 */
 	@SerialName("SortName")
 	public val sortName: String? = null,
 	@SerialName("ForcedSortName")
 	public val forcedSortName: String? = null,
 	/**
-	 * Gets or sets the video3 D format.
+	 * The video3 D format.
 	 */
 	@SerialName("Video3DFormat")
 	public val video3dFormat: Video3dFormat? = null,
 	/**
-	 * Gets or sets the premiere date.
+	 * The premiere date.
 	 */
 	@SerialName("PremiereDate")
 	public val premiereDate: DateTime? = null,
 	/**
-	 * Gets or sets the external urls.
+	 * The external urls.
 	 */
 	@SerialName("ExternalUrls")
 	public val externalUrls: List<ExternalUrl>? = null,
 	/**
-	 * Gets or sets the media versions.
+	 * The media versions.
 	 */
 	@SerialName("MediaSources")
 	public val mediaSources: List<MediaSourceInfo>? = null,
 	/**
-	 * Gets or sets the critic rating.
+	 * The critic rating.
 	 */
 	@SerialName("CriticRating")
 	public val criticRating: Float? = null,
 	@SerialName("ProductionLocations")
 	public val productionLocations: List<String>? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	@SerialName("EnableMediaSourceDisplay")
 	public val enableMediaSourceDisplay: Boolean? = null,
 	/**
-	 * Gets or sets the official rating.
+	 * The official rating.
 	 */
 	@SerialName("OfficialRating")
 	public val officialRating: String? = null,
 	/**
-	 * Gets or sets the custom rating.
+	 * The custom rating.
 	 */
 	@SerialName("CustomRating")
 	public val customRating: String? = null,
 	/**
-	 * Gets or sets the channel identifier.
+	 * The channel identifier.
 	 */
 	@SerialName("ChannelId")
 	public val channelId: UUID? = null,
 	@SerialName("ChannelName")
 	public val channelName: String? = null,
 	/**
-	 * Gets or sets the overview.
+	 * The overview.
 	 */
 	@SerialName("Overview")
 	public val overview: String? = null,
 	/**
-	 * Gets or sets the taglines.
+	 * The taglines.
 	 */
 	@SerialName("Taglines")
 	public val taglines: List<String>? = null,
 	/**
-	 * Gets or sets the genres.
+	 * The genres.
 	 */
 	@SerialName("Genres")
 	public val genres: List<String>? = null,
 	/**
-	 * Gets or sets the community rating.
+	 * The community rating.
 	 */
 	@SerialName("CommunityRating")
 	public val communityRating: Float? = null,
 	/**
-	 * Gets or sets the cumulative run time ticks.
+	 * The cumulative run time ticks.
 	 */
 	@SerialName("CumulativeRunTimeTicks")
 	public val cumulativeRunTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the run time ticks.
+	 * The run time ticks.
 	 */
 	@SerialName("RunTimeTicks")
 	public val runTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the play access.
+	 * The play access.
 	 */
 	@SerialName("PlayAccess")
 	public val playAccess: PlayAccess? = null,
 	/**
-	 * Gets or sets the aspect ratio.
+	 * The aspect ratio.
 	 */
 	@SerialName("AspectRatio")
 	public val aspectRatio: String? = null,
 	/**
-	 * Gets or sets the production year.
+	 * The production year.
 	 */
 	@SerialName("ProductionYear")
 	public val productionYear: Int? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is place holder.
+	 * A value indicating whether this instance is place holder.
 	 */
 	@SerialName("IsPlaceHolder")
 	public val isPlaceHolder: Boolean? = null,
 	/**
-	 * Gets or sets the number.
+	 * The number.
 	 */
 	@SerialName("Number")
 	public val number: String? = null,
 	@SerialName("ChannelNumber")
 	public val channelNumber: String? = null,
 	/**
-	 * Gets or sets the index number.
+	 * The index number.
 	 */
 	@SerialName("IndexNumber")
 	public val indexNumber: Int? = null,
 	/**
-	 * Gets or sets the index number end.
+	 * The index number end.
 	 */
 	@SerialName("IndexNumberEnd")
 	public val indexNumberEnd: Int? = null,
 	/**
-	 * Gets or sets the parent index number.
+	 * The parent index number.
 	 */
 	@SerialName("ParentIndexNumber")
 	public val parentIndexNumber: Int? = null,
 	/**
-	 * Gets or sets the trailer urls.
+	 * The trailer urls.
 	 */
 	@SerialName("RemoteTrailers")
 	public val remoteTrailers: List<MediaUrl>? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is HD.
+	 * A value indicating whether this instance is HD.
 	 */
 	@SerialName("IsHD")
 	public val isHd: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is folder.
+	 * A value indicating whether this instance is folder.
 	 */
 	@SerialName("IsFolder")
 	public val isFolder: Boolean? = null,
 	/**
-	 * Gets or sets the parent id.
+	 * The parent id.
 	 */
 	@SerialName("ParentId")
 	public val parentId: UUID? = null,
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: BaseItemKind,
 	/**
-	 * Gets or sets the people.
+	 * The people.
 	 */
 	@SerialName("People")
 	public val people: List<BaseItemPerson>? = null,
 	/**
-	 * Gets or sets the studios.
+	 * The studios.
 	 */
 	@SerialName("Studios")
 	public val studios: List<NameGuidPair>? = null,
 	@SerialName("GenreItems")
 	public val genreItems: List<NameGuidPair>? = null,
 	/**
-	 * Gets or sets wether the item has a logo, this will hold the Id of the Parent that has one.
+	 * Wether the item has a logo, this will hold the Id of the Parent that has one.
 	 */
 	@SerialName("ParentLogoItemId")
 	public val parentLogoItemId: UUID? = null,
 	/**
-	 * Gets or sets wether the item has any backdrops, this will hold the Id of the Parent that has
-	 * one.
+	 * Wether the item has any backdrops, this will hold the Id of the Parent that has one.
 	 */
 	@SerialName("ParentBackdropItemId")
 	public val parentBackdropItemId: UUID? = null,
 	/**
-	 * Gets or sets the parent backdrop image tags.
+	 * The parent backdrop image tags.
 	 */
 	@SerialName("ParentBackdropImageTags")
 	public val parentBackdropImageTags: List<String>? = null,
 	/**
-	 * Gets or sets the local trailer count.
+	 * The local trailer count.
 	 */
 	@SerialName("LocalTrailerCount")
 	public val localTrailerCount: Int? = null,
 	/**
-	 * Gets or sets the user data for this item based on the user it's being requested for.
+	 * The user data for this item based on the user it's being requested for.
 	 */
 	@SerialName("UserData")
 	public val userData: UserItemDataDto? = null,
 	/**
-	 * Gets or sets the recursive item count.
+	 * The recursive item count.
 	 */
 	@SerialName("RecursiveItemCount")
 	public val recursiveItemCount: Int? = null,
 	/**
-	 * Gets or sets the child count.
+	 * The child count.
 	 */
 	@SerialName("ChildCount")
 	public val childCount: Int? = null,
 	/**
-	 * Gets or sets the name of the series.
+	 * The name of the series.
 	 */
 	@SerialName("SeriesName")
 	public val seriesName: String? = null,
 	/**
-	 * Gets or sets the series id.
+	 * The series id.
 	 */
 	@SerialName("SeriesId")
 	public val seriesId: UUID? = null,
 	/**
-	 * Gets or sets the season identifier.
+	 * The season identifier.
 	 */
 	@SerialName("SeasonId")
 	public val seasonId: UUID? = null,
 	/**
-	 * Gets or sets the special feature count.
+	 * The special feature count.
 	 */
 	@SerialName("SpecialFeatureCount")
 	public val specialFeatureCount: Int? = null,
 	/**
-	 * Gets or sets the display preferences id.
+	 * The display preferences id.
 	 */
 	@SerialName("DisplayPreferencesId")
 	public val displayPreferencesId: String? = null,
 	/**
-	 * Gets or sets the status.
+	 * The status.
 	 */
 	@SerialName("Status")
 	public val status: String? = null,
 	/**
-	 * Gets or sets the air time.
+	 * The air time.
 	 */
 	@SerialName("AirTime")
 	public val airTime: String? = null,
 	/**
-	 * Gets or sets the air days.
+	 * The air days.
 	 */
 	@SerialName("AirDays")
 	public val airDays: List<DayOfWeek>? = null,
 	/**
-	 * Gets or sets the tags.
+	 * The tags.
 	 */
 	@SerialName("Tags")
 	public val tags: List<String>? = null,
 	/**
-	 * Gets or sets the primary image aspect ratio, after image enhancements.
+	 * The primary image aspect ratio, after image enhancements.
 	 */
 	@SerialName("PrimaryImageAspectRatio")
 	public val primaryImageAspectRatio: Double? = null,
 	/**
-	 * Gets or sets the artists.
+	 * The artists.
 	 */
 	@SerialName("Artists")
 	public val artists: List<String>? = null,
 	/**
-	 * Gets or sets the artist items.
+	 * The artist items.
 	 */
 	@SerialName("ArtistItems")
 	public val artistItems: List<NameGuidPair>? = null,
 	/**
-	 * Gets or sets the album.
+	 * The album.
 	 */
 	@SerialName("Album")
 	public val album: String? = null,
 	/**
-	 * Gets or sets the type of the collection.
+	 * The type of the collection.
 	 */
 	@SerialName("CollectionType")
 	public val collectionType: String? = null,
 	/**
-	 * Gets or sets the display order.
+	 * The display order.
 	 */
 	@SerialName("DisplayOrder")
 	public val displayOrder: String? = null,
 	/**
-	 * Gets or sets the album id.
+	 * The album id.
 	 */
 	@SerialName("AlbumId")
 	public val albumId: UUID? = null,
 	/**
-	 * Gets or sets the album image tag.
+	 * The album image tag.
 	 */
 	@SerialName("AlbumPrimaryImageTag")
 	public val albumPrimaryImageTag: String? = null,
 	/**
-	 * Gets or sets the series primary image tag.
+	 * The series primary image tag.
 	 */
 	@SerialName("SeriesPrimaryImageTag")
 	public val seriesPrimaryImageTag: String? = null,
 	/**
-	 * Gets or sets the album artist.
+	 * The album artist.
 	 */
 	@SerialName("AlbumArtist")
 	public val albumArtist: String? = null,
 	/**
-	 * Gets or sets the album artists.
+	 * The album artists.
 	 */
 	@SerialName("AlbumArtists")
 	public val albumArtists: List<NameGuidPair>? = null,
 	/**
-	 * Gets or sets the name of the season.
+	 * The name of the season.
 	 */
 	@SerialName("SeasonName")
 	public val seasonName: String? = null,
 	/**
-	 * Gets or sets the media streams.
+	 * The media streams.
 	 */
 	@SerialName("MediaStreams")
 	public val mediaStreams: List<MediaStream>? = null,
 	/**
-	 * Gets or sets the type of the video.
+	 * The type of the video.
 	 */
 	@SerialName("VideoType")
 	public val videoType: VideoType? = null,
 	/**
-	 * Gets or sets the part count.
+	 * The part count.
 	 */
 	@SerialName("PartCount")
 	public val partCount: Int? = null,
 	@SerialName("MediaSourceCount")
 	public val mediaSourceCount: Int? = null,
 	/**
-	 * Gets or sets the image tags.
+	 * The image tags.
 	 */
 	@SerialName("ImageTags")
 	public val imageTags: Map<ImageType, String>? = null,
 	/**
-	 * Gets or sets the backdrop image tags.
+	 * The backdrop image tags.
 	 */
 	@SerialName("BackdropImageTags")
 	public val backdropImageTags: List<String>? = null,
 	/**
-	 * Gets or sets the screenshot image tags.
+	 * The screenshot image tags.
 	 */
 	@SerialName("ScreenshotImageTags")
 	public val screenshotImageTags: List<String>? = null,
 	/**
-	 * Gets or sets the parent logo image tag.
+	 * The parent logo image tag.
 	 */
 	@SerialName("ParentLogoImageTag")
 	public val parentLogoImageTag: String? = null,
 	/**
-	 * Gets or sets wether the item has fan art, this will hold the Id of the Parent that has one.
+	 * Wether the item has fan art, this will hold the Id of the Parent that has one.
 	 */
 	@SerialName("ParentArtItemId")
 	public val parentArtItemId: UUID? = null,
 	/**
-	 * Gets or sets the parent art image tag.
+	 * The parent art image tag.
 	 */
 	@SerialName("ParentArtImageTag")
 	public val parentArtImageTag: String? = null,
 	/**
-	 * Gets or sets the series thumb image tag.
+	 * The series thumb image tag.
 	 */
 	@SerialName("SeriesThumbImageTag")
 	public val seriesThumbImageTag: String? = null,
@@ -468,101 +467,101 @@ public data class BaseItemDto(
 	@SerialName("ImageBlurHashes")
 	public val imageBlurHashes: Map<ImageType, Map<String, String>>? = null,
 	/**
-	 * Gets or sets the series studio.
+	 * The series studio.
 	 */
 	@SerialName("SeriesStudio")
 	public val seriesStudio: String? = null,
 	/**
-	 * Gets or sets the parent thumb item id.
+	 * The parent thumb item id.
 	 */
 	@SerialName("ParentThumbItemId")
 	public val parentThumbItemId: UUID? = null,
 	/**
-	 * Gets or sets the parent thumb image tag.
+	 * The parent thumb image tag.
 	 */
 	@SerialName("ParentThumbImageTag")
 	public val parentThumbImageTag: String? = null,
 	/**
-	 * Gets or sets the parent primary image item identifier.
+	 * The parent primary image item identifier.
 	 */
 	@SerialName("ParentPrimaryImageItemId")
 	public val parentPrimaryImageItemId: String? = null,
 	/**
-	 * Gets or sets the parent primary image tag.
+	 * The parent primary image tag.
 	 */
 	@SerialName("ParentPrimaryImageTag")
 	public val parentPrimaryImageTag: String? = null,
 	/**
-	 * Gets or sets the chapters.
+	 * The chapters.
 	 */
 	@SerialName("Chapters")
 	public val chapters: List<ChapterInfo>? = null,
 	/**
-	 * Gets or sets the type of the location.
+	 * The type of the location.
 	 */
 	@SerialName("LocationType")
 	public val locationType: LocationType? = null,
 	/**
-	 * Gets or sets the type of the iso.
+	 * The type of the iso.
 	 */
 	@SerialName("IsoType")
 	public val isoType: IsoType? = null,
 	/**
-	 * Gets or sets the type of the media.
+	 * The type of the media.
 	 */
 	@SerialName("MediaType")
 	public val mediaType: String? = null,
 	/**
-	 * Gets or sets the end date.
+	 * The end date.
 	 */
 	@SerialName("EndDate")
 	public val endDate: DateTime? = null,
 	/**
-	 * Gets or sets the locked fields.
+	 * The locked fields.
 	 */
 	@SerialName("LockedFields")
 	public val lockedFields: List<MetadataField>? = null,
 	/**
-	 * Gets or sets the trailer count.
+	 * The trailer count.
 	 */
 	@SerialName("TrailerCount")
 	public val trailerCount: Int? = null,
 	/**
-	 * Gets or sets the movie count.
+	 * The movie count.
 	 */
 	@SerialName("MovieCount")
 	public val movieCount: Int? = null,
 	/**
-	 * Gets or sets the series count.
+	 * The series count.
 	 */
 	@SerialName("SeriesCount")
 	public val seriesCount: Int? = null,
 	@SerialName("ProgramCount")
 	public val programCount: Int? = null,
 	/**
-	 * Gets or sets the episode count.
+	 * The episode count.
 	 */
 	@SerialName("EpisodeCount")
 	public val episodeCount: Int? = null,
 	/**
-	 * Gets or sets the song count.
+	 * The song count.
 	 */
 	@SerialName("SongCount")
 	public val songCount: Int? = null,
 	/**
-	 * Gets or sets the album count.
+	 * The album count.
 	 */
 	@SerialName("AlbumCount")
 	public val albumCount: Int? = null,
 	@SerialName("ArtistCount")
 	public val artistCount: Int? = null,
 	/**
-	 * Gets or sets the music video count.
+	 * The music video count.
 	 */
 	@SerialName("MusicVideoCount")
 	public val musicVideoCount: Int? = null,
 	/**
-	 * Gets or sets a value indicating whether [enable internet providers].
+	 * A value indicating whether [enable internet providers].
 	 */
 	@SerialName("LockData")
 	public val lockData: Boolean? = null,
@@ -595,92 +594,92 @@ public data class BaseItemDto(
 	@SerialName("IsoSpeedRating")
 	public val isoSpeedRating: Int? = null,
 	/**
-	 * Gets or sets the series timer identifier.
+	 * The series timer identifier.
 	 */
 	@SerialName("SeriesTimerId")
 	public val seriesTimerId: String? = null,
 	/**
-	 * Gets or sets the program identifier.
+	 * The program identifier.
 	 */
 	@SerialName("ProgramId")
 	public val programId: String? = null,
 	/**
-	 * Gets or sets the channel primary image tag.
+	 * The channel primary image tag.
 	 */
 	@SerialName("ChannelPrimaryImageTag")
 	public val channelPrimaryImageTag: String? = null,
 	/**
-	 * Gets or sets the start date of the recording, in UTC.
+	 * The start date of the recording, in UTC.
 	 */
 	@SerialName("StartDate")
 	public val startDate: DateTime? = null,
 	/**
-	 * Gets or sets the completion percentage.
+	 * The completion percentage.
 	 */
 	@SerialName("CompletionPercentage")
 	public val completionPercentage: Double? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is repeat.
+	 * A value indicating whether this instance is repeat.
 	 */
 	@SerialName("IsRepeat")
 	public val isRepeat: Boolean? = null,
 	/**
-	 * Gets or sets the episode title.
+	 * The episode title.
 	 */
 	@SerialName("EpisodeTitle")
 	public val episodeTitle: String? = null,
 	/**
-	 * Gets or sets the type of the channel.
+	 * The type of the channel.
 	 */
 	@SerialName("ChannelType")
 	public val channelType: ChannelType? = null,
 	/**
-	 * Gets or sets the audio.
+	 * The audio.
 	 */
 	@SerialName("Audio")
 	public val audio: ProgramAudio? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is movie.
+	 * A value indicating whether this instance is movie.
 	 */
 	@SerialName("IsMovie")
 	public val isMovie: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is sports.
+	 * A value indicating whether this instance is sports.
 	 */
 	@SerialName("IsSports")
 	public val isSports: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is series.
+	 * A value indicating whether this instance is series.
 	 */
 	@SerialName("IsSeries")
 	public val isSeries: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is live.
+	 * A value indicating whether this instance is live.
 	 */
 	@SerialName("IsLive")
 	public val isLive: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is news.
+	 * A value indicating whether this instance is news.
 	 */
 	@SerialName("IsNews")
 	public val isNews: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is kids.
+	 * A value indicating whether this instance is kids.
 	 */
 	@SerialName("IsKids")
 	public val isKids: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is premiere.
+	 * A value indicating whether this instance is premiere.
 	 */
 	@SerialName("IsPremiere")
 	public val isPremiere: Boolean? = null,
 	/**
-	 * Gets or sets the timer identifier.
+	 * The timer identifier.
 	 */
 	@SerialName("TimerId")
 	public val timerId: String? = null,
 	/**
-	 * Gets or sets the current program.
+	 * The current program.
 	 */
 	@SerialName("CurrentProgram")
 	public val currentProgram: BaseItemDto? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemDtoQueryResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemDtoQueryResult.kt
@@ -13,17 +13,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class BaseItemDtoQueryResult(
 	/**
-	 * Gets or sets the items.
+	 * The items.
 	 */
 	@SerialName("Items")
 	public val items: List<BaseItemDto>? = null,
 	/**
-	 * Gets or sets the total number of records available.
+	 * The total number of records available.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the index of the first record in Items.
+	 * The index of the first record in Items.
 	 */
 	@SerialName("StartIndex")
 	public val startIndex: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemPerson.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemPerson.kt
@@ -21,32 +21,32 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class BaseItemPerson(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the identifier.
+	 * The identifier.
 	 */
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets or sets the role.
+	 * The role.
 	 */
 	@SerialName("Role")
 	public val role: String? = null,
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: String? = null,
 	/**
-	 * Gets or sets the primary image tag.
+	 * The primary image tag.
 	 */
 	@SerialName("PrimaryImageTag")
 	public val primaryImageTag: String? = null,
 	/**
-	 * Gets or sets the primary image blurhash.
+	 * The primary image blurhash.
 	 */
 	@SerialName("ImageBlurHashes")
 	public val imageBlurHashes: Map<ImageType, Map<String, String>>? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BookInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BookInfo.kt
@@ -20,37 +20,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class BookInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BookInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class BookInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BoxSetInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BoxSetInfo.kt
@@ -20,37 +20,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class BoxSetInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BoxSetInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class BoxSetInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BrandingOptions.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BrandingOptions.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class BrandingOptions(
 	/**
-	 * Gets or sets the login disclaimer.
+	 * The login disclaimer.
 	 */
 	@SerialName("LoginDisclaimer")
 	public val loginDisclaimer: String? = null,
 	/**
-	 * Gets or sets the custom CSS.
+	 * The custom CSS.
 	 */
 	@SerialName("CustomCss")
 	public val customCss: String? = null,
 	/**
-	 * Gets or sets a value indicating whether to enable the splashscreen.
+	 * A value indicating whether to enable the splashscreen.
 	 */
 	@SerialName("SplashscreenEnabled")
 	public val splashscreenEnabled: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BufferRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BufferRequestDto.kt
@@ -26,22 +26,22 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class BufferRequestDto(
 	/**
-	 * Gets or sets when the request has been made by the client.
+	 * When the request has been made by the client.
 	 */
 	@SerialName("When")
 	public val `when`: DateTime,
 	/**
-	 * Gets or sets the position ticks.
+	 * The position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long,
 	/**
-	 * Gets or sets a value indicating whether the client playback is unpaused.
+	 * A value indicating whether the client playback is unpaused.
 	 */
 	@SerialName("IsPlaying")
 	public val isPlaying: Boolean,
 	/**
-	 * Gets or sets the playlist item identifier of the playing item.
+	 * The playlist item identifier of the playing item.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelFeatures.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelFeatures.kt
@@ -20,62 +20,62 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class ChannelFeatures(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets the identifier.
+	 * The identifier.
 	 */
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets or sets a value indicating whether this instance can search.
+	 * A value indicating whether this instance can search.
 	 */
 	@SerialName("CanSearch")
 	public val canSearch: Boolean,
 	/**
-	 * Gets or sets the media types.
+	 * The media types.
 	 */
 	@SerialName("MediaTypes")
 	public val mediaTypes: List<ChannelMediaType>,
 	/**
-	 * Gets or sets the content types.
+	 * The content types.
 	 */
 	@SerialName("ContentTypes")
 	public val contentTypes: List<ChannelMediaContentType>,
 	/**
-	 * Gets or sets the maximum number of records the channel allows retrieving at a time.
+	 * The maximum number of records the channel allows retrieving at a time.
 	 */
 	@SerialName("MaxPageSize")
 	public val maxPageSize: Int? = null,
 	/**
-	 * Gets or sets the automatic refresh levels.
+	 * The automatic refresh levels.
 	 */
 	@SerialName("AutoRefreshLevels")
 	public val autoRefreshLevels: Int? = null,
 	/**
-	 * Gets or sets the default sort orders.
+	 * The default sort orders.
 	 */
 	@SerialName("DefaultSortFields")
 	public val defaultSortFields: List<ChannelItemSortField>,
 	/**
-	 * Gets or sets a value indicating whether a sort ascending/descending toggle is supported.
+	 * A value indicating whether a sort ascending/descending toggle is supported.
 	 */
 	@SerialName("SupportsSortOrderToggle")
 	public val supportsSortOrderToggle: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [supports latest media].
+	 * A value indicating whether [supports latest media].
 	 */
 	@SerialName("SupportsLatestMedia")
 	public val supportsLatestMedia: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance can filter.
+	 * A value indicating whether this instance can filter.
 	 */
 	@SerialName("CanFilter")
 	public val canFilter: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [supports content downloading].
+	 * A value indicating whether [supports content downloading].
 	 */
 	@SerialName("SupportsContentDownloading")
 	public val supportsContentDownloading: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMappingOptionsDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMappingOptionsDto.kt
@@ -16,22 +16,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ChannelMappingOptionsDto(
 	/**
-	 * Gets or sets list of tuner channels.
+	 * List of tuner channels.
 	 */
 	@SerialName("TunerChannels")
 	public val tunerChannels: List<TunerChannelMapping>,
 	/**
-	 * Gets or sets list of provider channels.
+	 * List of provider channels.
 	 */
 	@SerialName("ProviderChannels")
 	public val providerChannels: List<NameIdPair>,
 	/**
-	 * Gets or sets list of mappings.
+	 * List of mappings.
 	 */
 	@SerialName("Mappings")
 	public val mappings: List<NameValuePair>,
 	/**
-	 * Gets or sets provider name.
+	 * Provider name.
 	 */
 	@SerialName("ProviderName")
 	public val providerName: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChapterInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChapterInfo.kt
@@ -21,17 +21,17 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class ChapterInfo(
 	/**
-	 * Gets or sets the start position ticks.
+	 * The start position ticks.
 	 */
 	@SerialName("StartPositionTicks")
 	public val startPositionTicks: Long,
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the image path.
+	 * The image path.
 	 */
 	@SerialName("ImagePath")
 	public val imagePath: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ClientCapabilitiesDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ClientCapabilitiesDto.kt
@@ -17,37 +17,37 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ClientCapabilitiesDto(
 	/**
-	 * Gets or sets the list of playable media types.
+	 * The list of playable media types.
 	 */
 	@SerialName("PlayableMediaTypes")
 	public val playableMediaTypes: List<String>,
 	/**
-	 * Gets or sets the list of supported commands.
+	 * The list of supported commands.
 	 */
 	@SerialName("SupportedCommands")
 	public val supportedCommands: List<GeneralCommandType>,
 	/**
-	 * Gets or sets a value indicating whether session supports media control.
+	 * A value indicating whether session supports media control.
 	 */
 	@SerialName("SupportsMediaControl")
 	public val supportsMediaControl: Boolean,
 	/**
-	 * Gets or sets a value indicating whether session supports content uploading.
+	 * A value indicating whether session supports content uploading.
 	 */
 	@SerialName("SupportsContentUploading")
 	public val supportsContentUploading: Boolean,
 	/**
-	 * Gets or sets the message callback url.
+	 * The message callback url.
 	 */
 	@SerialName("MessageCallbackUrl")
 	public val messageCallbackUrl: String? = null,
 	/**
-	 * Gets or sets a value indicating whether session supports a persistent identifier.
+	 * A value indicating whether session supports a persistent identifier.
 	 */
 	@SerialName("SupportsPersistentIdentifier")
 	public val supportsPersistentIdentifier: Boolean,
 	/**
-	 * Gets or sets a value indicating whether session supports sync.
+	 * A value indicating whether session supports sync.
 	 */
 	@SerialName("SupportsSync")
 	public val supportsSync: Boolean,
@@ -67,12 +67,12 @@ public data class ClientCapabilitiesDto(
 	@SerialName("DeviceProfile")
 	public val deviceProfile: DeviceProfile? = null,
 	/**
-	 * Gets or sets the app store url.
+	 * The app store url.
 	 */
 	@SerialName("AppStoreUrl")
 	public val appStoreUrl: String? = null,
 	/**
-	 * Gets or sets the icon url.
+	 * The icon url.
 	 */
 	@SerialName("IconUrl")
 	public val iconUrl: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ClientLogDocumentResponseDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ClientLogDocumentResponseDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ClientLogDocumentResponseDto(
 	/**
-	 * Gets the resulting filename.
+	 * The resulting filename.
 	 */
 	@SerialName("FileName")
 	public val fileName: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ConfigurationPageInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ConfigurationPageInfo.kt
@@ -21,32 +21,32 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class ConfigurationPageInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets a value indicating whether the configurations page is enabled in the main menu.
+	 * A value indicating whether the configurations page is enabled in the main menu.
 	 */
 	@SerialName("EnableInMainMenu")
 	public val enableInMainMenu: Boolean,
 	/**
-	 * Gets or sets the menu section.
+	 * The menu section.
 	 */
 	@SerialName("MenuSection")
 	public val menuSection: String? = null,
 	/**
-	 * Gets or sets the menu icon.
+	 * The menu icon.
 	 */
 	@SerialName("MenuIcon")
 	public val menuIcon: String? = null,
 	/**
-	 * Gets or sets the display name.
+	 * The display name.
 	 */
 	@SerialName("DisplayName")
 	public val displayName: String? = null,
 	/**
-	 * Gets or sets the plugin id.
+	 * The plugin id.
 	 */
 	@SerialName("PluginId")
 	public val pluginId: UUID? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CountryInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CountryInfo.kt
@@ -15,22 +15,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class CountryInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the display name.
+	 * The display name.
 	 */
 	@SerialName("DisplayName")
 	public val displayName: String? = null,
 	/**
-	 * Gets or sets the name of the two letter ISO region.
+	 * The name of the two letter ISO region.
 	 */
 	@SerialName("TwoLetterISORegionName")
 	public val twoLetterIsoRegionName: String? = null,
 	/**
-	 * Gets or sets the name of the three letter ISO region.
+	 * The name of the three letter ISO region.
 	 */
 	@SerialName("ThreeLetterISORegionName")
 	public val threeLetterIsoRegionName: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CreatePlaylistDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CreatePlaylistDto.kt
@@ -21,22 +21,22 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class CreatePlaylistDto(
 	/**
-	 * Gets or sets the name of the new playlist.
+	 * The name of the new playlist.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets item ids to add to the playlist.
+	 * Item ids to add to the playlist.
 	 */
 	@SerialName("Ids")
 	public val ids: List<UUID>,
 	/**
-	 * Gets or sets the user id.
+	 * The user id.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID? = null,
 	/**
-	 * Gets or sets the media type.
+	 * The media type.
 	 */
 	@SerialName("MediaType")
 	public val mediaType: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CreateUserByName.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CreateUserByName.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class CreateUserByName(
 	/**
-	 * Gets or sets the username.
+	 * The username.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the password.
+	 * The password.
 	 */
 	@SerialName("Password")
 	public val password: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CultureDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CultureDto.kt
@@ -16,22 +16,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class CultureDto(
 	/**
-	 * Gets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets the display name.
+	 * The display name.
 	 */
 	@SerialName("DisplayName")
 	public val displayName: String,
 	/**
-	 * Gets the name of the two letter ISO language.
+	 * The name of the two letter ISO language.
 	 */
 	@SerialName("TwoLetterISOLanguageName")
 	public val twoLetterIsoLanguageName: String,
 	/**
-	 * Gets the name of the three letter ISO language.
+	 * The name of the three letter ISO language.
 	 */
 	@SerialName("ThreeLetterISOLanguageName")
 	public val threeLetterIsoLanguageName: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DefaultDirectoryBrowserInfoDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DefaultDirectoryBrowserInfoDto(
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceIdentification.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceIdentification.kt
@@ -13,47 +13,47 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DeviceIdentification(
 	/**
-	 * Gets or sets the name of the friendly.
+	 * The name of the friendly.
 	 */
 	@SerialName("FriendlyName")
 	public val friendlyName: String,
 	/**
-	 * Gets or sets the model number.
+	 * The model number.
 	 */
 	@SerialName("ModelNumber")
 	public val modelNumber: String,
 	/**
-	 * Gets or sets the serial number.
+	 * The serial number.
 	 */
 	@SerialName("SerialNumber")
 	public val serialNumber: String,
 	/**
-	 * Gets or sets the name of the model.
+	 * The name of the model.
 	 */
 	@SerialName("ModelName")
 	public val modelName: String,
 	/**
-	 * Gets or sets the model description.
+	 * The model description.
 	 */
 	@SerialName("ModelDescription")
 	public val modelDescription: String,
 	/**
-	 * Gets or sets the model URL.
+	 * The model URL.
 	 */
 	@SerialName("ModelUrl")
 	public val modelUrl: String,
 	/**
-	 * Gets or sets the manufacturer.
+	 * The manufacturer.
 	 */
 	@SerialName("Manufacturer")
 	public val manufacturer: String,
 	/**
-	 * Gets or sets the manufacturer URL.
+	 * The manufacturer URL.
 	 */
 	@SerialName("ManufacturerUrl")
 	public val manufacturerUrl: String,
 	/**
-	 * Gets or sets the headers.
+	 * The headers.
 	 */
 	@SerialName("Headers")
 	public val headers: List<HttpHeaderInfo>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceInfo.kt
@@ -24,42 +24,42 @@ public data class DeviceInfo(
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the access token.
+	 * The access token.
 	 */
 	@SerialName("AccessToken")
 	public val accessToken: String? = null,
 	/**
-	 * Gets or sets the identifier.
+	 * The identifier.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets the last name of the user.
+	 * The last name of the user.
 	 */
 	@SerialName("LastUserName")
 	public val lastUserName: String? = null,
 	/**
-	 * Gets or sets the name of the application.
+	 * The name of the application.
 	 */
 	@SerialName("AppName")
 	public val appName: String? = null,
 	/**
-	 * Gets or sets the application version.
+	 * The application version.
 	 */
 	@SerialName("AppVersion")
 	public val appVersion: String? = null,
 	/**
-	 * Gets or sets the last user identifier.
+	 * The last user identifier.
 	 */
 	@SerialName("LastUserId")
 	public val lastUserId: UUID,
 	/**
-	 * Gets or sets the date last modified.
+	 * The date last modified.
 	 */
 	@SerialName("DateLastActivity")
 	public val dateLastActivity: DateTime,
 	/**
-	 * Gets or sets the capabilities.
+	 * The capabilities.
 	 */
 	@SerialName("Capabilities")
 	public val capabilities: ClientCapabilities? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceInfoQueryResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceInfoQueryResult.kt
@@ -13,17 +13,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DeviceInfoQueryResult(
 	/**
-	 * Gets or sets the items.
+	 * The items.
 	 */
 	@SerialName("Items")
 	public val items: List<DeviceInfo>? = null,
 	/**
-	 * Gets or sets the total number of records available.
+	 * The total number of records available.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the index of the first record in Items.
+	 * The index of the first record in Items.
 	 */
 	@SerialName("StartIndex")
 	public val startIndex: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceOptions.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceOptions.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DeviceOptions(
 	/**
-	 * Gets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: Int,
 	/**
-	 * Gets the device id.
+	 * The device id.
 	 */
 	@SerialName("DeviceId")
 	public val deviceId: String,
 	/**
-	 * Gets or sets the custom name.
+	 * The custom name.
 	 */
 	@SerialName("CustomName")
 	public val customName: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceOptionsDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceOptionsDto.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DeviceOptionsDto(
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: Int,
 	/**
-	 * Gets or sets the device id.
+	 * The device id.
 	 */
 	@SerialName("DeviceId")
 	public val deviceId: String? = null,
 	/**
-	 * Gets or sets the custom name.
+	 * The custom name.
 	 */
 	@SerialName("CustomName")
 	public val customName: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfile.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfile.kt
@@ -28,199 +28,197 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DeviceProfile(
 	/**
-	 * Gets or sets the name of this device profile.
+	 * The name of this device profile.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the Id.
+	 * The Id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets the Identification.
+	 * The Identification.
 	 */
 	@SerialName("Identification")
 	public val identification: DeviceIdentification? = null,
 	/**
-	 * Gets or sets the friendly name of the device profile, which can be shown to users.
+	 * The friendly name of the device profile, which can be shown to users.
 	 */
 	@SerialName("FriendlyName")
 	public val friendlyName: String? = null,
 	/**
-	 * Gets or sets the manufacturer of the device which this profile represents.
+	 * The manufacturer of the device which this profile represents.
 	 */
 	@SerialName("Manufacturer")
 	public val manufacturer: String? = null,
 	/**
-	 * Gets or sets an url for the manufacturer of the device which this profile represents.
+	 * An url for the manufacturer of the device which this profile represents.
 	 */
 	@SerialName("ManufacturerUrl")
 	public val manufacturerUrl: String? = null,
 	/**
-	 * Gets or sets the model name of the device which this profile represents.
+	 * The model name of the device which this profile represents.
 	 */
 	@SerialName("ModelName")
 	public val modelName: String? = null,
 	/**
-	 * Gets or sets the model description of the device which this profile represents.
+	 * The model description of the device which this profile represents.
 	 */
 	@SerialName("ModelDescription")
 	public val modelDescription: String? = null,
 	/**
-	 * Gets or sets the model number of the device which this profile represents.
+	 * The model number of the device which this profile represents.
 	 */
 	@SerialName("ModelNumber")
 	public val modelNumber: String? = null,
 	/**
-	 * Gets or sets the ModelUrl.
+	 * The ModelUrl.
 	 */
 	@SerialName("ModelUrl")
 	public val modelUrl: String? = null,
 	/**
-	 * Gets or sets the serial number of the device which this profile represents.
+	 * The serial number of the device which this profile represents.
 	 */
 	@SerialName("SerialNumber")
 	public val serialNumber: String? = null,
 	/**
-	 * Gets or sets a value indicating whether EnableAlbumArtInDidl.
+	 * A value indicating whether EnableAlbumArtInDidl.
 	 */
 	@SerialName("EnableAlbumArtInDidl")
 	public val enableAlbumArtInDidl: Boolean = false,
 	/**
-	 * Gets or sets a value indicating whether EnableSingleAlbumArtLimit.
+	 * A value indicating whether EnableSingleAlbumArtLimit.
 	 */
 	@SerialName("EnableSingleAlbumArtLimit")
 	public val enableSingleAlbumArtLimit: Boolean = false,
 	/**
-	 * Gets or sets a value indicating whether EnableSingleSubtitleLimit.
+	 * A value indicating whether EnableSingleSubtitleLimit.
 	 */
 	@SerialName("EnableSingleSubtitleLimit")
 	public val enableSingleSubtitleLimit: Boolean = false,
 	/**
-	 * Gets or sets the SupportedMediaTypes.
+	 * The SupportedMediaTypes.
 	 */
 	@SerialName("SupportedMediaTypes")
 	public val supportedMediaTypes: String,
 	/**
-	 * Gets or sets the UserId.
+	 * The UserId.
 	 */
 	@SerialName("UserId")
 	public val userId: String? = null,
 	/**
-	 * Gets or sets the AlbumArtPn.
+	 * The AlbumArtPn.
 	 */
 	@SerialName("AlbumArtPn")
 	public val albumArtPn: String? = null,
 	/**
-	 * Gets or sets the MaxAlbumArtWidth.
+	 * The MaxAlbumArtWidth.
 	 */
 	@SerialName("MaxAlbumArtWidth")
 	public val maxAlbumArtWidth: Int? = null,
 	/**
-	 * Gets or sets the MaxAlbumArtHeight.
+	 * The MaxAlbumArtHeight.
 	 */
 	@SerialName("MaxAlbumArtHeight")
 	public val maxAlbumArtHeight: Int? = null,
 	/**
-	 * Gets or sets the maximum allowed width of embedded icons.
+	 * The maximum allowed width of embedded icons.
 	 */
 	@SerialName("MaxIconWidth")
 	public val maxIconWidth: Int? = null,
 	/**
-	 * Gets or sets the maximum allowed height of embedded icons.
+	 * The maximum allowed height of embedded icons.
 	 */
 	@SerialName("MaxIconHeight")
 	public val maxIconHeight: Int? = null,
 	/**
-	 * Gets or sets the maximum allowed bitrate for all streamed content.
+	 * The maximum allowed bitrate for all streamed content.
 	 */
 	@SerialName("MaxStreamingBitrate")
 	public val maxStreamingBitrate: Int? = null,
 	/**
-	 * Gets or sets the maximum allowed bitrate for statically streamed content (= direct played
-	 * files).
+	 * The maximum allowed bitrate for statically streamed content (= direct played files).
 	 */
 	@SerialName("MaxStaticBitrate")
 	public val maxStaticBitrate: Int? = null,
 	/**
-	 * Gets or sets the maximum allowed bitrate for transcoded music streams.
+	 * The maximum allowed bitrate for transcoded music streams.
 	 */
 	@SerialName("MusicStreamingTranscodingBitrate")
 	public val musicStreamingTranscodingBitrate: Int? = null,
 	/**
-	 * Gets or sets the maximum allowed bitrate for statically streamed (= direct played) music files.
+	 * The maximum allowed bitrate for statically streamed (= direct played) music files.
 	 */
 	@SerialName("MaxStaticMusicBitrate")
 	public val maxStaticMusicBitrate: Int? = null,
 	/**
-	 * Gets or sets the content of the aggregationFlags element in the urn:schemas-sonycom:av
-	 * namespace.
+	 * The content of the aggregationFlags element in the urn:schemas-sonycom:av namespace.
 	 */
 	@SerialName("SonyAggregationFlags")
 	public val sonyAggregationFlags: String? = null,
 	/**
-	 * Gets or sets the ProtocolInfo.
+	 * The ProtocolInfo.
 	 */
 	@SerialName("ProtocolInfo")
 	public val protocolInfo: String? = null,
 	/**
-	 * Gets or sets the TimelineOffsetSeconds.
+	 * The TimelineOffsetSeconds.
 	 */
 	@SerialName("TimelineOffsetSeconds")
 	public val timelineOffsetSeconds: Int = 0,
 	/**
-	 * Gets or sets a value indicating whether RequiresPlainVideoItems.
+	 * A value indicating whether RequiresPlainVideoItems.
 	 */
 	@SerialName("RequiresPlainVideoItems")
 	public val requiresPlainVideoItems: Boolean = false,
 	/**
-	 * Gets or sets a value indicating whether RequiresPlainFolders.
+	 * A value indicating whether RequiresPlainFolders.
 	 */
 	@SerialName("RequiresPlainFolders")
 	public val requiresPlainFolders: Boolean = false,
 	/**
-	 * Gets or sets a value indicating whether EnableMSMediaReceiverRegistrar.
+	 * A value indicating whether EnableMSMediaReceiverRegistrar.
 	 */
 	@SerialName("EnableMSMediaReceiverRegistrar")
 	public val enableMsMediaReceiverRegistrar: Boolean = false,
 	/**
-	 * Gets or sets a value indicating whether IgnoreTranscodeByteRangeRequests.
+	 * A value indicating whether IgnoreTranscodeByteRangeRequests.
 	 */
 	@SerialName("IgnoreTranscodeByteRangeRequests")
 	public val ignoreTranscodeByteRangeRequests: Boolean = false,
 	/**
-	 * Gets or sets the XmlRootAttributes.
+	 * The XmlRootAttributes.
 	 */
 	@SerialName("XmlRootAttributes")
 	public val xmlRootAttributes: List<XmlAttribute>,
 	/**
-	 * Gets or sets the direct play profiles.
+	 * The direct play profiles.
 	 */
 	@SerialName("DirectPlayProfiles")
 	public val directPlayProfiles: List<DirectPlayProfile>,
 	/**
-	 * Gets or sets the transcoding profiles.
+	 * The transcoding profiles.
 	 */
 	@SerialName("TranscodingProfiles")
 	public val transcodingProfiles: List<TranscodingProfile>,
 	/**
-	 * Gets or sets the container profiles.
+	 * The container profiles.
 	 */
 	@SerialName("ContainerProfiles")
 	public val containerProfiles: List<ContainerProfile>,
 	/**
-	 * Gets or sets the codec profiles.
+	 * The codec profiles.
 	 */
 	@SerialName("CodecProfiles")
 	public val codecProfiles: List<CodecProfile>,
 	/**
-	 * Gets or sets the ResponseProfiles.
+	 * The ResponseProfiles.
 	 */
 	@SerialName("ResponseProfiles")
 	public val responseProfiles: List<ResponseProfile>,
 	/**
-	 * Gets or sets the subtitle profiles.
+	 * The subtitle profiles.
 	 */
 	@SerialName("SubtitleProfiles")
 	public val subtitleProfiles: List<SubtitleProfile>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfileInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfileInfo.kt
@@ -12,17 +12,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DeviceProfileInfo(
 	/**
-	 * Gets or sets the identifier.
+	 * The identifier.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: DeviceProfileType,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DisplayPreferencesDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DisplayPreferencesDto.kt
@@ -18,72 +18,72 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DisplayPreferencesDto(
 	/**
-	 * Gets or sets the user id.
+	 * The user id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets the type of the view.
+	 * The type of the view.
 	 */
 	@SerialName("ViewType")
 	public val viewType: String? = null,
 	/**
-	 * Gets or sets the sort by.
+	 * The sort by.
 	 */
 	@SerialName("SortBy")
 	public val sortBy: String? = null,
 	/**
-	 * Gets or sets the index by.
+	 * The index by.
 	 */
 	@SerialName("IndexBy")
 	public val indexBy: String? = null,
 	/**
-	 * Gets or sets a value indicating whether [remember indexing].
+	 * A value indicating whether [remember indexing].
 	 */
 	@SerialName("RememberIndexing")
 	public val rememberIndexing: Boolean,
 	/**
-	 * Gets or sets the height of the primary image.
+	 * The height of the primary image.
 	 */
 	@SerialName("PrimaryImageHeight")
 	public val primaryImageHeight: Int,
 	/**
-	 * Gets or sets the width of the primary image.
+	 * The width of the primary image.
 	 */
 	@SerialName("PrimaryImageWidth")
 	public val primaryImageWidth: Int,
 	/**
-	 * Gets or sets the custom prefs.
+	 * The custom prefs.
 	 */
 	@SerialName("CustomPrefs")
 	public val customPrefs: Map<String, String?>,
 	/**
-	 * Gets or sets the scroll direction.
+	 * The scroll direction.
 	 */
 	@SerialName("ScrollDirection")
 	public val scrollDirection: ScrollDirection,
 	/**
-	 * Gets or sets a value indicating whether to show backdrops on this item.
+	 * A value indicating whether to show backdrops on this item.
 	 */
 	@SerialName("ShowBackdrop")
 	public val showBackdrop: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [remember sorting].
+	 * A value indicating whether [remember sorting].
 	 */
 	@SerialName("RememberSorting")
 	public val rememberSorting: Boolean,
 	/**
-	 * Gets or sets the sort order.
+	 * The sort order.
 	 */
 	@SerialName("SortOrder")
 	public val sortOrder: SortOrder,
 	/**
-	 * Gets or sets a value indicating whether [show sidebar].
+	 * A value indicating whether [show sidebar].
 	 */
 	@SerialName("ShowSidebar")
 	public val showSidebar: Boolean,
 	/**
-	 * Gets or sets the client.
+	 * The client.
 	 */
 	@SerialName("Client")
 	public val client: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DlnaOptions.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DlnaOptions.kt
@@ -17,14 +17,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class DlnaOptions(
 	/**
-	 * Gets or sets a value indicating whether gets or sets a value to indicate the status of the dlna
-	 * playTo subsystem.
+	 * A value indicating whether gets or sets a value to indicate the status of the dlna playTo
+	 * subsystem.
 	 */
 	@SerialName("EnablePlayTo")
 	public val enablePlayTo: Boolean,
 	/**
-	 * Gets or sets a value indicating whether gets or sets a value to indicate the status of the dlna
-	 * server subsystem.
+	 * A value indicating whether gets or sets a value to indicate the status of the dlna server
+	 * subsystem.
 	 */
 	@SerialName("EnableServer")
 	public val enableServer: Boolean,
@@ -50,28 +50,28 @@ public data class DlnaOptions(
 	@SerialName("ClientDiscoveryIntervalSeconds")
 	public val clientDiscoveryIntervalSeconds: Int,
 	/**
-	 * Gets or sets the frequency at which ssdp alive notifications are transmitted.
+	 * The frequency at which ssdp alive notifications are transmitted.
 	 */
 	@SerialName("AliveMessageIntervalSeconds")
 	public val aliveMessageIntervalSeconds: Int,
 	/**
-	 * Gets or sets the frequency at which ssdp alive notifications are transmitted. MIGRATING - TO BE
-	 * REMOVED ONCE WEB HAS BEEN ALTERED.
+	 * The frequency at which ssdp alive notifications are transmitted. MIGRATING - TO BE REMOVED ONCE
+	 * WEB HAS BEEN ALTERED.
 	 */
 	@SerialName("BlastAliveMessageIntervalSeconds")
 	public val blastAliveMessageIntervalSeconds: Int,
 	/**
-	 * Gets or sets the default user account that the dlna server uses.
+	 * The default user account that the dlna server uses.
 	 */
 	@SerialName("DefaultUserId")
 	public val defaultUserId: String? = null,
 	/**
-	 * Gets or sets a value indicating whether playTo device profiles should be created.
+	 * A value indicating whether playTo device profiles should be created.
 	 */
 	@SerialName("AutoCreatePlayToProfiles")
 	public val autoCreatePlayToProfiles: Boolean,
 	/**
-	 * Gets or sets a value indicating whether to blast alive messages.
+	 * A value indicating whether to blast alive messages.
 	 */
 	@SerialName("BlastAliveMessages")
 	public val blastAliveMessages: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/EncodingOptions.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/EncodingOptions.kt
@@ -34,13 +34,12 @@ public data class EncodingOptions(
 	@SerialName("HardwareAccelerationType")
 	public val hardwareAccelerationType: String? = null,
 	/**
-	 * Gets or sets the FFmpeg path as set by the user via the UI.
+	 * The FFmpeg path as set by the user via the UI.
 	 */
 	@SerialName("EncoderAppPath")
 	public val encoderAppPath: String? = null,
 	/**
-	 * Gets or sets the current FFmpeg path being used by the system and displayed on the transcode
-	 * page.
+	 * The current FFmpeg path being used by the system and displayed on the transcode page.
 	 */
 	@SerialName("EncoderAppPathDisplay")
 	public val encoderAppPathDisplay: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdInfo.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ExternalIdInfo(
 	/**
-	 * Gets or sets the display name of the external id provider (IE: IMDB, MusicBrainz, etc).
+	 * The display name of the external id provider (IE: IMDB, MusicBrainz, etc).
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets the unique key for this id. This key should be unique across all providers.
+	 * The unique key for this id. This key should be unique across all providers.
 	 */
 	@SerialName("Key")
 	public val key: String,
@@ -35,7 +35,7 @@ public data class ExternalIdInfo(
 	@SerialName("Type")
 	public val type: ExternalIdMediaType? = null,
 	/**
-	 * Gets or sets the URL format string.
+	 * The URL format string.
 	 */
 	@SerialName("UrlFormatString")
 	public val urlFormatString: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalUrl.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalUrl.kt
@@ -12,12 +12,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ExternalUrl(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the type of the item.
+	 * The type of the item.
 	 */
 	@SerialName("Url")
 	public val url: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FileSystemEntryInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FileSystemEntryInfo.kt
@@ -15,17 +15,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class FileSystemEntryInfo(
 	/**
-	 * Gets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String,
 	/**
-	 * Gets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: FileSystemEntryType,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FontFile.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FontFile.kt
@@ -21,22 +21,22 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class FontFile(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the size.
+	 * The size.
 	 */
 	@SerialName("Size")
 	public val size: Long,
 	/**
-	 * Gets or sets the date created.
+	 * The date created.
 	 */
 	@SerialName("DateCreated")
 	public val dateCreated: DateTime,
 	/**
-	 * Gets or sets the date modified.
+	 * The date modified.
 	 */
 	@SerialName("DateModified")
 	public val dateModified: DateTime,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ForgotPasswordDto(
 	/**
-	 * Gets or sets the entered username to have its password reset.
+	 * The entered username to have its password reset.
 	 */
 	@SerialName("EnteredUsername")
 	public val enteredUsername: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordPinDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordPinDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ForgotPasswordPinDto(
 	/**
-	 * Gets or sets the entered pin to have the password reset.
+	 * The entered pin to have the password reset.
 	 */
 	@SerialName("Pin")
 	public val pin: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordResult.kt
@@ -17,17 +17,17 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class ForgotPasswordResult(
 	/**
-	 * Gets or sets the action.
+	 * The action.
 	 */
 	@SerialName("Action")
 	public val action: ForgotPasswordAction,
 	/**
-	 * Gets or sets the pin file.
+	 * The pin file.
 	 */
 	@SerialName("PinFile")
 	public val pinFile: String? = null,
 	/**
-	 * Gets or sets the pin expiration date.
+	 * The pin expiration date.
 	 */
 	@SerialName("PinExpirationDate")
 	public val pinExpirationDate: DateTime? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GetProgramsDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GetProgramsDto.kt
@@ -28,12 +28,12 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class GetProgramsDto(
 	/**
-	 * Gets or sets the channels to return guide information for.
+	 * The channels to return guide information for.
 	 */
 	@SerialName("ChannelIds")
 	public val channelIds: List<UUID>,
 	/**
-	 * Gets or sets optional. Filter by user id.
+	 * Optional. Filter by user id.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID,
@@ -123,17 +123,17 @@ public data class GetProgramsDto(
 	@SerialName("SortBy")
 	public val sortBy: List<String>,
 	/**
-	 * Gets or sets sort Order - Ascending,Descending.
+	 * Sort Order - Ascending,Descending.
 	 */
 	@SerialName("SortOrder")
 	public val sortOrder: List<SortOrder>,
 	/**
-	 * Gets or sets the genres to return guide information for.
+	 * The genres to return guide information for.
 	 */
 	@SerialName("Genres")
 	public val genres: List<String>,
 	/**
-	 * Gets or sets the genre ids to return guide information for.
+	 * The genre ids to return guide information for.
 	 */
 	@SerialName("GenreIds")
 	public val genreIds: List<UUID>,
@@ -144,7 +144,7 @@ public data class GetProgramsDto(
 	@SerialName("EnableImages")
 	public val enableImages: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether retrieve total record count.
+	 * A value indicating whether retrieve total record count.
 	 */
 	@SerialName("EnableTotalRecordCount")
 	public val enableTotalRecordCount: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupInfoDto.kt
@@ -26,27 +26,27 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class GroupInfoDto(
 	/**
-	 * Gets the group identifier.
+	 * The group identifier.
 	 */
 	@SerialName("GroupId")
 	public val groupId: UUID,
 	/**
-	 * Gets the group name.
+	 * The group name.
 	 */
 	@SerialName("GroupName")
 	public val groupName: String,
 	/**
-	 * Gets the group state.
+	 * The group state.
 	 */
 	@SerialName("State")
 	public val state: GroupStateType,
 	/**
-	 * Gets the participants.
+	 * The participants.
 	 */
 	@SerialName("Participants")
 	public val participants: List<String>,
 	/**
-	 * Gets the date when this DTO has been created.
+	 * The date when this DTO has been created.
 	 */
 	@SerialName("LastUpdatedAt")
 	public val lastUpdatedAt: DateTime,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GuideInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GuideInfo.kt
@@ -16,12 +16,12 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class GuideInfo(
 	/**
-	 * Gets or sets the start date.
+	 * The start date.
 	 */
 	@SerialName("StartDate")
 	public val startDate: DateTime,
 	/**
-	 * Gets or sets the end date.
+	 * The end date.
 	 */
 	@SerialName("EndDate")
 	public val endDate: DateTime,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/IPlugin.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/IPlugin.kt
@@ -21,38 +21,37 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class IPlugin(
 	/**
-	 * Gets the name of the plugin.
+	 * The name of the plugin.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets the Description.
+	 * The Description.
 	 */
 	@SerialName("Description")
 	public val description: String? = null,
 	/**
-	 * Gets the unique id.
+	 * The unique id.
 	 */
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets the plugin version.
+	 * The plugin version.
 	 */
 	@SerialName("Version")
 	public val version: String? = null,
 	/**
-	 * Gets the path to the assembly file.
+	 * The path to the assembly file.
 	 */
 	@SerialName("AssemblyFilePath")
 	public val assemblyFilePath: String? = null,
 	/**
-	 * Gets a value indicating whether the plugin can be uninstalled.
+	 * A value indicating whether the plugin can be uninstalled.
 	 */
 	@SerialName("CanUninstall")
 	public val canUninstall: Boolean,
 	/**
-	 * Gets the full path to the data folder, where the plugin can store any miscellaneous files
-	 * needed.
+	 * The full path to the data folder, where the plugin can store any miscellaneous files needed.
 	 */
 	@SerialName("DataFolderPath")
 	public val dataFolderPath: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/IgnoreWaitRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/IgnoreWaitRequestDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class IgnoreWaitRequestDto(
 	/**
-	 * Gets or sets a value indicating whether the client should be ignored.
+	 * A value indicating whether the client should be ignored.
 	 */
 	@SerialName("IgnoreWait")
 	public val ignoreWait: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageByNameInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageByNameInfo.kt
@@ -13,27 +13,27 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ImageByNameInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the theme.
+	 * The theme.
 	 */
 	@SerialName("Theme")
 	public val theme: String? = null,
 	/**
-	 * Gets or sets the context.
+	 * The context.
 	 */
 	@SerialName("Context")
 	public val context: String? = null,
 	/**
-	 * Gets or sets the length of the file.
+	 * The length of the file.
 	 */
 	@SerialName("FileLength")
 	public val fileLength: Long,
 	/**
-	 * Gets or sets the format.
+	 * The format.
 	 */
 	@SerialName("Format")
 	public val format: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageInfo.kt
@@ -17,42 +17,42 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ImageInfo(
 	/**
-	 * Gets or sets the type of the image.
+	 * The type of the image.
 	 */
 	@SerialName("ImageType")
 	public val imageType: ImageType,
 	/**
-	 * Gets or sets the index of the image.
+	 * The index of the image.
 	 */
 	@SerialName("ImageIndex")
 	public val imageIndex: Int? = null,
 	/**
-	 * Gets or sets the image tag.
+	 * The image tag.
 	 */
 	@SerialName("ImageTag")
 	public val imageTag: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the blurhash.
+	 * The blurhash.
 	 */
 	@SerialName("BlurHash")
 	public val blurHash: String? = null,
 	/**
-	 * Gets or sets the height.
+	 * The height.
 	 */
 	@SerialName("Height")
 	public val height: Int? = null,
 	/**
-	 * Gets or sets the width.
+	 * The width.
 	 */
 	@SerialName("Width")
 	public val width: Int? = null,
 	/**
-	 * Gets or sets the size.
+	 * The size.
 	 */
 	@SerialName("Size")
 	public val size: Long,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageOption.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageOption.kt
@@ -12,17 +12,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ImageOption(
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: ImageType,
 	/**
-	 * Gets or sets the limit.
+	 * The limit.
 	 */
 	@SerialName("Limit")
 	public val limit: Int,
 	/**
-	 * Gets or sets the minimum width.
+	 * The minimum width.
 	 */
 	@SerialName("MinWidth")
 	public val minWidth: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageProviderInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageProviderInfo.kt
@@ -16,12 +16,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ImageProviderInfo(
 	/**
-	 * Gets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets the supported image types.
+	 * The supported image types.
 	 */
 	@SerialName("SupportedImages")
 	public val supportedImages: List<ImageType>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/InstallationInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/InstallationInfo.kt
@@ -20,37 +20,37 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class InstallationInfo(
 	/**
-	 * Gets or sets the Id.
+	 * The Id.
 	 */
 	@SerialName("Guid")
 	public val guid: UUID,
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the version.
+	 * The version.
 	 */
 	@SerialName("Version")
 	public val version: String? = null,
 	/**
-	 * Gets or sets the changelog for this version.
+	 * The changelog for this version.
 	 */
 	@SerialName("Changelog")
 	public val changelog: String? = null,
 	/**
-	 * Gets or sets the source URL.
+	 * The source URL.
 	 */
 	@SerialName("SourceUrl")
 	public val sourceUrl: String? = null,
 	/**
-	 * Gets or sets a checksum for the binary.
+	 * A checksum for the binary.
 	 */
 	@SerialName("Checksum")
 	public val checksum: String? = null,
 	/**
-	 * Gets or sets package information for the installation.
+	 * Package information for the installation.
 	 */
 	@SerialName("PackageInfo")
 	public val packageInfo: PackageInfo? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemCounts.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemCounts.kt
@@ -15,62 +15,62 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ItemCounts(
 	/**
-	 * Gets or sets the movie count.
+	 * The movie count.
 	 */
 	@SerialName("MovieCount")
 	public val movieCount: Int,
 	/**
-	 * Gets or sets the series count.
+	 * The series count.
 	 */
 	@SerialName("SeriesCount")
 	public val seriesCount: Int,
 	/**
-	 * Gets or sets the episode count.
+	 * The episode count.
 	 */
 	@SerialName("EpisodeCount")
 	public val episodeCount: Int,
 	/**
-	 * Gets or sets the artist count.
+	 * The artist count.
 	 */
 	@SerialName("ArtistCount")
 	public val artistCount: Int,
 	/**
-	 * Gets or sets the program count.
+	 * The program count.
 	 */
 	@SerialName("ProgramCount")
 	public val programCount: Int,
 	/**
-	 * Gets or sets the trailer count.
+	 * The trailer count.
 	 */
 	@SerialName("TrailerCount")
 	public val trailerCount: Int,
 	/**
-	 * Gets or sets the song count.
+	 * The song count.
 	 */
 	@SerialName("SongCount")
 	public val songCount: Int,
 	/**
-	 * Gets or sets the album count.
+	 * The album count.
 	 */
 	@SerialName("AlbumCount")
 	public val albumCount: Int,
 	/**
-	 * Gets or sets the music video count.
+	 * The music video count.
 	 */
 	@SerialName("MusicVideoCount")
 	public val musicVideoCount: Int,
 	/**
-	 * Gets or sets the box set count.
+	 * The box set count.
 	 */
 	@SerialName("BoxSetCount")
 	public val boxSetCount: Int,
 	/**
-	 * Gets or sets the book count.
+	 * The book count.
 	 */
 	@SerialName("BookCount")
 	public val bookCount: Int,
 	/**
-	 * Gets or sets the item count.
+	 * The item count.
 	 */
 	@SerialName("ItemCount")
 	public val itemCount: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/JoinGroupRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/JoinGroupRequestDto.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class JoinGroupRequestDto(
 	/**
-	 * Gets or sets the group identifier.
+	 * The group identifier.
 	 */
 	@SerialName("GroupId")
 	public val groupId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryOptionInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryOptionInfoDto.kt
@@ -16,12 +16,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LibraryOptionInfoDto(
 	/**
-	 * Gets or sets name.
+	 * Name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets a value indicating whether default enabled.
+	 * A value indicating whether default enabled.
 	 */
 	@SerialName("DefaultEnabled")
 	public val defaultEnabled: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryOptions.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryOptions.kt
@@ -39,12 +39,12 @@ public data class LibraryOptions(
 	@SerialName("AutomaticRefreshIntervalDays")
 	public val automaticRefreshIntervalDays: Int,
 	/**
-	 * Gets or sets the preferred metadata language.
+	 * The preferred metadata language.
 	 */
 	@SerialName("PreferredMetadataLanguage")
 	public val preferredMetadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryOptionsResultDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryOptionsResultDto.kt
@@ -15,22 +15,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LibraryOptionsResultDto(
 	/**
-	 * Gets or sets the metadata savers.
+	 * The metadata savers.
 	 */
 	@SerialName("MetadataSavers")
 	public val metadataSavers: List<LibraryOptionInfoDto>,
 	/**
-	 * Gets or sets the metadata readers.
+	 * The metadata readers.
 	 */
 	@SerialName("MetadataReaders")
 	public val metadataReaders: List<LibraryOptionInfoDto>,
 	/**
-	 * Gets or sets the subtitle fetchers.
+	 * The subtitle fetchers.
 	 */
 	@SerialName("SubtitleFetchers")
 	public val subtitleFetchers: List<LibraryOptionInfoDto>,
 	/**
-	 * Gets or sets the type options.
+	 * The type options.
 	 */
 	@SerialName("TypeOptions")
 	public val typeOptions: List<LibraryTypeOptionsDto>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryTypeOptionsDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryTypeOptionsDto.kt
@@ -16,27 +16,27 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LibraryTypeOptionsDto(
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: String? = null,
 	/**
-	 * Gets or sets the metadata fetchers.
+	 * The metadata fetchers.
 	 */
 	@SerialName("MetadataFetchers")
 	public val metadataFetchers: List<LibraryOptionInfoDto>,
 	/**
-	 * Gets or sets the image fetchers.
+	 * The image fetchers.
 	 */
 	@SerialName("ImageFetchers")
 	public val imageFetchers: List<LibraryOptionInfoDto>,
 	/**
-	 * Gets or sets the supported image types.
+	 * The supported image types.
 	 */
 	@SerialName("SupportedImageTypes")
 	public val supportedImageTypes: List<ImageType>,
 	/**
-	 * Gets or sets the default image options.
+	 * The default image options.
 	 */
 	@SerialName("DefaultImageOptions")
 	public val defaultImageOptions: List<ImageOption>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryUpdateInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LibraryUpdateInfo.kt
@@ -17,27 +17,27 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LibraryUpdateInfo(
 	/**
-	 * Gets or sets the folders added to.
+	 * The folders added to.
 	 */
 	@SerialName("FoldersAddedTo")
 	public val foldersAddedTo: List<String>,
 	/**
-	 * Gets or sets the folders removed from.
+	 * The folders removed from.
 	 */
 	@SerialName("FoldersRemovedFrom")
 	public val foldersRemovedFrom: List<String>,
 	/**
-	 * Gets or sets the items added.
+	 * The items added.
 	 */
 	@SerialName("ItemsAdded")
 	public val itemsAdded: List<String>,
 	/**
-	 * Gets or sets the items removed.
+	 * The items removed.
 	 */
 	@SerialName("ItemsRemoved")
 	public val itemsRemoved: List<String>,
 	/**
-	 * Gets or sets the items updated.
+	 * The items updated.
 	 */
 	@SerialName("ItemsUpdated")
 	public val itemsUpdated: List<String>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvInfo.kt
@@ -14,17 +14,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LiveTvInfo(
 	/**
-	 * Gets or sets the services.
+	 * The services.
 	 */
 	@SerialName("Services")
 	public val services: List<LiveTvServiceInfo>,
 	/**
-	 * Gets or sets a value indicating whether this instance is enabled.
+	 * A value indicating whether this instance is enabled.
 	 */
 	@SerialName("IsEnabled")
 	public val isEnabled: Boolean,
 	/**
-	 * Gets or sets the enabled users.
+	 * The enabled users.
 	 */
 	@SerialName("EnabledUsers")
 	public val enabledUsers: List<String>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvServiceInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvServiceInfo.kt
@@ -17,37 +17,37 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LiveTvServiceInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the home page URL.
+	 * The home page URL.
 	 */
 	@SerialName("HomePageUrl")
 	public val homePageUrl: String? = null,
 	/**
-	 * Gets or sets the status.
+	 * The status.
 	 */
 	@SerialName("Status")
 	public val status: LiveTvServiceStatus,
 	/**
-	 * Gets or sets the status message.
+	 * The status message.
 	 */
 	@SerialName("StatusMessage")
 	public val statusMessage: String? = null,
 	/**
-	 * Gets or sets the version.
+	 * The version.
 	 */
 	@SerialName("Version")
 	public val version: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance has update available.
+	 * A value indicating whether this instance has update available.
 	 */
 	@SerialName("HasUpdateAvailable")
 	public val hasUpdateAvailable: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is visible.
+	 * A value indicating whether this instance is visible.
 	 */
 	@SerialName("IsVisible")
 	public val isVisible: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LogFile.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LogFile.kt
@@ -18,22 +18,22 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class LogFile(
 	/**
-	 * Gets or sets the date created.
+	 * The date created.
 	 */
 	@SerialName("DateCreated")
 	public val dateCreated: DateTime,
 	/**
-	 * Gets or sets the date modified.
+	 * The date modified.
 	 */
 	@SerialName("DateModified")
 	public val dateModified: DateTime,
 	/**
-	 * Gets or sets the size.
+	 * The size.
 	 */
 	@SerialName("Size")
 	public val size: Long,
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaAttachment.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaAttachment.kt
@@ -16,37 +16,37 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class MediaAttachment(
 	/**
-	 * Gets or sets the codec.
+	 * The codec.
 	 */
 	@SerialName("Codec")
 	public val codec: String? = null,
 	/**
-	 * Gets or sets the codec tag.
+	 * The codec tag.
 	 */
 	@SerialName("CodecTag")
 	public val codecTag: String? = null,
 	/**
-	 * Gets or sets the comment.
+	 * The comment.
 	 */
 	@SerialName("Comment")
 	public val comment: String? = null,
 	/**
-	 * Gets or sets the index.
+	 * The index.
 	 */
 	@SerialName("Index")
 	public val index: Int,
 	/**
-	 * Gets or sets the filename.
+	 * The filename.
 	 */
 	@SerialName("FileName")
 	public val fileName: String? = null,
 	/**
-	 * Gets or sets the MIME type.
+	 * The MIME type.
 	 */
 	@SerialName("MimeType")
 	public val mimeType: String? = null,
 	/**
-	 * Gets or sets the delivery URL.
+	 * The delivery URL.
 	 */
 	@SerialName("DeliveryUrl")
 	public val deliveryUrl: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaEncoderPathDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaEncoderPathDto.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class MediaEncoderPathDto(
 	/**
-	 * Gets or sets media encoder path.
+	 * Media encoder path.
 	 */
 	@SerialName("Path")
 	public val path: String,
 	/**
-	 * Gets or sets media encoder path type.
+	 * Media encoder path type.
 	 */
 	@SerialName("PathType")
 	public val pathType: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaPathDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaPathDto.kt
@@ -15,17 +15,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class MediaPathDto(
 	/**
-	 * Gets or sets the name of the library.
+	 * The name of the library.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets the path to add.
+	 * The path to add.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the path info.
+	 * The path info.
 	 */
 	@SerialName("PathInfo")
 	public val pathInfo: MediaPathInfo? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaStream.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaStream.kt
@@ -19,112 +19,112 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class MediaStream(
 	/**
-	 * Gets or sets the codec.
+	 * The codec.
 	 */
 	@SerialName("Codec")
 	public val codec: String? = null,
 	/**
-	 * Gets or sets the codec tag.
+	 * The codec tag.
 	 */
 	@SerialName("CodecTag")
 	public val codecTag: String? = null,
 	/**
-	 * Gets or sets the language.
+	 * The language.
 	 */
 	@SerialName("Language")
 	public val language: String? = null,
 	/**
-	 * Gets or sets the color range.
+	 * The color range.
 	 */
 	@SerialName("ColorRange")
 	public val colorRange: String? = null,
 	/**
-	 * Gets or sets the color space.
+	 * The color space.
 	 */
 	@SerialName("ColorSpace")
 	public val colorSpace: String? = null,
 	/**
-	 * Gets or sets the color transfer.
+	 * The color transfer.
 	 */
 	@SerialName("ColorTransfer")
 	public val colorTransfer: String? = null,
 	/**
-	 * Gets or sets the color primaries.
+	 * The color primaries.
 	 */
 	@SerialName("ColorPrimaries")
 	public val colorPrimaries: String? = null,
 	/**
-	 * Gets or sets the Dolby Vision version major.
+	 * The Dolby Vision version major.
 	 */
 	@SerialName("DvVersionMajor")
 	public val dvVersionMajor: Int? = null,
 	/**
-	 * Gets or sets the Dolby Vision version minor.
+	 * The Dolby Vision version minor.
 	 */
 	@SerialName("DvVersionMinor")
 	public val dvVersionMinor: Int? = null,
 	/**
-	 * Gets or sets the Dolby Vision profile.
+	 * The Dolby Vision profile.
 	 */
 	@SerialName("DvProfile")
 	public val dvProfile: Int? = null,
 	/**
-	 * Gets or sets the Dolby Vision level.
+	 * The Dolby Vision level.
 	 */
 	@SerialName("DvLevel")
 	public val dvLevel: Int? = null,
 	/**
-	 * Gets or sets the Dolby Vision rpu present flag.
+	 * The Dolby Vision rpu present flag.
 	 */
 	@SerialName("RpuPresentFlag")
 	public val rpuPresentFlag: Int? = null,
 	/**
-	 * Gets or sets the Dolby Vision el present flag.
+	 * The Dolby Vision el present flag.
 	 */
 	@SerialName("ElPresentFlag")
 	public val elPresentFlag: Int? = null,
 	/**
-	 * Gets or sets the Dolby Vision bl present flag.
+	 * The Dolby Vision bl present flag.
 	 */
 	@SerialName("BlPresentFlag")
 	public val blPresentFlag: Int? = null,
 	/**
-	 * Gets or sets the Dolby Vision bl signal compatibility id.
+	 * The Dolby Vision bl signal compatibility id.
 	 */
 	@SerialName("DvBlSignalCompatibilityId")
 	public val dvBlSignalCompatibilityId: Int? = null,
 	/**
-	 * Gets or sets the comment.
+	 * The comment.
 	 */
 	@SerialName("Comment")
 	public val comment: String? = null,
 	/**
-	 * Gets or sets the time base.
+	 * The time base.
 	 */
 	@SerialName("TimeBase")
 	public val timeBase: String? = null,
 	/**
-	 * Gets or sets the codec time base.
+	 * The codec time base.
 	 */
 	@SerialName("CodecTimeBase")
 	public val codecTimeBase: String? = null,
 	/**
-	 * Gets or sets the title.
+	 * The title.
 	 */
 	@SerialName("Title")
 	public val title: String? = null,
 	/**
-	 * Gets the video range.
+	 * The video range.
 	 */
 	@SerialName("VideoRange")
 	public val videoRange: String? = null,
 	/**
-	 * Gets the video range type.
+	 * The video range type.
 	 */
 	@SerialName("VideoRangeType")
 	public val videoRangeType: String? = null,
 	/**
-	 * Gets the video dovi title.
+	 * The video dovi title.
 	 */
 	@SerialName("VideoDoViTitle")
 	public val videoDoViTitle: String? = null,
@@ -141,146 +141,146 @@ public data class MediaStream(
 	@SerialName("NalLengthSize")
 	public val nalLengthSize: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is interlaced.
+	 * A value indicating whether this instance is interlaced.
 	 */
 	@SerialName("IsInterlaced")
 	public val isInterlaced: Boolean,
 	@SerialName("IsAVC")
 	public val isAvc: Boolean? = null,
 	/**
-	 * Gets or sets the channel layout.
+	 * The channel layout.
 	 */
 	@SerialName("ChannelLayout")
 	public val channelLayout: String? = null,
 	/**
-	 * Gets or sets the bit rate.
+	 * The bit rate.
 	 */
 	@SerialName("BitRate")
 	public val bitRate: Int? = null,
 	/**
-	 * Gets or sets the bit depth.
+	 * The bit depth.
 	 */
 	@SerialName("BitDepth")
 	public val bitDepth: Int? = null,
 	/**
-	 * Gets or sets the reference frames.
+	 * The reference frames.
 	 */
 	@SerialName("RefFrames")
 	public val refFrames: Int? = null,
 	/**
-	 * Gets or sets the length of the packet.
+	 * The length of the packet.
 	 */
 	@SerialName("PacketLength")
 	public val packetLength: Int? = null,
 	/**
-	 * Gets or sets the channels.
+	 * The channels.
 	 */
 	@SerialName("Channels")
 	public val channels: Int? = null,
 	/**
-	 * Gets or sets the sample rate.
+	 * The sample rate.
 	 */
 	@SerialName("SampleRate")
 	public val sampleRate: Int? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is default.
+	 * A value indicating whether this instance is default.
 	 */
 	@SerialName("IsDefault")
 	public val isDefault: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is forced.
+	 * A value indicating whether this instance is forced.
 	 */
 	@SerialName("IsForced")
 	public val isForced: Boolean,
 	/**
-	 * Gets or sets the height.
+	 * The height.
 	 */
 	@SerialName("Height")
 	public val height: Int? = null,
 	/**
-	 * Gets or sets the width.
+	 * The width.
 	 */
 	@SerialName("Width")
 	public val width: Int? = null,
 	/**
-	 * Gets or sets the average frame rate.
+	 * The average frame rate.
 	 */
 	@SerialName("AverageFrameRate")
 	public val averageFrameRate: Float? = null,
 	/**
-	 * Gets or sets the real frame rate.
+	 * The real frame rate.
 	 */
 	@SerialName("RealFrameRate")
 	public val realFrameRate: Float? = null,
 	/**
-	 * Gets or sets the profile.
+	 * The profile.
 	 */
 	@SerialName("Profile")
 	public val profile: String? = null,
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: MediaStreamType,
 	/**
-	 * Gets or sets the aspect ratio.
+	 * The aspect ratio.
 	 */
 	@SerialName("AspectRatio")
 	public val aspectRatio: String? = null,
 	/**
-	 * Gets or sets the index.
+	 * The index.
 	 */
 	@SerialName("Index")
 	public val index: Int,
 	/**
-	 * Gets or sets the score.
+	 * The score.
 	 */
 	@SerialName("Score")
 	public val score: Int? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is external.
+	 * A value indicating whether this instance is external.
 	 */
 	@SerialName("IsExternal")
 	public val isExternal: Boolean,
 	/**
-	 * Gets or sets the method.
+	 * The method.
 	 */
 	@SerialName("DeliveryMethod")
 	public val deliveryMethod: SubtitleDeliveryMethod? = null,
 	/**
-	 * Gets or sets the delivery URL.
+	 * The delivery URL.
 	 */
 	@SerialName("DeliveryUrl")
 	public val deliveryUrl: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is external URL.
+	 * A value indicating whether this instance is external URL.
 	 */
 	@SerialName("IsExternalUrl")
 	public val isExternalUrl: Boolean? = null,
 	@SerialName("IsTextSubtitleStream")
 	public val isTextSubtitleStream: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [supports external stream].
+	 * A value indicating whether [supports external stream].
 	 */
 	@SerialName("SupportsExternalStream")
 	public val supportsExternalStream: Boolean,
 	/**
-	 * Gets or sets the filename.
+	 * The filename.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the pixel format.
+	 * The pixel format.
 	 */
 	@SerialName("PixelFormat")
 	public val pixelFormat: String? = null,
 	/**
-	 * Gets or sets the level.
+	 * The level.
 	 */
 	@SerialName("Level")
 	public val level: Double? = null,
 	/**
-	 * Gets or sets whether this instance is anamorphic.
+	 * Whether this instance is anamorphic.
 	 */
 	@SerialName("IsAnamorphic")
 	public val isAnamorphic: Boolean? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaUpdateInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaUpdateInfoDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class MediaUpdateInfoDto(
 	/**
-	 * Gets or sets the list of updates.
+	 * The list of updates.
 	 */
 	@SerialName("Updates")
 	public val updates: List<MediaUpdateInfoPathDto>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaUpdateInfoPathDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaUpdateInfoPathDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class MediaUpdateInfoPathDto(
 	/**
-	 * Gets or sets media path.
+	 * Media path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MovePlaylistItemRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MovePlaylistItemRequestDto.kt
@@ -20,12 +20,12 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class MovePlaylistItemRequestDto(
 	/**
-	 * Gets or sets the playlist identifier of the item.
+	 * The playlist identifier of the item.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: UUID,
 	/**
-	 * Gets or sets the new position.
+	 * The new position.
 	 */
 	@SerialName("NewIndex")
 	public val newIndex: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MovieInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MovieInfo.kt
@@ -20,37 +20,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class MovieInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MovieInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class MovieInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MusicVideoInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MusicVideoInfo.kt
@@ -21,37 +21,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class MusicVideoInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MusicVideoInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class MusicVideoInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NameIdPair.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NameIdPair.kt
@@ -12,12 +12,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class NameIdPair(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the identifier.
+	 * The identifier.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NameValuePair.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NameValuePair.kt
@@ -12,12 +12,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class NameValuePair(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the value.
+	 * The value.
 	 */
 	@SerialName("Value")
 	public val `value`: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NetworkConfiguration.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NetworkConfiguration.kt
@@ -18,70 +18,69 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class NetworkConfiguration(
 	/**
-	 * Gets or sets a value indicating whether the server should force connections over HTTPS.
+	 * A value indicating whether the server should force connections over HTTPS.
 	 */
 	@SerialName("RequireHttps")
 	public val requireHttps: Boolean,
 	/**
-	 * Gets or sets the filesystem path of an X.509 certificate to use for SSL.
+	 * The filesystem path of an X.509 certificate to use for SSL.
 	 */
 	@SerialName("CertificatePath")
 	public val certificatePath: String,
 	/**
-	 * Gets or sets the password required to access the X.509 certificate data in the file specified by
+	 * The password required to access the X.509 certificate data in the file specified by
 	 * Jellyfin.Networking.Configuration.NetworkConfiguration.CertificatePath.
 	 */
 	@SerialName("CertificatePassword")
 	public val certificatePassword: String,
 	/**
-	 * Gets or sets a value used to specify the URL prefix that your Jellyfin instance can be accessed
-	 * at.
+	 * A value used to specify the URL prefix that your Jellyfin instance can be accessed at.
 	 */
 	@SerialName("BaseUrl")
 	public val baseUrl: String,
 	/**
-	 * Gets or sets the public HTTPS port.
+	 * The public HTTPS port.
 	 */
 	@SerialName("PublicHttpsPort")
 	public val publicHttpsPort: Int,
 	/**
-	 * Gets or sets the HTTP server port number.
+	 * The HTTP server port number.
 	 */
 	@SerialName("HttpServerPortNumber")
 	public val httpServerPortNumber: Int,
 	/**
-	 * Gets or sets the HTTPS server port number.
+	 * The HTTPS server port number.
 	 */
 	@SerialName("HttpsPortNumber")
 	public val httpsPortNumber: Int,
 	/**
-	 * Gets or sets a value indicating whether to use HTTPS.
+	 * A value indicating whether to use HTTPS.
 	 */
 	@SerialName("EnableHttps")
 	public val enableHttps: Boolean,
 	/**
-	 * Gets or sets the public mapped port.
+	 * The public mapped port.
 	 */
 	@SerialName("PublicPort")
 	public val publicPort: Int,
 	/**
-	 * Gets or sets a value indicating whether the http port should be mapped as part of UPnP automatic
-	 * port forwarding.
+	 * A value indicating whether the http port should be mapped as part of UPnP automatic port
+	 * forwarding.
 	 */
 	@SerialName("UPnPCreateHttpPortMap")
 	public val uPnPCreateHttpPortMap: Boolean,
 	/**
-	 * Gets or sets the UDPPortRange.
+	 * The UDPPortRange.
 	 */
 	@SerialName("UDPPortRange")
 	public val udpPortRange: String,
 	/**
-	 * Gets or sets a value indicating whether gets or sets IPV6 capability.
+	 * A value indicating whether gets or sets IPV6 capability.
 	 */
 	@SerialName("EnableIPV6")
 	public val enableIpv6: Boolean,
 	/**
-	 * Gets or sets a value indicating whether gets or sets IPV4 capability.
+	 * A value indicating whether gets or sets IPV4 capability.
 	 */
 	@SerialName("EnableIPV4")
 	public val enableIpv4: Boolean,
@@ -101,35 +100,35 @@ public data class NetworkConfiguration(
 	@SerialName("SSDPTracingFilter")
 	public val ssdpTracingFilter: String,
 	/**
-	 * Gets or sets the number of times SSDP UDP messages are sent.
+	 * The number of times SSDP UDP messages are sent.
 	 */
 	@SerialName("UDPSendCount")
 	public val udpSendCount: Int,
 	/**
-	 * Gets or sets the delay between each groups of SSDP messages (in ms).
+	 * The delay between each groups of SSDP messages (in ms).
 	 */
 	@SerialName("UDPSendDelay")
 	public val udpSendDelay: Int,
 	/**
-	 * Gets or sets a value indicating whether address names that match
+	 * A value indicating whether address names that match
 	 * Jellyfin.Networking.Configuration.NetworkConfiguration.VirtualInterfaceNames should be Ignore for
 	 * the purposes of binding.
 	 */
 	@SerialName("IgnoreVirtualInterfaces")
 	public val ignoreVirtualInterfaces: Boolean,
 	/**
-	 * Gets or sets a value indicating the interfaces that should be ignored. The list can be comma
-	 * separated. `P:Jellyfin.Networking.Configuration.NetworkConfiguration.IgnoreVirtualInterfaces`.
+	 * A value indicating the interfaces that should be ignored. The list can be comma separated.
+	 * `P:Jellyfin.Networking.Configuration.NetworkConfiguration.IgnoreVirtualInterfaces`.
 	 */
 	@SerialName("VirtualInterfaceNames")
 	public val virtualInterfaceNames: String,
 	/**
-	 * Gets or sets the time (in seconds) between the pings of SSDP gateway monitor.
+	 * The time (in seconds) between the pings of SSDP gateway monitor.
 	 */
 	@SerialName("GatewayMonitorPeriod")
 	public val gatewayMonitorPeriod: Int,
 	/**
-	 * Gets a value indicating whether multi-socket binding is available.
+	 * A value indicating whether multi-socket binding is available.
 	 */
 	@SerialName("EnableMultiSocketBinding")
 	public val enableMultiSocketBinding: Boolean,
@@ -141,7 +140,7 @@ public data class NetworkConfiguration(
 	@SerialName("TrustAllIP6Interfaces")
 	public val trustAllIp6Interfaces: Boolean,
 	/**
-	 * Gets or sets the ports that HDHomerun uses.
+	 * The ports that HDHomerun uses.
 	 */
 	@SerialName("HDHomerunPortRange")
 	public val hdHomerunPortRange: String,
@@ -152,57 +151,55 @@ public data class NetworkConfiguration(
 	@SerialName("PublishedServerUriBySubnet")
 	public val publishedServerUriBySubnet: List<String>,
 	/**
-	 * Gets or sets a value indicating whether Autodiscovery tracing is enabled.
+	 * A value indicating whether Autodiscovery tracing is enabled.
 	 */
 	@SerialName("AutoDiscoveryTracing")
 	public val autoDiscoveryTracing: Boolean,
 	/**
-	 * Gets or sets a value indicating whether Autodiscovery is enabled.
+	 * A value indicating whether Autodiscovery is enabled.
 	 */
 	@SerialName("AutoDiscovery")
 	public val autoDiscovery: Boolean,
 	/**
-	 * Gets or sets the filter for remote IP connectivity. Used in conjuntion with
+	 * The filter for remote IP connectivity. Used in conjuntion with
 	 * `P:Jellyfin.Networking.Configuration.NetworkConfiguration.IsRemoteIPFilterBlacklist`.
 	 */
 	@SerialName("RemoteIPFilter")
 	public val remoteIpFilter: List<String>,
 	/**
-	 * Gets or sets a value indicating whether
+	 * A value indicating whether
 	 * `P:Jellyfin.Networking.Configuration.NetworkConfiguration.RemoteIPFilter` contains a blacklist or a
 	 * whitelist. Default is a whitelist.
 	 */
 	@SerialName("IsRemoteIPFilterBlacklist")
 	public val isRemoteIpFilterBlacklist: Boolean,
 	/**
-	 * Gets or sets a value indicating whether to enable automatic port forwarding.
+	 * A value indicating whether to enable automatic port forwarding.
 	 */
 	@SerialName("EnableUPnP")
 	public val enableUPnP: Boolean,
 	/**
-	 * Gets or sets a value indicating whether access outside of the LAN is permitted.
+	 * A value indicating whether access outside of the LAN is permitted.
 	 */
 	@SerialName("EnableRemoteAccess")
 	public val enableRemoteAccess: Boolean,
 	/**
-	 * Gets or sets the subnets that are deemed to make up the LAN.
+	 * The subnets that are deemed to make up the LAN.
 	 */
 	@SerialName("LocalNetworkSubnets")
 	public val localNetworkSubnets: List<String>,
 	/**
-	 * Gets or sets the interface addresses which Jellyfin will bind to. If empty, all interfaces will
-	 * be used.
+	 * The interface addresses which Jellyfin will bind to. If empty, all interfaces will be used.
 	 */
 	@SerialName("LocalNetworkAddresses")
 	public val localNetworkAddresses: List<String>,
 	/**
-	 * Gets or sets the known proxies. If the proxy is a network, it's added to the KnownNetworks.
+	 * The known proxies. If the proxy is a network, it's added to the KnownNetworks.
 	 */
 	@SerialName("KnownProxies")
 	public val knownProxies: List<String>,
 	/**
-	 * Gets or sets a value indicating whether the published server uri is based on information in HTTP
-	 * requests.
+	 * A value indicating whether the published server uri is based on information in HTTP requests.
 	 */
 	@SerialName("EnablePublishedServerUriByRequest")
 	public val enablePublishedServerUriByRequest: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NewGroupRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NewGroupRequestDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class NewGroupRequestDto(
 	/**
-	 * Gets or sets the group name.
+	 * The group name.
 	 */
 	@SerialName("GroupName")
 	public val groupName: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NextItemRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NextItemRequestDto.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class NextItemRequestDto(
 	/**
-	 * Gets or sets the playing item identifier.
+	 * The playing item identifier.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationDto.kt
@@ -21,42 +21,42 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class NotificationDto(
 	/**
-	 * Gets or sets the notification ID. Defaults to an empty string.
+	 * The notification ID. Defaults to an empty string.
 	 */
 	@SerialName("Id")
 	public val id: String,
 	/**
-	 * Gets or sets the notification's user ID. Defaults to an empty string.
+	 * The notification's user ID. Defaults to an empty string.
 	 */
 	@SerialName("UserId")
 	public val userId: String,
 	/**
-	 * Gets or sets the notification date.
+	 * The notification date.
 	 */
 	@SerialName("Date")
 	public val date: DateTime,
 	/**
-	 * Gets or sets a value indicating whether the notification has been read. Defaults to false.
+	 * A value indicating whether the notification has been read. Defaults to false.
 	 */
 	@SerialName("IsRead")
 	public val isRead: Boolean,
 	/**
-	 * Gets or sets the notification's name. Defaults to an empty string.
+	 * The notification's name. Defaults to an empty string.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets the notification's description. Defaults to an empty string.
+	 * The notification's description. Defaults to an empty string.
 	 */
 	@SerialName("Description")
 	public val description: String,
 	/**
-	 * Gets or sets the notification's URL. Defaults to an empty string.
+	 * The notification's URL. Defaults to an empty string.
 	 */
 	@SerialName("Url")
 	public val url: String,
 	/**
-	 * Gets or sets the notification level.
+	 * The notification level.
 	 */
 	@SerialName("Level")
 	public val level: NotificationLevel,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationOption.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationOption.kt
@@ -16,28 +16,27 @@ public data class NotificationOption(
 	@SerialName("Type")
 	public val type: String? = null,
 	/**
-	 * Gets or sets user Ids to not monitor (it's opt out).
+	 * User Ids to not monitor (it's opt out).
 	 */
 	@SerialName("DisabledMonitorUsers")
 	public val disabledMonitorUsers: List<String>,
 	/**
-	 * Gets or sets user Ids to send to (if SendToUserMode == Custom).
+	 * User Ids to send to (if SendToUserMode == Custom).
 	 */
 	@SerialName("SendToUsers")
 	public val sendToUsers: List<String>,
 	/**
-	 * Gets or sets a value indicating whether this MediaBrowser.Model.Notifications.NotificationOption
-	 * is enabled.
+	 * A value indicating whether this MediaBrowser.Model.Notifications.NotificationOption is enabled.
 	 */
 	@SerialName("Enabled")
 	public val enabled: Boolean,
 	/**
-	 * Gets or sets the disabled services.
+	 * The disabled services.
 	 */
 	@SerialName("DisabledServices")
 	public val disabledServices: List<String>,
 	/**
-	 * Gets or sets the send to user mode.
+	 * The send to user mode.
 	 */
 	@SerialName("SendToUserMode")
 	public val sendToUserMode: SendToUserType,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationResultDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationResultDto.kt
@@ -16,12 +16,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class NotificationResultDto(
 	/**
-	 * Gets or sets the current page of notifications.
+	 * The current page of notifications.
 	 */
 	@SerialName("Notifications")
 	public val notifications: List<NotificationDto>,
 	/**
-	 * Gets or sets the total number of notifications.
+	 * The total number of notifications.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationsSummaryDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationsSummaryDto.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class NotificationsSummaryDto(
 	/**
-	 * Gets or sets the number of unread notifications.
+	 * The number of unread notifications.
 	 */
 	@SerialName("UnreadCount")
 	public val unreadCount: Int,
 	/**
-	 * Gets or sets the maximum unread notification level.
+	 * The maximum unread notification level.
 	 */
 	@SerialName("MaxUnreadNotificationLevel")
 	public val maxUnreadNotificationLevel: NotificationLevel? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ObjectGroupUpdate.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ObjectGroupUpdate.kt
@@ -20,17 +20,17 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class ObjectGroupUpdate(
 	/**
-	 * Gets the group identifier.
+	 * The group identifier.
 	 */
 	@SerialName("GroupId")
 	public val groupId: UUID,
 	/**
-	 * Gets the update type.
+	 * The update type.
 	 */
 	@SerialName("Type")
 	public val type: GroupUpdateType,
 	/**
-	 * Gets the update data.
+	 * The update data.
 	 */
 	@SerialName("Data")
 	public val `data`: JsonElement,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/OpenLiveStreamDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/OpenLiveStreamDto.kt
@@ -24,57 +24,57 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class OpenLiveStreamDto(
 	/**
-	 * Gets or sets the open token.
+	 * The open token.
 	 */
 	@SerialName("OpenToken")
 	public val openToken: String? = null,
 	/**
-	 * Gets or sets the user id.
+	 * The user id.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID? = null,
 	/**
-	 * Gets or sets the play session id.
+	 * The play session id.
 	 */
 	@SerialName("PlaySessionId")
 	public val playSessionId: String? = null,
 	/**
-	 * Gets or sets the max streaming bitrate.
+	 * The max streaming bitrate.
 	 */
 	@SerialName("MaxStreamingBitrate")
 	public val maxStreamingBitrate: Int? = null,
 	/**
-	 * Gets or sets the start time in ticks.
+	 * The start time in ticks.
 	 */
 	@SerialName("StartTimeTicks")
 	public val startTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the audio stream index.
+	 * The audio stream index.
 	 */
 	@SerialName("AudioStreamIndex")
 	public val audioStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the subtitle stream index.
+	 * The subtitle stream index.
 	 */
 	@SerialName("SubtitleStreamIndex")
 	public val subtitleStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the max audio channels.
+	 * The max audio channels.
 	 */
 	@SerialName("MaxAudioChannels")
 	public val maxAudioChannels: Int? = null,
 	/**
-	 * Gets or sets the item id.
+	 * The item id.
 	 */
 	@SerialName("ItemId")
 	public val itemId: UUID? = null,
 	/**
-	 * Gets or sets a value indicating whether to enable direct play.
+	 * A value indicating whether to enable direct play.
 	 */
 	@SerialName("EnableDirectPlay")
 	public val enableDirectPlay: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether to enale direct stream.
+	 * A value indicating whether to enale direct stream.
 	 */
 	@SerialName("EnableDirectStream")
 	public val enableDirectStream: Boolean? = null,
@@ -94,7 +94,7 @@ public data class OpenLiveStreamDto(
 	@SerialName("DeviceProfile")
 	public val deviceProfile: DeviceProfile? = null,
 	/**
-	 * Gets or sets the device play protocols.
+	 * The device play protocols.
 	 */
 	@SerialName("DirectPlayProtocols")
 	public val directPlayProtocols: List<MediaProtocol>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PackageInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PackageInfo.kt
@@ -21,27 +21,27 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PackageInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("name")
 	public val name: String,
 	/**
-	 * Gets or sets a long description of the plugin containing features or helpful explanations.
+	 * A long description of the plugin containing features or helpful explanations.
 	 */
 	@SerialName("description")
 	public val description: String,
 	/**
-	 * Gets or sets a short overview of what the plugin does.
+	 * A short overview of what the plugin does.
 	 */
 	@SerialName("overview")
 	public val overview: String,
 	/**
-	 * Gets or sets the owner.
+	 * The owner.
 	 */
 	@SerialName("owner")
 	public val owner: String,
 	/**
-	 * Gets or sets the category.
+	 * The category.
 	 */
 	@SerialName("category")
 	public val category: String,
@@ -52,12 +52,12 @@ public data class PackageInfo(
 	@SerialName("guid")
 	public val guid: UUID,
 	/**
-	 * Gets or sets the versions.
+	 * The versions.
 	 */
 	@SerialName("versions")
 	public val versions: List<VersionInfo>,
 	/**
-	 * Gets or sets the image url for the package.
+	 * The image url for the package.
 	 */
 	@SerialName("imageUrl")
 	public val imageUrl: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ParentalRating.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ParentalRating.kt
@@ -16,12 +16,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ParentalRating(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the value.
+	 * The value.
 	 */
 	@SerialName("Value")
 	public val `value`: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PathSubstitution.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PathSubstitution.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PathSubstitution(
 	/**
-	 * Gets or sets the value to substitute.
+	 * The value to substitute.
 	 */
 	@SerialName("From")
 	public val from: String,
 	/**
-	 * Gets or sets the value to substitution with.
+	 * The value to substitution with.
 	 */
 	@SerialName("To")
 	public val to: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PersonLookupInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PersonLookupInfo.kt
@@ -20,37 +20,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class PersonLookupInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PersonLookupInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class PersonLookupInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PinRedeemResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PinRedeemResult.kt
@@ -14,13 +14,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PinRedeemResult(
 	/**
-	 * Gets or sets a value indicating whether this MediaBrowser.Model.Users.PinRedeemResult is
-	 * success.
+	 * A value indicating whether this MediaBrowser.Model.Users.PinRedeemResult is success.
 	 */
 	@SerialName("Success")
 	public val success: Boolean,
 	/**
-	 * Gets or sets the users reset.
+	 * The users reset.
 	 */
 	@SerialName("UsersReset")
 	public val usersReset: List<String>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PingRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PingRequestDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PingRequestDto(
 	/**
-	 * Gets or sets the ping time.
+	 * The ping time.
 	 */
 	@SerialName("Ping")
 	public val ping: Long,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayRequest.kt
@@ -23,22 +23,22 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PlayRequest(
 	/**
-	 * Gets or sets the item ids.
+	 * The item ids.
 	 */
 	@SerialName("ItemIds")
 	public val itemIds: List<UUID>? = null,
 	/**
-	 * Gets or sets the start position ticks that the first item should be played at.
+	 * The start position ticks that the first item should be played at.
 	 */
 	@SerialName("StartPositionTicks")
 	public val startPositionTicks: Long? = null,
 	/**
-	 * Gets or sets the play command.
+	 * The play command.
 	 */
 	@SerialName("PlayCommand")
 	public val playCommand: PlayCommand,
 	/**
-	 * Gets or sets the controlling user identifier.
+	 * The controlling user identifier.
 	 */
 	@SerialName("ControllingUserId")
 	public val controllingUserId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayRequestDto.kt
@@ -22,17 +22,17 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PlayRequestDto(
 	/**
-	 * Gets or sets the playing queue.
+	 * The playing queue.
 	 */
 	@SerialName("PlayingQueue")
 	public val playingQueue: List<UUID>,
 	/**
-	 * Gets or sets the position of the playing item in the queue.
+	 * The position of the playing item in the queue.
 	 */
 	@SerialName("PlayingItemPosition")
 	public val playingItemPosition: Int,
 	/**
-	 * Gets or sets the start position ticks.
+	 * The start position ticks.
 	 */
 	@SerialName("StartPositionTicks")
 	public val startPositionTicks: Long,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackInfoDto.kt
@@ -23,42 +23,42 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PlaybackInfoDto(
 	/**
-	 * Gets or sets the playback userId.
+	 * The playback userId.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID? = null,
 	/**
-	 * Gets or sets the max streaming bitrate.
+	 * The max streaming bitrate.
 	 */
 	@SerialName("MaxStreamingBitrate")
 	public val maxStreamingBitrate: Int? = null,
 	/**
-	 * Gets or sets the start time in ticks.
+	 * The start time in ticks.
 	 */
 	@SerialName("StartTimeTicks")
 	public val startTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the audio stream index.
+	 * The audio stream index.
 	 */
 	@SerialName("AudioStreamIndex")
 	public val audioStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the subtitle stream index.
+	 * The subtitle stream index.
 	 */
 	@SerialName("SubtitleStreamIndex")
 	public val subtitleStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the max audio channels.
+	 * The max audio channels.
 	 */
 	@SerialName("MaxAudioChannels")
 	public val maxAudioChannels: Int? = null,
 	/**
-	 * Gets or sets the media source id.
+	 * The media source id.
 	 */
 	@SerialName("MediaSourceId")
 	public val mediaSourceId: String? = null,
 	/**
-	 * Gets or sets the live stream id.
+	 * The live stream id.
 	 */
 	@SerialName("LiveStreamId")
 	public val liveStreamId: String? = null,
@@ -78,32 +78,32 @@ public data class PlaybackInfoDto(
 	@SerialName("DeviceProfile")
 	public val deviceProfile: DeviceProfile? = null,
 	/**
-	 * Gets or sets a value indicating whether to enable direct play.
+	 * A value indicating whether to enable direct play.
 	 */
 	@SerialName("EnableDirectPlay")
 	public val enableDirectPlay: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether to enable direct stream.
+	 * A value indicating whether to enable direct stream.
 	 */
 	@SerialName("EnableDirectStream")
 	public val enableDirectStream: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether to enable transcoding.
+	 * A value indicating whether to enable transcoding.
 	 */
 	@SerialName("EnableTranscoding")
 	public val enableTranscoding: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether to enable video stream copy.
+	 * A value indicating whether to enable video stream copy.
 	 */
 	@SerialName("AllowVideoStreamCopy")
 	public val allowVideoStreamCopy: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether to allow audio stream copy.
+	 * A value indicating whether to allow audio stream copy.
 	 */
 	@SerialName("AllowAudioStreamCopy")
 	public val allowAudioStreamCopy: Boolean? = null,
 	/**
-	 * Gets or sets a value indicating whether to auto open the live stream.
+	 * A value indicating whether to auto open the live stream.
 	 */
 	@SerialName("AutoOpenLiveStream")
 	public val autoOpenLiveStream: Boolean? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackInfoResponse.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackInfoResponse.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PlaybackInfoResponse(
 	/**
-	 * Gets or sets the media sources.
+	 * The media sources.
 	 */
 	@SerialName("MediaSources")
 	public val mediaSources: List<MediaSourceInfo>,
 	/**
-	 * Gets or sets the play session identifier.
+	 * The play session identifier.
 	 */
 	@SerialName("PlaySessionId")
 	public val playSessionId: String? = null,
 	/**
-	 * Gets or sets the error code.
+	 * The error code.
 	 */
 	@SerialName("ErrorCode")
 	public val errorCode: PlaybackErrorCode? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackProgressInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackProgressInfo.kt
@@ -24,59 +24,59 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PlaybackProgressInfo(
 	/**
-	 * Gets or sets a value indicating whether this instance can seek.
+	 * A value indicating whether this instance can seek.
 	 */
 	@SerialName("CanSeek")
 	public val canSeek: Boolean,
 	/**
-	 * Gets or sets the item.
+	 * The item.
 	 */
 	@SerialName("Item")
 	public val item: BaseItemDto? = null,
 	/**
-	 * Gets or sets the item identifier.
+	 * The item identifier.
 	 */
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the session id.
+	 * The session id.
 	 */
 	@SerialName("SessionId")
 	public val sessionId: String? = null,
 	/**
-	 * Gets or sets the media version identifier.
+	 * The media version identifier.
 	 */
 	@SerialName("MediaSourceId")
 	public val mediaSourceId: String? = null,
 	/**
-	 * Gets or sets the index of the audio stream.
+	 * The index of the audio stream.
 	 */
 	@SerialName("AudioStreamIndex")
 	public val audioStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the index of the subtitle stream.
+	 * The index of the subtitle stream.
 	 */
 	@SerialName("SubtitleStreamIndex")
 	public val subtitleStreamIndex: Int? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is paused.
+	 * A value indicating whether this instance is paused.
 	 */
 	@SerialName("IsPaused")
 	public val isPaused: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is muted.
+	 * A value indicating whether this instance is muted.
 	 */
 	@SerialName("IsMuted")
 	public val isMuted: Boolean,
 	/**
-	 * Gets or sets the position ticks.
+	 * The position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long? = null,
 	@SerialName("PlaybackStartTimeTicks")
 	public val playbackStartTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the volume level.
+	 * The volume level.
 	 */
 	@SerialName("VolumeLevel")
 	public val volumeLevel: Int? = null,
@@ -85,22 +85,22 @@ public data class PlaybackProgressInfo(
 	@SerialName("AspectRatio")
 	public val aspectRatio: String? = null,
 	/**
-	 * Gets or sets the play method.
+	 * The play method.
 	 */
 	@SerialName("PlayMethod")
 	public val playMethod: PlayMethod,
 	/**
-	 * Gets or sets the live stream identifier.
+	 * The live stream identifier.
 	 */
 	@SerialName("LiveStreamId")
 	public val liveStreamId: String? = null,
 	/**
-	 * Gets or sets the play session identifier.
+	 * The play session identifier.
 	 */
 	@SerialName("PlaySessionId")
 	public val playSessionId: String? = null,
 	/**
-	 * Gets or sets the repeat mode.
+	 * The repeat mode.
 	 */
 	@SerialName("RepeatMode")
 	public val repeatMode: RepeatMode,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackStartInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackStartInfo.kt
@@ -24,59 +24,59 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PlaybackStartInfo(
 	/**
-	 * Gets or sets a value indicating whether this instance can seek.
+	 * A value indicating whether this instance can seek.
 	 */
 	@SerialName("CanSeek")
 	public val canSeek: Boolean,
 	/**
-	 * Gets or sets the item.
+	 * The item.
 	 */
 	@SerialName("Item")
 	public val item: BaseItemDto? = null,
 	/**
-	 * Gets or sets the item identifier.
+	 * The item identifier.
 	 */
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the session id.
+	 * The session id.
 	 */
 	@SerialName("SessionId")
 	public val sessionId: String? = null,
 	/**
-	 * Gets or sets the media version identifier.
+	 * The media version identifier.
 	 */
 	@SerialName("MediaSourceId")
 	public val mediaSourceId: String? = null,
 	/**
-	 * Gets or sets the index of the audio stream.
+	 * The index of the audio stream.
 	 */
 	@SerialName("AudioStreamIndex")
 	public val audioStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the index of the subtitle stream.
+	 * The index of the subtitle stream.
 	 */
 	@SerialName("SubtitleStreamIndex")
 	public val subtitleStreamIndex: Int? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is paused.
+	 * A value indicating whether this instance is paused.
 	 */
 	@SerialName("IsPaused")
 	public val isPaused: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is muted.
+	 * A value indicating whether this instance is muted.
 	 */
 	@SerialName("IsMuted")
 	public val isMuted: Boolean,
 	/**
-	 * Gets or sets the position ticks.
+	 * The position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long? = null,
 	@SerialName("PlaybackStartTimeTicks")
 	public val playbackStartTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the volume level.
+	 * The volume level.
 	 */
 	@SerialName("VolumeLevel")
 	public val volumeLevel: Int? = null,
@@ -85,22 +85,22 @@ public data class PlaybackStartInfo(
 	@SerialName("AspectRatio")
 	public val aspectRatio: String? = null,
 	/**
-	 * Gets or sets the play method.
+	 * The play method.
 	 */
 	@SerialName("PlayMethod")
 	public val playMethod: PlayMethod,
 	/**
-	 * Gets or sets the live stream identifier.
+	 * The live stream identifier.
 	 */
 	@SerialName("LiveStreamId")
 	public val liveStreamId: String? = null,
 	/**
-	 * Gets or sets the play session identifier.
+	 * The play session identifier.
 	 */
 	@SerialName("PlaySessionId")
 	public val playSessionId: String? = null,
 	/**
-	 * Gets or sets the repeat mode.
+	 * The repeat mode.
 	 */
 	@SerialName("RepeatMode")
 	public val repeatMode: RepeatMode,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackStopInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackStopInfo.kt
@@ -23,43 +23,42 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PlaybackStopInfo(
 	/**
-	 * Gets or sets the item.
+	 * The item.
 	 */
 	@SerialName("Item")
 	public val item: BaseItemDto? = null,
 	/**
-	 * Gets or sets the item identifier.
+	 * The item identifier.
 	 */
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the session id.
+	 * The session id.
 	 */
 	@SerialName("SessionId")
 	public val sessionId: String? = null,
 	/**
-	 * Gets or sets the media version identifier.
+	 * The media version identifier.
 	 */
 	@SerialName("MediaSourceId")
 	public val mediaSourceId: String? = null,
 	/**
-	 * Gets or sets the position ticks.
+	 * The position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long? = null,
 	/**
-	 * Gets or sets the live stream identifier.
+	 * The live stream identifier.
 	 */
 	@SerialName("LiveStreamId")
 	public val liveStreamId: String? = null,
 	/**
-	 * Gets or sets the play session identifier.
+	 * The play session identifier.
 	 */
 	@SerialName("PlaySessionId")
 	public val playSessionId: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this MediaBrowser.Model.Session.PlaybackStopInfo is
-	 * failed.
+	 * A value indicating whether this MediaBrowser.Model.Session.PlaybackStopInfo is failed.
 	 */
 	@SerialName("Failed")
 	public val failed: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayerStateInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayerStateInfo.kt
@@ -15,57 +15,57 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PlayerStateInfo(
 	/**
-	 * Gets or sets the now playing position ticks.
+	 * The now playing position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance can seek.
+	 * A value indicating whether this instance can seek.
 	 */
 	@SerialName("CanSeek")
 	public val canSeek: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is paused.
+	 * A value indicating whether this instance is paused.
 	 */
 	@SerialName("IsPaused")
 	public val isPaused: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is muted.
+	 * A value indicating whether this instance is muted.
 	 */
 	@SerialName("IsMuted")
 	public val isMuted: Boolean,
 	/**
-	 * Gets or sets the volume level.
+	 * The volume level.
 	 */
 	@SerialName("VolumeLevel")
 	public val volumeLevel: Int? = null,
 	/**
-	 * Gets or sets the index of the now playing audio stream.
+	 * The index of the now playing audio stream.
 	 */
 	@SerialName("AudioStreamIndex")
 	public val audioStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the index of the now playing subtitle stream.
+	 * The index of the now playing subtitle stream.
 	 */
 	@SerialName("SubtitleStreamIndex")
 	public val subtitleStreamIndex: Int? = null,
 	/**
-	 * Gets or sets the now playing media version identifier.
+	 * The now playing media version identifier.
 	 */
 	@SerialName("MediaSourceId")
 	public val mediaSourceId: String? = null,
 	/**
-	 * Gets or sets the play method.
+	 * The play method.
 	 */
 	@SerialName("PlayMethod")
 	public val playMethod: PlayMethod? = null,
 	/**
-	 * Gets or sets the repeat mode.
+	 * The repeat mode.
 	 */
 	@SerialName("RepeatMode")
 	public val repeatMode: RepeatMode,
 	/**
-	 * Gets or sets the now playing live stream identifier.
+	 * The now playing live stream identifier.
 	 */
 	@SerialName("LiveStreamId")
 	public val liveStreamId: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaystateRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaystateRequest.kt
@@ -20,7 +20,7 @@ public data class PlaystateRequest(
 	@SerialName("SeekPositionTicks")
 	public val seekPositionTicks: Long? = null,
 	/**
-	 * Gets or sets the controlling user identifier.
+	 * The controlling user identifier.
 	 */
 	@SerialName("ControllingUserId")
 	public val controllingUserId: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PluginInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PluginInfo.kt
@@ -22,42 +22,42 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PluginInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets the version.
+	 * The version.
 	 */
 	@SerialName("Version")
 	public val version: String,
 	/**
-	 * Gets or sets the name of the configuration file.
+	 * The name of the configuration file.
 	 */
 	@SerialName("ConfigurationFileName")
 	public val configurationFileName: String? = null,
 	/**
-	 * Gets or sets the description.
+	 * The description.
 	 */
 	@SerialName("Description")
 	public val description: String,
 	/**
-	 * Gets or sets the unique id.
+	 * The unique id.
 	 */
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets or sets a value indicating whether the plugin can be uninstalled.
+	 * A value indicating whether the plugin can be uninstalled.
 	 */
 	@SerialName("CanUninstall")
 	public val canUninstall: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this plugin has a valid image.
+	 * A value indicating whether this plugin has a valid image.
 	 */
 	@SerialName("HasImage")
 	public val hasImage: Boolean,
 	/**
-	 * Gets or sets a value indicating the status of the plugin.
+	 * A value indicating the status of the plugin.
 	 */
 	@SerialName("Status")
 	public val status: PluginStatus,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PreviousItemRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PreviousItemRequestDto.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class PreviousItemRequestDto(
 	/**
-	 * Gets or sets the playing item identifier.
+	 * The playing item identifier.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PublicSystemInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PublicSystemInfo.kt
@@ -13,37 +13,37 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PublicSystemInfo(
 	/**
-	 * Gets or sets the local address.
+	 * The local address.
 	 */
 	@SerialName("LocalAddress")
 	public val localAddress: String? = null,
 	/**
-	 * Gets or sets the name of the server.
+	 * The name of the server.
 	 */
 	@SerialName("ServerName")
 	public val serverName: String? = null,
 	/**
-	 * Gets or sets the server version.
+	 * The server version.
 	 */
 	@SerialName("Version")
 	public val version: String? = null,
 	/**
-	 * Gets or sets the product name. This is the AssemblyProduct name.
+	 * The product name. This is the AssemblyProduct name.
 	 */
 	@SerialName("ProductName")
 	public val productName: String? = null,
 	/**
-	 * Gets or sets the operating system.
+	 * The operating system.
 	 */
 	@SerialName("OperatingSystem")
 	public val operatingSystem: String? = null,
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets a value indicating whether the startup wizard is completed.
+	 * A value indicating whether the startup wizard is completed.
 	 */
 	@SerialName("StartupWizardCompleted")
 	public val startupWizardCompleted: Boolean? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/QueueRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/QueueRequestDto.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class QueueRequestDto(
 	/**
-	 * Gets or sets the items to enqueue.
+	 * The items to enqueue.
 	 */
 	@SerialName("ItemIds")
 	public val itemIds: List<UUID>,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/QuickConnectDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/QuickConnectDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class QuickConnectDto(
 	/**
-	 * Gets or sets the quick connect secret.
+	 * The quick connect secret.
 	 */
 	@SerialName("Secret")
 	public val secret: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/QuickConnectResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/QuickConnectResult.kt
@@ -21,43 +21,43 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class QuickConnectResult(
 	/**
-	 * Gets or sets a value indicating whether this request is authorized.
+	 * A value indicating whether this request is authorized.
 	 */
 	@SerialName("Authenticated")
 	public val authenticated: Boolean,
 	/**
-	 * Gets the secret value used to uniquely identify this request. Can be used to retrieve
-	 * authentication information.
+	 * The secret value used to uniquely identify this request. Can be used to retrieve authentication
+	 * information.
 	 */
 	@SerialName("Secret")
 	public val secret: String,
 	/**
-	 * Gets the user facing code used so the user can quickly differentiate this request from others.
+	 * The user facing code used so the user can quickly differentiate this request from others.
 	 */
 	@SerialName("Code")
 	public val code: String,
 	/**
-	 * Gets the requesting device id.
+	 * The requesting device id.
 	 */
 	@SerialName("DeviceId")
 	public val deviceId: String,
 	/**
-	 * Gets the requesting device name.
+	 * The requesting device name.
 	 */
 	@SerialName("DeviceName")
 	public val deviceName: String,
 	/**
-	 * Gets the requesting app name.
+	 * The requesting app name.
 	 */
 	@SerialName("AppName")
 	public val appName: String,
 	/**
-	 * Gets the requesting app version.
+	 * The requesting app version.
 	 */
 	@SerialName("AppVersion")
 	public val appVersion: String,
 	/**
-	 * Gets or sets the DateTime that this request was created.
+	 * The DateTime that this request was created.
 	 */
 	@SerialName("DateAdded")
 	public val dateAdded: DateTime,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ReadyRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ReadyRequestDto.kt
@@ -26,22 +26,22 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class ReadyRequestDto(
 	/**
-	 * Gets or sets when the request has been made by the client.
+	 * When the request has been made by the client.
 	 */
 	@SerialName("When")
 	public val `when`: DateTime,
 	/**
-	 * Gets or sets the position ticks.
+	 * The position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long,
 	/**
-	 * Gets or sets a value indicating whether the client playback is unpaused.
+	 * A value indicating whether the client playback is unpaused.
 	 */
 	@SerialName("IsPlaying")
 	public val isPlaying: Boolean,
 	/**
-	 * Gets or sets the playlist item identifier of the playing item.
+	 * The playlist item identifier of the playing item.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoteImageInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoteImageInfo.kt
@@ -17,52 +17,52 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class RemoteImageInfo(
 	/**
-	 * Gets or sets the name of the provider.
+	 * The name of the provider.
 	 */
 	@SerialName("ProviderName")
 	public val providerName: String? = null,
 	/**
-	 * Gets or sets the URL.
+	 * The URL.
 	 */
 	@SerialName("Url")
 	public val url: String? = null,
 	/**
-	 * Gets or sets a url used for previewing a smaller version.
+	 * A url used for previewing a smaller version.
 	 */
 	@SerialName("ThumbnailUrl")
 	public val thumbnailUrl: String? = null,
 	/**
-	 * Gets or sets the height.
+	 * The height.
 	 */
 	@SerialName("Height")
 	public val height: Int? = null,
 	/**
-	 * Gets or sets the width.
+	 * The width.
 	 */
 	@SerialName("Width")
 	public val width: Int? = null,
 	/**
-	 * Gets or sets the community rating.
+	 * The community rating.
 	 */
 	@SerialName("CommunityRating")
 	public val communityRating: Double? = null,
 	/**
-	 * Gets or sets the vote count.
+	 * The vote count.
 	 */
 	@SerialName("VoteCount")
 	public val voteCount: Int? = null,
 	/**
-	 * Gets or sets the language.
+	 * The language.
 	 */
 	@SerialName("Language")
 	public val language: String? = null,
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: ImageType,
 	/**
-	 * Gets or sets the type of the rating.
+	 * The type of the rating.
 	 */
 	@SerialName("RatingType")
 	public val ratingType: RatingType,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoteImageResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoteImageResult.kt
@@ -17,17 +17,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class RemoteImageResult(
 	/**
-	 * Gets or sets the images.
+	 * The images.
 	 */
 	@SerialName("Images")
 	public val images: List<RemoteImageInfo>? = null,
 	/**
-	 * Gets or sets the total record count.
+	 * The total record count.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the providers.
+	 * The providers.
 	 */
 	@SerialName("Providers")
 	public val providers: List<String>? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoteSearchResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoteSearchResult.kt
@@ -20,17 +20,17 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class RemoteSearchResult(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("ProductionYear")
 	public val productionYear: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RemoveFromPlaylistRequestDto.kt
@@ -21,18 +21,18 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class RemoveFromPlaylistRequestDto(
 	/**
-	 * Gets or sets the playlist identifiers ot the items. Ignored when clearing the playlist.
+	 * The playlist identifiers ot the items. Ignored when clearing the playlist.
 	 */
 	@SerialName("PlaylistItemIds")
 	public val playlistItemIds: List<UUID>,
 	/**
-	 * Gets or sets a value indicating whether the entire playlist should be cleared.
+	 * A value indicating whether the entire playlist should be cleared.
 	 */
 	@SerialName("ClearPlaylist")
 	public val clearPlaylist: Boolean,
 	/**
-	 * Gets or sets a value indicating whether the playing item should be removed as well. Used only
-	 * when clearing the playlist.
+	 * A value indicating whether the playing item should be removed as well. Used only when clearing
+	 * the playlist.
 	 */
 	@SerialName("ClearPlayingItem")
 	public val clearPlayingItem: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RepositoryInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RepositoryInfo.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class RepositoryInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the URL.
+	 * The URL.
 	 */
 	@SerialName("Url")
 	public val url: String? = null,
 	/**
-	 * Gets or sets a value indicating whether the repository is enabled.
+	 * A value indicating whether the repository is enabled.
 	 */
 	@SerialName("Enabled")
 	public val enabled: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SearchHint.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SearchHint.kt
@@ -30,76 +30,76 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class SearchHint(
 	/**
-	 * Gets or sets the item id.
+	 * The item id.
 	 */
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the matched term.
+	 * The matched term.
 	 */
 	@SerialName("MatchedTerm")
 	public val matchedTerm: String? = null,
 	/**
-	 * Gets or sets the index number.
+	 * The index number.
 	 */
 	@SerialName("IndexNumber")
 	public val indexNumber: Int? = null,
 	/**
-	 * Gets or sets the production year.
+	 * The production year.
 	 */
 	@SerialName("ProductionYear")
 	public val productionYear: Int? = null,
 	/**
-	 * Gets or sets the parent index number.
+	 * The parent index number.
 	 */
 	@SerialName("ParentIndexNumber")
 	public val parentIndexNumber: Int? = null,
 	/**
-	 * Gets or sets the image tag.
+	 * The image tag.
 	 */
 	@SerialName("PrimaryImageTag")
 	public val primaryImageTag: String? = null,
 	/**
-	 * Gets or sets the thumb image tag.
+	 * The thumb image tag.
 	 */
 	@SerialName("ThumbImageTag")
 	public val thumbImageTag: String? = null,
 	/**
-	 * Gets or sets the thumb image item identifier.
+	 * The thumb image item identifier.
 	 */
 	@SerialName("ThumbImageItemId")
 	public val thumbImageItemId: String? = null,
 	/**
-	 * Gets or sets the backdrop image tag.
+	 * The backdrop image tag.
 	 */
 	@SerialName("BackdropImageTag")
 	public val backdropImageTag: String? = null,
 	/**
-	 * Gets or sets the backdrop image item identifier.
+	 * The backdrop image item identifier.
 	 */
 	@SerialName("BackdropImageItemId")
 	public val backdropImageItemId: String? = null,
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: String? = null,
 	@SerialName("IsFolder")
 	public val isFolder: Boolean? = null,
 	/**
-	 * Gets or sets the run time ticks.
+	 * The run time ticks.
 	 */
 	@SerialName("RunTimeTicks")
 	public val runTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the type of the media.
+	 * The type of the media.
 	 */
 	@SerialName("MediaType")
 	public val mediaType: String? = null,
@@ -108,51 +108,51 @@ public data class SearchHint(
 	@SerialName("EndDate")
 	public val endDate: DateTime? = null,
 	/**
-	 * Gets or sets the series.
+	 * The series.
 	 */
 	@SerialName("Series")
 	public val series: String? = null,
 	@SerialName("Status")
 	public val status: String? = null,
 	/**
-	 * Gets or sets the album.
+	 * The album.
 	 */
 	@SerialName("Album")
 	public val album: String? = null,
 	@SerialName("AlbumId")
 	public val albumId: UUID,
 	/**
-	 * Gets or sets the album artist.
+	 * The album artist.
 	 */
 	@SerialName("AlbumArtist")
 	public val albumArtist: String? = null,
 	/**
-	 * Gets or sets the artists.
+	 * The artists.
 	 */
 	@SerialName("Artists")
 	public val artists: List<String>? = null,
 	/**
-	 * Gets or sets the song count.
+	 * The song count.
 	 */
 	@SerialName("SongCount")
 	public val songCount: Int? = null,
 	/**
-	 * Gets or sets the episode count.
+	 * The episode count.
 	 */
 	@SerialName("EpisodeCount")
 	public val episodeCount: Int? = null,
 	/**
-	 * Gets or sets the channel identifier.
+	 * The channel identifier.
 	 */
 	@SerialName("ChannelId")
 	public val channelId: UUID,
 	/**
-	 * Gets or sets the name of the channel.
+	 * The name of the channel.
 	 */
 	@SerialName("ChannelName")
 	public val channelName: String? = null,
 	/**
-	 * Gets or sets the primary image aspect ratio.
+	 * The primary image aspect ratio.
 	 */
 	@SerialName("PrimaryImageAspectRatio")
 	public val primaryImageAspectRatio: Double? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SearchHintResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SearchHintResult.kt
@@ -16,12 +16,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class SearchHintResult(
 	/**
-	 * Gets the search hints.
+	 * The search hints.
 	 */
 	@SerialName("SearchHints")
 	public val searchHints: List<SearchHint>,
 	/**
-	 * Gets the total record count.
+	 * The total record count.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeekRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeekRequestDto.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class SeekRequestDto(
 	/**
-	 * Gets or sets the position ticks.
+	 * The position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SendCommand.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SendCommand.kt
@@ -25,32 +25,32 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class SendCommand(
 	/**
-	 * Gets the group identifier.
+	 * The group identifier.
 	 */
 	@SerialName("GroupId")
 	public val groupId: UUID,
 	/**
-	 * Gets the playlist identifier of the playing item.
+	 * The playlist identifier of the playing item.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: UUID,
 	/**
-	 * Gets or sets the UTC time when to execute the command.
+	 * The UTC time when to execute the command.
 	 */
 	@SerialName("When")
 	public val `when`: DateTime,
 	/**
-	 * Gets the position ticks.
+	 * The position ticks.
 	 */
 	@SerialName("PositionTicks")
 	public val positionTicks: Long? = null,
 	/**
-	 * Gets the command.
+	 * The command.
 	 */
 	@SerialName("Command")
 	public val command: SendCommandType,
 	/**
-	 * Gets the UTC time when this command has been emitted.
+	 * The UTC time when this command has been emitted.
 	 */
 	@SerialName("EmittedAt")
 	public val emittedAt: DateTime,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesInfo.kt
@@ -20,37 +20,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class SeriesInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class SeriesInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesTimerInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesTimerInfoDto.kt
@@ -29,162 +29,162 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class SeriesTimerInfoDto(
 	/**
-	 * Gets or sets the Id of the recording.
+	 * The Id of the recording.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	@SerialName("Type")
 	public val type: String? = null,
 	/**
-	 * Gets or sets the server identifier.
+	 * The server identifier.
 	 */
 	@SerialName("ServerId")
 	public val serverId: String? = null,
 	/**
-	 * Gets or sets the external identifier.
+	 * The external identifier.
 	 */
 	@SerialName("ExternalId")
 	public val externalId: String? = null,
 	/**
-	 * Gets or sets the channel id of the recording.
+	 * The channel id of the recording.
 	 */
 	@SerialName("ChannelId")
 	public val channelId: UUID,
 	/**
-	 * Gets or sets the external channel identifier.
+	 * The external channel identifier.
 	 */
 	@SerialName("ExternalChannelId")
 	public val externalChannelId: String? = null,
 	/**
-	 * Gets or sets the channel name of the recording.
+	 * The channel name of the recording.
 	 */
 	@SerialName("ChannelName")
 	public val channelName: String? = null,
 	@SerialName("ChannelPrimaryImageTag")
 	public val channelPrimaryImageTag: String? = null,
 	/**
-	 * Gets or sets the program identifier.
+	 * The program identifier.
 	 */
 	@SerialName("ProgramId")
 	public val programId: String? = null,
 	/**
-	 * Gets or sets the external program identifier.
+	 * The external program identifier.
 	 */
 	@SerialName("ExternalProgramId")
 	public val externalProgramId: String? = null,
 	/**
-	 * Gets or sets the name of the recording.
+	 * The name of the recording.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the description of the recording.
+	 * The description of the recording.
 	 */
 	@SerialName("Overview")
 	public val overview: String? = null,
 	/**
-	 * Gets or sets the start date of the recording, in UTC.
+	 * The start date of the recording, in UTC.
 	 */
 	@SerialName("StartDate")
 	public val startDate: DateTime,
 	/**
-	 * Gets or sets the end date of the recording, in UTC.
+	 * The end date of the recording, in UTC.
 	 */
 	@SerialName("EndDate")
 	public val endDate: DateTime,
 	/**
-	 * Gets or sets the name of the service.
+	 * The name of the service.
 	 */
 	@SerialName("ServiceName")
 	public val serviceName: String? = null,
 	/**
-	 * Gets or sets the priority.
+	 * The priority.
 	 */
 	@SerialName("Priority")
 	public val priority: Int,
 	/**
-	 * Gets or sets the pre padding seconds.
+	 * The pre padding seconds.
 	 */
 	@SerialName("PrePaddingSeconds")
 	public val prePaddingSeconds: Int,
 	/**
-	 * Gets or sets the post padding seconds.
+	 * The post padding seconds.
 	 */
 	@SerialName("PostPaddingSeconds")
 	public val postPaddingSeconds: Int,
 	/**
-	 * Gets or sets a value indicating whether this instance is pre padding required.
+	 * A value indicating whether this instance is pre padding required.
 	 */
 	@SerialName("IsPrePaddingRequired")
 	public val isPrePaddingRequired: Boolean,
 	/**
-	 * Gets or sets the Id of the Parent that has a backdrop if the item does not have one.
+	 * The Id of the Parent that has a backdrop if the item does not have one.
 	 */
 	@SerialName("ParentBackdropItemId")
 	public val parentBackdropItemId: String? = null,
 	/**
-	 * Gets or sets the parent backdrop image tags.
+	 * The parent backdrop image tags.
 	 */
 	@SerialName("ParentBackdropImageTags")
 	public val parentBackdropImageTags: List<String>? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is post padding required.
+	 * A value indicating whether this instance is post padding required.
 	 */
 	@SerialName("IsPostPaddingRequired")
 	public val isPostPaddingRequired: Boolean,
 	@SerialName("KeepUntil")
 	public val keepUntil: KeepUntil,
 	/**
-	 * Gets or sets a value indicating whether [record any time].
+	 * A value indicating whether [record any time].
 	 */
 	@SerialName("RecordAnyTime")
 	public val recordAnyTime: Boolean,
 	@SerialName("SkipEpisodesInLibrary")
 	public val skipEpisodesInLibrary: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [record any channel].
+	 * A value indicating whether [record any channel].
 	 */
 	@SerialName("RecordAnyChannel")
 	public val recordAnyChannel: Boolean,
 	@SerialName("KeepUpTo")
 	public val keepUpTo: Int,
 	/**
-	 * Gets or sets a value indicating whether [record new only].
+	 * A value indicating whether [record new only].
 	 */
 	@SerialName("RecordNewOnly")
 	public val recordNewOnly: Boolean,
 	/**
-	 * Gets or sets the days.
+	 * The days.
 	 */
 	@SerialName("Days")
 	public val days: List<DayOfWeek>? = null,
 	/**
-	 * Gets or sets the day pattern.
+	 * The day pattern.
 	 */
 	@SerialName("DayPattern")
 	public val dayPattern: DayPattern? = null,
 	/**
-	 * Gets or sets the image tags.
+	 * The image tags.
 	 */
 	@SerialName("ImageTags")
 	public val imageTags: Map<ImageType, String>? = null,
 	/**
-	 * Gets or sets the parent thumb item id.
+	 * The parent thumb item id.
 	 */
 	@SerialName("ParentThumbItemId")
 	public val parentThumbItemId: String? = null,
 	/**
-	 * Gets or sets the parent thumb image tag.
+	 * The parent thumb image tag.
 	 */
 	@SerialName("ParentThumbImageTag")
 	public val parentThumbImageTag: String? = null,
 	/**
-	 * Gets or sets the parent primary image item identifier.
+	 * The parent primary image item identifier.
 	 */
 	@SerialName("ParentPrimaryImageItemId")
 	public val parentPrimaryImageItemId: String? = null,
 	/**
-	 * Gets or sets the parent primary image tag.
+	 * The parent primary image tag.
 	 */
 	@SerialName("ParentPrimaryImageTag")
 	public val parentPrimaryImageTag: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesTimerInfoDtoQueryResult.kt
@@ -13,17 +13,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class SeriesTimerInfoDtoQueryResult(
 	/**
-	 * Gets or sets the items.
+	 * The items.
 	 */
 	@SerialName("Items")
 	public val items: List<SeriesTimerInfoDto>? = null,
 	/**
-	 * Gets or sets the total number of records available.
+	 * The total number of records available.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the index of the first record in Items.
+	 * The index of the first record in Items.
 	 */
 	@SerialName("StartIndex")
 	public val startIndex: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ServerConfiguration.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ServerConfiguration.kt
@@ -19,22 +19,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ServerConfiguration(
 	/**
-	 * Gets or sets the number of days we should retain log files.
+	 * The number of days we should retain log files.
 	 */
 	@SerialName("LogFileRetentionDays")
 	public val logFileRetentionDays: Int,
 	/**
-	 * Gets or sets a value indicating whether this instance is first run.
+	 * A value indicating whether this instance is first run.
 	 */
 	@SerialName("IsStartupWizardCompleted")
 	public val isStartupWizardCompleted: Boolean,
 	/**
-	 * Gets or sets the cache path.
+	 * The cache path.
 	 */
 	@SerialName("CachePath")
 	public val cachePath: String? = null,
 	/**
-	 * Gets or sets the last known version that was ran using the configuration.
+	 * The last known version that was ran using the configuration.
 	 */
 	@SerialName("PreviousVersion")
 	public val previousVersion: String? = null,
@@ -45,90 +45,85 @@ public data class ServerConfiguration(
 	@SerialName("PreviousVersionStr")
 	public val previousVersionStr: String? = null,
 	/**
-	 * Gets or sets a value indicating whether to enable prometheus metrics exporting.
+	 * A value indicating whether to enable prometheus metrics exporting.
 	 */
 	@SerialName("EnableMetrics")
 	public val enableMetrics: Boolean,
 	@SerialName("EnableNormalizedItemByNameIds")
 	public val enableNormalizedItemByNameIds: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is port authorized.
+	 * A value indicating whether this instance is port authorized.
 	 */
 	@SerialName("IsPortAuthorized")
 	public val isPortAuthorized: Boolean,
 	/**
-	 * Gets or sets a value indicating whether quick connect is available for use on this server.
+	 * A value indicating whether quick connect is available for use on this server.
 	 */
 	@SerialName("QuickConnectAvailable")
 	public val quickConnectAvailable: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [enable case sensitive item ids].
+	 * A value indicating whether [enable case sensitive item ids].
 	 */
 	@SerialName("EnableCaseSensitiveItemIds")
 	public val enableCaseSensitiveItemIds: Boolean,
 	@SerialName("DisableLiveTvChannelUserDataName")
 	public val disableLiveTvChannelUserDataName: Boolean,
 	/**
-	 * Gets or sets the metadata path.
+	 * The metadata path.
 	 */
 	@SerialName("MetadataPath")
 	public val metadataPath: String,
 	@SerialName("MetadataNetworkPath")
 	public val metadataNetworkPath: String,
 	/**
-	 * Gets or sets the preferred metadata language.
+	 * The preferred metadata language.
 	 */
 	@SerialName("PreferredMetadataLanguage")
 	public val preferredMetadataLanguage: String,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String,
 	/**
-	 * Gets or sets characters to be replaced with a ' ' in strings to create a sort name.
+	 * Characters to be replaced with a ' ' in strings to create a sort name.
 	 */
 	@SerialName("SortReplaceCharacters")
 	public val sortReplaceCharacters: List<String>,
 	/**
-	 * Gets or sets characters to be removed from strings to create a sort name.
+	 * Characters to be removed from strings to create a sort name.
 	 */
 	@SerialName("SortRemoveCharacters")
 	public val sortRemoveCharacters: List<String>,
 	/**
-	 * Gets or sets words to be removed from strings to create a sort name.
+	 * Words to be removed from strings to create a sort name.
 	 */
 	@SerialName("SortRemoveWords")
 	public val sortRemoveWords: List<String>,
 	/**
-	 * Gets or sets the minimum percentage of an item that must be played in order for playstate to be
-	 * updated.
+	 * The minimum percentage of an item that must be played in order for playstate to be updated.
 	 */
 	@SerialName("MinResumePct")
 	public val minResumePct: Int,
 	/**
-	 * Gets or sets the maximum percentage of an item that can be played while still saving playstate.
-	 * If this percentage is crossed playstate will be reset to the beginning and the item will be marked
-	 * watched.
+	 * The maximum percentage of an item that can be played while still saving playstate. If this
+	 * percentage is crossed playstate will be reset to the beginning and the item will be marked watched.
 	 */
 	@SerialName("MaxResumePct")
 	public val maxResumePct: Int,
 	/**
-	 * Gets or sets the minimum duration that an item must have in order to be eligible for playstate
-	 * updates..
+	 * The minimum duration that an item must have in order to be eligible for playstate updates..
 	 */
 	@SerialName("MinResumeDurationSeconds")
 	public val minResumeDurationSeconds: Int,
 	/**
-	 * Gets or sets the minimum minutes of a book that must be played in order for playstate to be
-	 * updated.
+	 * The minimum minutes of a book that must be played in order for playstate to be updated.
 	 */
 	@SerialName("MinAudiobookResume")
 	public val minAudiobookResume: Int,
 	/**
-	 * Gets or sets the remaining minutes of a book that can be played while still saving playstate. If
-	 * this percentage is crossed playstate will be reset to the beginning and the item will be marked
-	 * watched.
+	 * The remaining minutes of a book that can be played while still saving playstate. If this
+	 * percentage is crossed playstate will be reset to the beginning and the item will be marked watched.
 	 */
 	@SerialName("MaxAudiobookResume")
 	public val maxAudiobookResume: Int,
@@ -142,7 +137,7 @@ public data class ServerConfiguration(
 	@SerialName("LibraryMonitorDelay")
 	public val libraryMonitorDelay: Int,
 	/**
-	 * Gets or sets the image saving convention.
+	 * The image saving convention.
 	 */
 	@SerialName("ImageSavingConvention")
 	public val imageSavingConvention: ImageSavingConvention,
@@ -177,43 +172,42 @@ public data class ServerConfiguration(
 	@SerialName("PathSubstitutions")
 	public val pathSubstitutions: List<PathSubstitution>,
 	/**
-	 * Gets or sets a value indicating whether slow server responses should be logged as a warning.
+	 * A value indicating whether slow server responses should be logged as a warning.
 	 */
 	@SerialName("EnableSlowResponseWarning")
 	public val enableSlowResponseWarning: Boolean,
 	/**
-	 * Gets or sets the threshold for the slow response time warning in ms.
+	 * The threshold for the slow response time warning in ms.
 	 */
 	@SerialName("SlowResponseThresholdMs")
 	public val slowResponseThresholdMs: Long,
 	/**
-	 * Gets or sets the cors hosts.
+	 * The cors hosts.
 	 */
 	@SerialName("CorsHosts")
 	public val corsHosts: List<String>,
 	/**
-	 * Gets or sets the number of days we should retain activity logs.
+	 * The number of days we should retain activity logs.
 	 */
 	@SerialName("ActivityLogRetentionDays")
 	public val activityLogRetentionDays: Int? = null,
 	/**
-	 * Gets or sets the how the library scan fans out.
+	 * The how the library scan fans out.
 	 */
 	@SerialName("LibraryScanFanoutConcurrency")
 	public val libraryScanFanoutConcurrency: Int,
 	/**
-	 * Gets or sets the how many metadata refreshes can run concurrently.
+	 * The how many metadata refreshes can run concurrently.
 	 */
 	@SerialName("LibraryMetadataRefreshConcurrency")
 	public val libraryMetadataRefreshConcurrency: Int,
 	/**
-	 * Gets or sets a value indicating whether older plugins should automatically be deleted from the
-	 * plugin folder.
+	 * A value indicating whether older plugins should automatically be deleted from the plugin folder.
 	 */
 	@SerialName("RemoveOldPlugins")
 	public val removeOldPlugins: Boolean,
 	/**
-	 * Gets or sets a value indicating whether clients should be allowed to upload logs.
+	 * A value indicating whether clients should be allowed to upload logs.
 	 */
 	@SerialName("AllowClientLogUpload")
 	public val allowClientLogUpload: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ServerDiscoveryInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ServerDiscoveryInfo.kt
@@ -15,22 +15,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ServerDiscoveryInfo(
 	/**
-	 * Gets the address.
+	 * The address.
 	 */
 	@SerialName("Address")
 	public val address: String,
 	/**
-	 * Gets the server identifier.
+	 * The server identifier.
 	 */
 	@SerialName("Id")
 	public val id: String,
 	/**
-	 * Gets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets the endpoint address.
+	 * The endpoint address.
 	 */
 	@SerialName("EndpointAddress")
 	public val endpointAddress: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SessionInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SessionInfo.kt
@@ -33,52 +33,52 @@ public data class SessionInfo(
 	@SerialName("Capabilities")
 	public val capabilities: ClientCapabilities? = null,
 	/**
-	 * Gets or sets the remote end point.
+	 * The remote end point.
 	 */
 	@SerialName("RemoteEndPoint")
 	public val remoteEndPoint: String? = null,
 	/**
-	 * Gets the playable media types.
+	 * The playable media types.
 	 */
 	@SerialName("PlayableMediaTypes")
 	public val playableMediaTypes: List<String>? = null,
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets the user id.
+	 * The user id.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID,
 	/**
-	 * Gets or sets the username.
+	 * The username.
 	 */
 	@SerialName("UserName")
 	public val userName: String? = null,
 	/**
-	 * Gets or sets the type of the client.
+	 * The type of the client.
 	 */
 	@SerialName("Client")
 	public val client: String? = null,
 	/**
-	 * Gets or sets the last activity date.
+	 * The last activity date.
 	 */
 	@SerialName("LastActivityDate")
 	public val lastActivityDate: DateTime,
 	/**
-	 * Gets or sets the last playback check in.
+	 * The last playback check in.
 	 */
 	@SerialName("LastPlaybackCheckIn")
 	public val lastPlaybackCheckIn: DateTime,
 	/**
-	 * Gets or sets the name of the device.
+	 * The name of the device.
 	 */
 	@SerialName("DeviceName")
 	public val deviceName: String? = null,
 	/**
-	 * Gets or sets the type of the device.
+	 * The type of the device.
 	 */
 	@SerialName("DeviceType")
 	public val deviceType: String? = null,
@@ -100,19 +100,19 @@ public data class SessionInfo(
 	@SerialName("NowViewingItem")
 	public val nowViewingItem: BaseItemDto? = null,
 	/**
-	 * Gets or sets the device id.
+	 * The device id.
 	 */
 	@SerialName("DeviceId")
 	public val deviceId: String? = null,
 	/**
-	 * Gets or sets the application version.
+	 * The application version.
 	 */
 	@SerialName("ApplicationVersion")
 	public val applicationVersion: String? = null,
 	@SerialName("TranscodingInfo")
 	public val transcodingInfo: TranscodingInfo? = null,
 	/**
-	 * Gets a value indicating whether this instance is active.
+	 * A value indicating whether this instance is active.
 	 */
 	@SerialName("IsActive")
 	public val isActive: Boolean,
@@ -133,7 +133,7 @@ public data class SessionInfo(
 	@SerialName("UserPrimaryImageTag")
 	public val userPrimaryImageTag: String? = null,
 	/**
-	 * Gets the supported commands.
+	 * The supported commands.
 	 */
 	@SerialName("SupportedCommands")
 	public val supportedCommands: List<GeneralCommandType>? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SessionUserInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SessionUserInfo.kt
@@ -20,12 +20,12 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class SessionUserInfo(
 	/**
-	 * Gets or sets the user identifier.
+	 * The user identifier.
 	 */
 	@SerialName("UserId")
 	public val userId: UUID,
 	/**
-	 * Gets or sets the name of the user.
+	 * The name of the user.
 	 */
 	@SerialName("UserName")
 	public val userName: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SetChannelMappingDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SetChannelMappingDto.kt
@@ -15,17 +15,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class SetChannelMappingDto(
 	/**
-	 * Gets or sets the provider id.
+	 * The provider id.
 	 */
 	@SerialName("ProviderId")
 	public val providerId: String,
 	/**
-	 * Gets or sets the tuner channel id.
+	 * The tuner channel id.
 	 */
 	@SerialName("TunerChannelId")
 	public val tunerChannelId: String,
 	/**
-	 * Gets or sets the provider channel id.
+	 * The provider channel id.
 	 */
 	@SerialName("ProviderChannelId")
 	public val providerChannelId: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SetPlaylistItemRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SetPlaylistItemRequestDto.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class SetPlaylistItemRequestDto(
 	/**
-	 * Gets or sets the playlist identifier of the playing item.
+	 * The playlist identifier of the playing item.
 	 */
 	@SerialName("PlaylistItemId")
 	public val playlistItemId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SongInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SongInfo.kt
@@ -21,37 +21,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class SongInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SpecialViewOptionDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SpecialViewOptionDto.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class SpecialViewOptionDto(
 	/**
-	 * Gets or sets view option name.
+	 * View option name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets view option id.
+	 * View option id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/StartupConfigurationDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/StartupConfigurationDto.kt
@@ -15,17 +15,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class StartupConfigurationDto(
 	/**
-	 * Gets or sets UI language culture.
+	 * UI language culture.
 	 */
 	@SerialName("UICulture")
 	public val uiCulture: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the preferred language for the metadata.
+	 * The preferred language for the metadata.
 	 */
 	@SerialName("PreferredMetadataLanguage")
 	public val preferredMetadataLanguage: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/StartupRemoteAccessDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/StartupRemoteAccessDto.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class StartupRemoteAccessDto(
 	/**
-	 * Gets or sets a value indicating whether enable remote access.
+	 * A value indicating whether enable remote access.
 	 */
 	@SerialName("EnableRemoteAccess")
 	public val enableRemoteAccess: Boolean,
 	/**
-	 * Gets or sets a value indicating whether enable automatic port mapping.
+	 * A value indicating whether enable automatic port mapping.
 	 */
 	@SerialName("EnableAutomaticPortMapping")
 	public val enableAutomaticPortMapping: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/StartupUserDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/StartupUserDto.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class StartupUserDto(
 	/**
-	 * Gets or sets the username.
+	 * The username.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the user's password.
+	 * The user's password.
 	 */
 	@SerialName("Password")
 	public val password: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SystemInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SystemInfo.kt
@@ -19,116 +19,116 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class SystemInfo(
 	/**
-	 * Gets or sets the local address.
+	 * The local address.
 	 */
 	@SerialName("LocalAddress")
 	public val localAddress: String? = null,
 	/**
-	 * Gets or sets the name of the server.
+	 * The name of the server.
 	 */
 	@SerialName("ServerName")
 	public val serverName: String? = null,
 	/**
-	 * Gets or sets the server version.
+	 * The server version.
 	 */
 	@SerialName("Version")
 	public val version: String? = null,
 	/**
-	 * Gets or sets the product name. This is the AssemblyProduct name.
+	 * The product name. This is the AssemblyProduct name.
 	 */
 	@SerialName("ProductName")
 	public val productName: String? = null,
 	/**
-	 * Gets or sets the operating system.
+	 * The operating system.
 	 */
 	@SerialName("OperatingSystem")
 	public val operatingSystem: String? = null,
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets a value indicating whether the startup wizard is completed.
+	 * A value indicating whether the startup wizard is completed.
 	 */
 	@SerialName("StartupWizardCompleted")
 	public val startupWizardCompleted: Boolean? = null,
 	/**
-	 * Gets or sets the display name of the operating system.
+	 * The display name of the operating system.
 	 */
 	@SerialName("OperatingSystemDisplayName")
 	public val operatingSystemDisplayName: String? = null,
 	/**
-	 * Gets or sets the package name.
+	 * The package name.
 	 */
 	@SerialName("PackageName")
 	public val packageName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance has pending restart.
+	 * A value indicating whether this instance has pending restart.
 	 */
 	@SerialName("HasPendingRestart")
 	public val hasPendingRestart: Boolean,
 	@SerialName("IsShuttingDown")
 	public val isShuttingDown: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [supports library monitor].
+	 * A value indicating whether [supports library monitor].
 	 */
 	@SerialName("SupportsLibraryMonitor")
 	public val supportsLibraryMonitor: Boolean,
 	/**
-	 * Gets or sets the web socket port number.
+	 * The web socket port number.
 	 */
 	@SerialName("WebSocketPortNumber")
 	public val webSocketPortNumber: Int,
 	/**
-	 * Gets or sets the completed installations.
+	 * The completed installations.
 	 */
 	@SerialName("CompletedInstallations")
 	public val completedInstallations: List<InstallationInfo>? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance can self restart.
+	 * A value indicating whether this instance can self restart.
 	 */
 	@SerialName("CanSelfRestart")
 	public val canSelfRestart: Boolean,
 	@SerialName("CanLaunchWebBrowser")
 	public val canLaunchWebBrowser: Boolean,
 	/**
-	 * Gets or sets the program data path.
+	 * The program data path.
 	 */
 	@SerialName("ProgramDataPath")
 	public val programDataPath: String? = null,
 	/**
-	 * Gets or sets the web UI resources path.
+	 * The web UI resources path.
 	 */
 	@SerialName("WebPath")
 	public val webPath: String? = null,
 	/**
-	 * Gets or sets the items by name path.
+	 * The items by name path.
 	 */
 	@SerialName("ItemsByNamePath")
 	public val itemsByNamePath: String? = null,
 	/**
-	 * Gets or sets the cache path.
+	 * The cache path.
 	 */
 	@SerialName("CachePath")
 	public val cachePath: String? = null,
 	/**
-	 * Gets or sets the log path.
+	 * The log path.
 	 */
 	@SerialName("LogPath")
 	public val logPath: String? = null,
 	/**
-	 * Gets or sets the internal metadata path.
+	 * The internal metadata path.
 	 */
 	@SerialName("InternalMetadataPath")
 	public val internalMetadataPath: String? = null,
 	/**
-	 * Gets or sets the transcode path.
+	 * The transcode path.
 	 */
 	@SerialName("TranscodingTempPath")
 	public val transcodingTempPath: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance has update available.
+	 * A value indicating whether this instance has update available.
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
 	@SerialName("HasUpdateAvailable")

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskInfo.kt
@@ -18,52 +18,52 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class TaskInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the state of the task.
+	 * The state of the task.
 	 */
 	@SerialName("State")
 	public val state: TaskState,
 	/**
-	 * Gets or sets the progress.
+	 * The progress.
 	 */
 	@SerialName("CurrentProgressPercentage")
 	public val currentProgressPercentage: Double? = null,
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets the last execution result.
+	 * The last execution result.
 	 */
 	@SerialName("LastExecutionResult")
 	public val lastExecutionResult: TaskResult? = null,
 	/**
-	 * Gets or sets the triggers.
+	 * The triggers.
 	 */
 	@SerialName("Triggers")
 	public val triggers: List<TaskTriggerInfo>? = null,
 	/**
-	 * Gets or sets the description.
+	 * The description.
 	 */
 	@SerialName("Description")
 	public val description: String? = null,
 	/**
-	 * Gets or sets the category.
+	 * The category.
 	 */
 	@SerialName("Category")
 	public val category: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is hidden.
+	 * A value indicating whether this instance is hidden.
 	 */
 	@SerialName("IsHidden")
 	public val isHidden: Boolean,
 	/**
-	 * Gets or sets the key.
+	 * The key.
 	 */
 	@SerialName("Key")
 	public val key: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskResult.kt
@@ -20,42 +20,42 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class TaskResult(
 	/**
-	 * Gets or sets the start time UTC.
+	 * The start time UTC.
 	 */
 	@SerialName("StartTimeUtc")
 	public val startTimeUtc: DateTime,
 	/**
-	 * Gets or sets the end time UTC.
+	 * The end time UTC.
 	 */
 	@SerialName("EndTimeUtc")
 	public val endTimeUtc: DateTime,
 	/**
-	 * Gets or sets the status.
+	 * The status.
 	 */
 	@SerialName("Status")
 	public val status: TaskCompletionStatus,
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the key.
+	 * The key.
 	 */
 	@SerialName("Key")
 	public val key: String? = null,
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	/**
-	 * Gets or sets the error message.
+	 * The error message.
 	 */
 	@SerialName("ErrorMessage")
 	public val errorMessage: String? = null,
 	/**
-	 * Gets or sets the long error message.
+	 * The long error message.
 	 */
 	@SerialName("LongErrorMessage")
 	public val longErrorMessage: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskTriggerInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskTriggerInfo.kt
@@ -16,27 +16,27 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class TaskTriggerInfo(
 	/**
-	 * Gets or sets the type.
+	 * The type.
 	 */
 	@SerialName("Type")
 	public val type: String? = null,
 	/**
-	 * Gets or sets the time of day.
+	 * The time of day.
 	 */
 	@SerialName("TimeOfDayTicks")
 	public val timeOfDayTicks: Long? = null,
 	/**
-	 * Gets or sets the interval.
+	 * The interval.
 	 */
 	@SerialName("IntervalTicks")
 	public val intervalTicks: Long? = null,
 	/**
-	 * Gets or sets the day of week.
+	 * The day of week.
 	 */
 	@SerialName("DayOfWeek")
 	public val dayOfWeek: DayOfWeek? = null,
 	/**
-	 * Gets or sets the maximum runtime ticks.
+	 * The maximum runtime ticks.
 	 */
 	@SerialName("MaxRuntimeTicks")
 	public val maxRuntimeTicks: Long? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ThemeMediaResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ThemeMediaResult.kt
@@ -21,22 +21,22 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class ThemeMediaResult(
 	/**
-	 * Gets or sets the items.
+	 * The items.
 	 */
 	@SerialName("Items")
 	public val items: List<BaseItemDto>? = null,
 	/**
-	 * Gets or sets the total number of records available.
+	 * The total number of records available.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the index of the first record in Items.
+	 * The index of the first record in Items.
 	 */
 	@SerialName("StartIndex")
 	public val startIndex: Int,
 	/**
-	 * Gets or sets the owner id.
+	 * The owner id.
 	 */
 	@SerialName("OwnerId")
 	public val ownerId: UUID,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TimerInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TimerInfoDto.kt
@@ -26,133 +26,133 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class TimerInfoDto(
 	/**
-	 * Gets or sets the Id of the recording.
+	 * The Id of the recording.
 	 */
 	@SerialName("Id")
 	public val id: String? = null,
 	@SerialName("Type")
 	public val type: String? = null,
 	/**
-	 * Gets or sets the server identifier.
+	 * The server identifier.
 	 */
 	@SerialName("ServerId")
 	public val serverId: String? = null,
 	/**
-	 * Gets or sets the external identifier.
+	 * The external identifier.
 	 */
 	@SerialName("ExternalId")
 	public val externalId: String? = null,
 	/**
-	 * Gets or sets the channel id of the recording.
+	 * The channel id of the recording.
 	 */
 	@SerialName("ChannelId")
 	public val channelId: UUID,
 	/**
-	 * Gets or sets the external channel identifier.
+	 * The external channel identifier.
 	 */
 	@SerialName("ExternalChannelId")
 	public val externalChannelId: String? = null,
 	/**
-	 * Gets or sets the channel name of the recording.
+	 * The channel name of the recording.
 	 */
 	@SerialName("ChannelName")
 	public val channelName: String? = null,
 	@SerialName("ChannelPrimaryImageTag")
 	public val channelPrimaryImageTag: String? = null,
 	/**
-	 * Gets or sets the program identifier.
+	 * The program identifier.
 	 */
 	@SerialName("ProgramId")
 	public val programId: String? = null,
 	/**
-	 * Gets or sets the external program identifier.
+	 * The external program identifier.
 	 */
 	@SerialName("ExternalProgramId")
 	public val externalProgramId: String? = null,
 	/**
-	 * Gets or sets the name of the recording.
+	 * The name of the recording.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the description of the recording.
+	 * The description of the recording.
 	 */
 	@SerialName("Overview")
 	public val overview: String? = null,
 	/**
-	 * Gets or sets the start date of the recording, in UTC.
+	 * The start date of the recording, in UTC.
 	 */
 	@SerialName("StartDate")
 	public val startDate: DateTime,
 	/**
-	 * Gets or sets the end date of the recording, in UTC.
+	 * The end date of the recording, in UTC.
 	 */
 	@SerialName("EndDate")
 	public val endDate: DateTime,
 	/**
-	 * Gets or sets the name of the service.
+	 * The name of the service.
 	 */
 	@SerialName("ServiceName")
 	public val serviceName: String? = null,
 	/**
-	 * Gets or sets the priority.
+	 * The priority.
 	 */
 	@SerialName("Priority")
 	public val priority: Int,
 	/**
-	 * Gets or sets the pre padding seconds.
+	 * The pre padding seconds.
 	 */
 	@SerialName("PrePaddingSeconds")
 	public val prePaddingSeconds: Int,
 	/**
-	 * Gets or sets the post padding seconds.
+	 * The post padding seconds.
 	 */
 	@SerialName("PostPaddingSeconds")
 	public val postPaddingSeconds: Int,
 	/**
-	 * Gets or sets a value indicating whether this instance is pre padding required.
+	 * A value indicating whether this instance is pre padding required.
 	 */
 	@SerialName("IsPrePaddingRequired")
 	public val isPrePaddingRequired: Boolean,
 	/**
-	 * Gets or sets the Id of the Parent that has a backdrop if the item does not have one.
+	 * The Id of the Parent that has a backdrop if the item does not have one.
 	 */
 	@SerialName("ParentBackdropItemId")
 	public val parentBackdropItemId: String? = null,
 	/**
-	 * Gets or sets the parent backdrop image tags.
+	 * The parent backdrop image tags.
 	 */
 	@SerialName("ParentBackdropImageTags")
 	public val parentBackdropImageTags: List<String>? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance is post padding required.
+	 * A value indicating whether this instance is post padding required.
 	 */
 	@SerialName("IsPostPaddingRequired")
 	public val isPostPaddingRequired: Boolean,
 	@SerialName("KeepUntil")
 	public val keepUntil: KeepUntil,
 	/**
-	 * Gets or sets the status.
+	 * The status.
 	 */
 	@SerialName("Status")
 	public val status: RecordingStatus,
 	/**
-	 * Gets or sets the series timer identifier.
+	 * The series timer identifier.
 	 */
 	@SerialName("SeriesTimerId")
 	public val seriesTimerId: String? = null,
 	/**
-	 * Gets or sets the external series timer identifier.
+	 * The external series timer identifier.
 	 */
 	@SerialName("ExternalSeriesTimerId")
 	public val externalSeriesTimerId: String? = null,
 	/**
-	 * Gets or sets the run time ticks.
+	 * The run time ticks.
 	 */
 	@SerialName("RunTimeTicks")
 	public val runTimeTicks: Long? = null,
 	/**
-	 * Gets or sets the program information.
+	 * The program information.
 	 */
 	@SerialName("ProgramInfo")
 	public val programInfo: BaseItemDto? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TimerInfoDtoQueryResult.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TimerInfoDtoQueryResult.kt
@@ -13,17 +13,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class TimerInfoDtoQueryResult(
 	/**
-	 * Gets or sets the items.
+	 * The items.
 	 */
 	@SerialName("Items")
 	public val items: List<TimerInfoDto>? = null,
 	/**
-	 * Gets or sets the total number of records available.
+	 * The total number of records available.
 	 */
 	@SerialName("TotalRecordCount")
 	public val totalRecordCount: Int,
 	/**
-	 * Gets or sets the index of the first record in Items.
+	 * The index of the first record in Items.
 	 */
 	@SerialName("StartIndex")
 	public val startIndex: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TrailerInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TrailerInfo.kt
@@ -20,37 +20,37 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class TrailerInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the original title.
+	 * The original title.
 	 */
 	@SerialName("OriginalTitle")
 	public val originalTitle: String? = null,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets the metadata language.
+	 * The metadata language.
 	 */
 	@SerialName("MetadataLanguage")
 	public val metadataLanguage: String? = null,
 	/**
-	 * Gets or sets the metadata country code.
+	 * The metadata country code.
 	 */
 	@SerialName("MetadataCountryCode")
 	public val metadataCountryCode: String? = null,
 	/**
-	 * Gets or sets the provider ids.
+	 * The provider ids.
 	 */
 	@SerialName("ProviderIds")
 	public val providerIds: Map<String, String?>? = null,
 	/**
-	 * Gets or sets the year.
+	 * The year.
 	 */
 	@SerialName("Year")
 	public val year: Int? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TrailerInfoRemoteSearchQuery.kt
@@ -22,12 +22,12 @@ public data class TrailerInfoRemoteSearchQuery(
 	@SerialName("ItemId")
 	public val itemId: UUID,
 	/**
-	 * Gets or sets the provider name to search within if set.
+	 * The provider name to search within if set.
 	 */
 	@SerialName("SearchProviderName")
 	public val searchProviderName: String? = null,
 	/**
-	 * Gets or sets a value indicating whether disabled providers should be included.
+	 * A value indicating whether disabled providers should be included.
 	 */
 	@SerialName("IncludeDisabledProviders")
 	public val includeDisabledProviders: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateLibraryOptionsDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateLibraryOptionsDto.kt
@@ -19,12 +19,12 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class UpdateLibraryOptionsDto(
 	/**
-	 * Gets or sets the library item id.
+	 * The library item id.
 	 */
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets or sets library options.
+	 * Library options.
 	 */
 	@SerialName("LibraryOptions")
 	public val libraryOptions: LibraryOptions? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateMediaPathRequestDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateMediaPathRequestDto.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class UpdateMediaPathRequestDto(
 	/**
-	 * Gets or sets the library name.
+	 * The library name.
 	 */
 	@SerialName("Name")
 	public val name: String,
 	/**
-	 * Gets or sets library folder path information.
+	 * Library folder path information.
 	 */
 	@SerialName("PathInfo")
 	public val pathInfo: MediaPathInfo,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateUserEasyPassword.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateUserEasyPassword.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class UpdateUserEasyPassword(
 	/**
-	 * Gets or sets the new sha1-hashed password.
+	 * The new sha1-hashed password.
 	 */
 	@SerialName("NewPassword")
 	public val newPassword: String? = null,
 	/**
-	 * Gets or sets the new password.
+	 * The new password.
 	 */
 	@SerialName("NewPw")
 	public val newPw: String? = null,
 	/**
-	 * Gets or sets a value indicating whether to reset the password.
+	 * A value indicating whether to reset the password.
 	 */
 	@SerialName("ResetPassword")
 	public val resetPassword: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateUserPassword.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UpdateUserPassword.kt
@@ -16,22 +16,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class UpdateUserPassword(
 	/**
-	 * Gets or sets the current sha1-hashed password.
+	 * The current sha1-hashed password.
 	 */
 	@SerialName("CurrentPassword")
 	public val currentPassword: String? = null,
 	/**
-	 * Gets or sets the current plain text password.
+	 * The current plain text password.
 	 */
 	@SerialName("CurrentPw")
 	public val currentPw: String? = null,
 	/**
-	 * Gets or sets the new plain text password.
+	 * The new plain text password.
 	 */
 	@SerialName("NewPw")
 	public val newPw: String? = null,
 	/**
-	 * Gets or sets a value indicating whether to reset the password.
+	 * A value indicating whether to reset the password.
 	 */
 	@SerialName("ResetPassword")
 	public val resetPassword: Boolean,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UploadSubtitleDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UploadSubtitleDto.kt
@@ -16,22 +16,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class UploadSubtitleDto(
 	/**
-	 * Gets or sets the subtitle language.
+	 * The subtitle language.
 	 */
 	@SerialName("Language")
 	public val language: String,
 	/**
-	 * Gets or sets the subtitle format.
+	 * The subtitle format.
 	 */
 	@SerialName("Format")
 	public val format: String,
 	/**
-	 * Gets or sets a value indicating whether the subtitle is forced.
+	 * A value indicating whether the subtitle is forced.
 	 */
 	@SerialName("IsForced")
 	public val isForced: Boolean,
 	/**
-	 * Gets or sets the subtitle data.
+	 * The subtitle data.
 	 */
 	@SerialName("Data")
 	public val `data`: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserConfiguration.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserConfiguration.kt
@@ -17,17 +17,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class UserConfiguration(
 	/**
-	 * Gets or sets the audio language preference.
+	 * The audio language preference.
 	 */
 	@SerialName("AudioLanguagePreference")
 	public val audioLanguagePreference: String? = null,
 	/**
-	 * Gets or sets a value indicating whether [play default audio track].
+	 * A value indicating whether [play default audio track].
 	 */
 	@SerialName("PlayDefaultAudioTrack")
 	public val playDefaultAudioTrack: Boolean,
 	/**
-	 * Gets or sets the subtitle language preference.
+	 * The subtitle language preference.
 	 */
 	@SerialName("SubtitleLanguagePreference")
 	public val subtitleLanguagePreference: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserDto.kt
@@ -27,12 +27,12 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class UserDto(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the server identifier.
+	 * The server identifier.
 	 */
 	@SerialName("ServerId")
 	public val serverId: String? = null,
@@ -43,57 +43,57 @@ public data class UserDto(
 	@SerialName("ServerName")
 	public val serverName: String? = null,
 	/**
-	 * Gets or sets the id.
+	 * The id.
 	 */
 	@SerialName("Id")
 	public val id: UUID,
 	/**
-	 * Gets or sets the primary image tag.
+	 * The primary image tag.
 	 */
 	@SerialName("PrimaryImageTag")
 	public val primaryImageTag: String? = null,
 	/**
-	 * Gets or sets a value indicating whether this instance has password.
+	 * A value indicating whether this instance has password.
 	 */
 	@SerialName("HasPassword")
 	public val hasPassword: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance has configured password.
+	 * A value indicating whether this instance has configured password.
 	 */
 	@SerialName("HasConfiguredPassword")
 	public val hasConfiguredPassword: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance has configured easy password.
+	 * A value indicating whether this instance has configured easy password.
 	 */
 	@SerialName("HasConfiguredEasyPassword")
 	public val hasConfiguredEasyPassword: Boolean,
 	/**
-	 * Gets or sets whether async login is enabled or not.
+	 * Whether async login is enabled or not.
 	 */
 	@SerialName("EnableAutoLogin")
 	public val enableAutoLogin: Boolean? = null,
 	/**
-	 * Gets or sets the last login date.
+	 * The last login date.
 	 */
 	@SerialName("LastLoginDate")
 	public val lastLoginDate: DateTime? = null,
 	/**
-	 * Gets or sets the last activity date.
+	 * The last activity date.
 	 */
 	@SerialName("LastActivityDate")
 	public val lastActivityDate: DateTime? = null,
 	/**
-	 * Gets or sets the configuration.
+	 * The configuration.
 	 */
 	@SerialName("Configuration")
 	public val configuration: UserConfiguration? = null,
 	/**
-	 * Gets or sets the policy.
+	 * The policy.
 	 */
 	@SerialName("Policy")
 	public val policy: UserPolicy? = null,
 	/**
-	 * Gets or sets the primary image aspect ratio.
+	 * The primary image aspect ratio.
 	 */
 	@SerialName("PrimaryImageAspectRatio")
 	public val primaryImageAspectRatio: Double? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserItemDataDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserItemDataDto.kt
@@ -24,57 +24,57 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class UserItemDataDto(
 	/**
-	 * Gets or sets the rating.
+	 * The rating.
 	 */
 	@SerialName("Rating")
 	public val rating: Double? = null,
 	/**
-	 * Gets or sets the played percentage.
+	 * The played percentage.
 	 */
 	@SerialName("PlayedPercentage")
 	public val playedPercentage: Double? = null,
 	/**
-	 * Gets or sets the unplayed item count.
+	 * The unplayed item count.
 	 */
 	@SerialName("UnplayedItemCount")
 	public val unplayedItemCount: Int? = null,
 	/**
-	 * Gets or sets the playback position ticks.
+	 * The playback position ticks.
 	 */
 	@SerialName("PlaybackPositionTicks")
 	public val playbackPositionTicks: Long,
 	/**
-	 * Gets or sets the play count.
+	 * The play count.
 	 */
 	@SerialName("PlayCount")
 	public val playCount: Int,
 	/**
-	 * Gets or sets a value indicating whether this instance is favorite.
+	 * A value indicating whether this instance is favorite.
 	 */
 	@SerialName("IsFavorite")
 	public val isFavorite: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this MediaBrowser.Model.Dto.UserItemDataDto is likes.
+	 * A value indicating whether this MediaBrowser.Model.Dto.UserItemDataDto is likes.
 	 */
 	@SerialName("Likes")
 	public val likes: Boolean? = null,
 	/**
-	 * Gets or sets the last played date.
+	 * The last played date.
 	 */
 	@SerialName("LastPlayedDate")
 	public val lastPlayedDate: DateTime? = null,
 	/**
-	 * Gets or sets a value indicating whether this MediaBrowser.Model.Dto.UserItemDataDto is played.
+	 * A value indicating whether this MediaBrowser.Model.Dto.UserItemDataDto is played.
 	 */
 	@SerialName("Played")
 	public val played: Boolean,
 	/**
-	 * Gets or sets the key.
+	 * The key.
 	 */
 	@SerialName("Key")
 	public val key: String? = null,
 	/**
-	 * Gets or sets the item identifier.
+	 * The item identifier.
 	 */
 	@SerialName("ItemId")
 	public val itemId: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserPolicy.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UserPolicy.kt
@@ -20,22 +20,22 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 @Serializable
 public data class UserPolicy(
 	/**
-	 * Gets or sets a value indicating whether this instance is administrator.
+	 * A value indicating whether this instance is administrator.
 	 */
 	@SerialName("IsAdministrator")
 	public val isAdministrator: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is hidden.
+	 * A value indicating whether this instance is hidden.
 	 */
 	@SerialName("IsHidden")
 	public val isHidden: Boolean,
 	/**
-	 * Gets or sets a value indicating whether this instance is disabled.
+	 * A value indicating whether this instance is disabled.
 	 */
 	@SerialName("IsDisabled")
 	public val isDisabled: Boolean,
 	/**
-	 * Gets or sets the max parental rating.
+	 * The max parental rating.
 	 */
 	@SerialName("MaxParentalRating")
 	public val maxParentalRating: Int? = null,
@@ -74,7 +74,7 @@ public data class UserPolicy(
 	@SerialName("EnableContentDownloading")
 	public val enableContentDownloading: Boolean,
 	/**
-	 * Gets or sets a value indicating whether [enable synchronize].
+	 * A value indicating whether [enable synchronize].
 	 */
 	@SerialName("EnableSyncTranscoding")
 	public val enableSyncTranscoding: Boolean,
@@ -111,7 +111,7 @@ public data class UserPolicy(
 	@SerialName("PasswordResetProviderId")
 	public val passwordResetProviderId: String? = null,
 	/**
-	 * Gets or sets a value indicating what SyncPlay features the user can access.
+	 * A value indicating what SyncPlay features the user can access.
 	 */
 	@SerialName("SyncPlayAccess")
 	public val syncPlayAccess: SyncPlayUserAccessType,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UtcTimeResponse.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UtcTimeResponse.kt
@@ -19,12 +19,12 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 @Serializable
 public data class UtcTimeResponse(
 	/**
-	 * Gets the UTC time when request has been received.
+	 * The UTC time when request has been received.
 	 */
 	@SerialName("RequestReceptionTime")
 	public val requestReceptionTime: DateTime,
 	/**
-	 * Gets the UTC time when response has been sent.
+	 * The UTC time when response has been sent.
 	 */
 	@SerialName("ResponseTransmissionTime")
 	public val responseTransmissionTime: DateTime,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ValidatePathDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ValidatePathDto.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ValidatePathDto(
 	/**
-	 * Gets or sets a value indicating whether validate if path is writable.
+	 * A value indicating whether validate if path is writable.
 	 */
 	@SerialName("ValidateWritable")
 	public val validateWritable: Boolean,
 	/**
-	 * Gets or sets the path.
+	 * The path.
 	 */
 	@SerialName("Path")
 	public val path: String? = null,
 	/**
-	 * Gets or sets is path file.
+	 * Is path file.
 	 */
 	@SerialName("IsFile")
 	public val isFile: Boolean? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/VersionInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/VersionInfo.kt
@@ -15,47 +15,47 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class VersionInfo(
 	/**
-	 * Gets or sets the version.
+	 * The version.
 	 */
 	@SerialName("version")
 	public val version: String,
 	/**
-	 * Gets the version as a System.Version.
+	 * The version as a System.Version.
 	 */
 	@SerialName("VersionNumber")
 	public val versionNumber: String,
 	/**
-	 * Gets or sets the changelog for this version.
+	 * The changelog for this version.
 	 */
 	@SerialName("changelog")
 	public val changelog: String? = null,
 	/**
-	 * Gets or sets the ABI that this version was built against.
+	 * The ABI that this version was built against.
 	 */
 	@SerialName("targetAbi")
 	public val targetAbi: String? = null,
 	/**
-	 * Gets or sets the source URL.
+	 * The source URL.
 	 */
 	@SerialName("sourceUrl")
 	public val sourceUrl: String? = null,
 	/**
-	 * Gets or sets a checksum for the binary.
+	 * A checksum for the binary.
 	 */
 	@SerialName("checksum")
 	public val checksum: String? = null,
 	/**
-	 * Gets or sets a timestamp of when the binary was built.
+	 * A timestamp of when the binary was built.
 	 */
 	@SerialName("timestamp")
 	public val timestamp: String? = null,
 	/**
-	 * Gets or sets the repository name.
+	 * The repository name.
 	 */
 	@SerialName("repositoryName")
 	public val repositoryName: String,
 	/**
-	 * Gets or sets the repository url.
+	 * The repository url.
 	 */
 	@SerialName("repositoryUrl")
 	public val repositoryUrl: String,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/VirtualFolderInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/VirtualFolderInfo.kt
@@ -17,29 +17,29 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class VirtualFolderInfo(
 	/**
-	 * Gets or sets the name.
+	 * The name.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the locations.
+	 * The locations.
 	 */
 	@SerialName("Locations")
 	public val locations: List<String>? = null,
 	/**
-	 * Gets or sets the type of the collection.
+	 * The type of the collection.
 	 */
 	@SerialName("CollectionType")
 	public val collectionType: CollectionTypeOptions? = null,
 	@SerialName("LibraryOptions")
 	public val libraryOptions: LibraryOptions? = null,
 	/**
-	 * Gets or sets the item identifier.
+	 * The item identifier.
 	 */
 	@SerialName("ItemId")
 	public val itemId: String? = null,
 	/**
-	 * Gets or sets the primary image item identifier.
+	 * The primary image item identifier.
 	 */
 	@SerialName("PrimaryImageItemId")
 	public val primaryImageItemId: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/WakeOnLanInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/WakeOnLanInfo.kt
@@ -16,12 +16,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class WakeOnLanInfo(
 	/**
-	 * Gets the MAC address of the device.
+	 * The MAC address of the device.
 	 */
 	@SerialName("MacAddress")
 	public val macAddress: String? = null,
 	/**
-	 * Gets or sets the wake-on-LAN port.
+	 * The wake-on-LAN port.
 	 */
 	@SerialName("Port")
 	public val port: Int,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/XmlAttribute.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/XmlAttribute.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class XmlAttribute(
 	/**
-	 * Gets or sets the name of the attribute.
+	 * The name of the attribute.
 	 */
 	@SerialName("Name")
 	public val name: String? = null,
 	/**
-	 * Gets or sets the value of the attribute.
+	 * The value of the attribute.
 	 */
 	@SerialName("Value")
 	public val `value`: String? = null,

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetAlbumArtistsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetAlbumArtistsRequest.kt
@@ -24,7 +24,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets all album artists from a given item, folder, or the entire library.
+ * All album artists from a given item, folder, or the entire library.
  */
 @Serializable
 public data class GetAlbumArtistsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetArtistsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetArtistsRequest.kt
@@ -24,7 +24,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets all artists from a given item, folder, or the entire library.
+ * All artists from a given item, folder, or the entire library.
  */
 @Serializable
 public data class GetArtistsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetAudioStreamByContainerRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetAudioStreamByContainerRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets an audio stream.
+ * An audio stream.
  */
 @Serializable
 public data class GetAudioStreamByContainerRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetAudioStreamRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetAudioStreamRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets an audio stream.
+ * An audio stream.
  */
 @Serializable
 public data class GetAudioStreamRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetChannelsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetChannelsRequest.kt
@@ -16,7 +16,7 @@ import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets available channels.
+ * Available channels.
  */
 @Serializable
 public data class GetChannelsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetEpisodesRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetEpisodesRequest.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets episodes for a tv season.
+ * Episodes for a tv season.
  */
 @Serializable
 public data class GetEpisodesRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetGenresRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetGenresRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets all genres from a given item, folder, or the entire library.
+ * All genres from a given item, folder, or the entire library.
  */
 @Serializable
 public data class GetGenresRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetHlsAudioSegmentRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetHlsAudioSegmentRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a video stream using HTTP live streaming.
+ * A video stream using HTTP live streaming.
  */
 @Serializable
 public data class GetHlsAudioSegmentRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetHlsVideoSegmentRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetHlsVideoSegmentRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a video stream using HTTP live streaming.
+ * A video stream using HTTP live streaming.
  */
 @Serializable
 public data class GetHlsVideoSegmentRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImage2DeprecatedRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImage2DeprecatedRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the item's image.
+ * The item's image.
  */
 @Serializable
 public data class GetItemImage2DeprecatedRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImage2Request.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImage2Request.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the item's image.
+ * The item's image.
  */
 @Serializable
 public data class GetItemImage2Request(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageByIndexDeprecatedRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageByIndexDeprecatedRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the item's image.
+ * The item's image.
  */
 @Serializable
 public data class GetItemImageByIndexDeprecatedRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageByIndexRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageByIndexRequest.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the item's image.
+ * The item's image.
  */
 @Serializable
 public data class GetItemImageByIndexRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageDeprecatedRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageDeprecatedRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the item's image.
+ * The item's image.
  */
 @Serializable
 public data class GetItemImageDeprecatedRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemImageRequest.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the item's image.
+ * The item's image.
  */
 @Serializable
 public data class GetItemImageRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemsByUserIdRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemsByUserIdRequest.kt
@@ -32,7 +32,7 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets items based on a query.
+ * Items based on a query.
  */
 @Serializable
 public data class GetItemsByUserIdRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetItemsRequest.kt
@@ -32,7 +32,7 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets items based on a query.
+ * Items based on a query.
  */
 @Serializable
 public data class GetItemsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLatestChannelItemsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLatestChannelItemsRequest.kt
@@ -18,7 +18,7 @@ import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets latest channel items.
+ * Latest channel items.
  */
 @Serializable
 public data class GetLatestChannelItemsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLatestMediaRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLatestMediaRequest.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets latest media.
+ * Latest media.
  */
 @Serializable
 public data class GetLatestMediaRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLiveHlsStreamRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLiveHlsStreamRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a hls live stream.
+ * A hls live stream.
  */
 @Serializable
 public data class GetLiveHlsStreamRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLiveTvChannelsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLiveTvChannelsRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets available live tv channels.
+ * Available live tv channels.
  */
 @Serializable
 public data class GetLiveTvChannelsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLiveTvProgramsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetLiveTvProgramsRequest.kt
@@ -26,7 +26,7 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets available live tv epgs.
+ * Available live tv epgs.
  */
 @Serializable
 public data class GetLiveTvProgramsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMasterHlsAudioPlaylistRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMasterHlsAudioPlaylistRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets an audio hls playlist stream.
+ * An audio hls playlist stream.
  */
 @Serializable
 public data class GetMasterHlsAudioPlaylistRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMasterHlsVideoPlaylistRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMasterHlsVideoPlaylistRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a video hls playlist stream.
+ * A video hls playlist stream.
  */
 @Serializable
 public data class GetMasterHlsVideoPlaylistRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMovieRecommendationsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMovieRecommendationsRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets movie recommendations.
+ * Movie recommendations.
  */
 @Serializable
 public data class GetMovieRecommendationsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMusicGenresRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetMusicGenresRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets all music genres from a given item, folder, or the entire library.
+ * All music genres from a given item, folder, or the entire library.
  */
 @Serializable
 public data class GetMusicGenresRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetNextUpRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetNextUpRequest.kt
@@ -25,7 +25,7 @@ import org.jellyfin.sdk.model.serializer.DateTimeSerializer
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a list of next up episodes.
+ * A list of next up episodes.
  */
 @Serializable
 public data class GetNextUpRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetPersonsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetPersonsRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets all persons.
+ * All persons.
  */
 @Serializable
 public data class GetPersonsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetPlaylistItemsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetPlaylistItemsRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the original items of a playlist.
+ * The original items of a playlist.
  */
 @Serializable
 public data class GetPlaylistItemsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetQueryFiltersRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetQueryFiltersRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets query filters.
+ * Query filters.
  */
 @Serializable
 public data class GetQueryFiltersRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRecommendedProgramsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRecommendedProgramsRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets recommended live tv epgs.
+ * Recommended live tv epgs.
  */
 @Serializable
 public data class GetRecommendedProgramsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRecordingsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRecordingsRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.RecordingStatus
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets live tv recordings.
+ * Live tv recordings.
  */
 @Serializable
 public data class GetRecordingsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRecordingsSeriesRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRecordingsSeriesRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.RecordingStatus
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets live tv recording series.
+ * Live tv recording series.
  */
 @Serializable
 public data class GetRecordingsSeriesRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRemoteImagesRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRemoteImagesRequest.kt
@@ -18,7 +18,7 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets available remote images for an item.
+ * Available remote images for an item.
  */
 @Serializable
 public data class GetRemoteImagesRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets the search hint result.
+ * The search hint result.
  */
 @Serializable
 public data class GetRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetResumeItemsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetResumeItemsRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets items based on a query.
+ * Items based on a query.
  */
 @Serializable
 public data class GetResumeItemsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSeasonsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSeasonsRequest.kt
@@ -20,7 +20,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets seasons for a tv series.
+ * Seasons for a tv series.
  */
 @Serializable
 public data class GetSeasonsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarAlbumsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarAlbumsRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets similar items.
+ * Similar items.
  */
 @Serializable
 public data class GetSimilarAlbumsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarArtistsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarArtistsRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets similar items.
+ * Similar items.
  */
 @Serializable
 public data class GetSimilarArtistsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarItemsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarItemsRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets similar items.
+ * Similar items.
  */
 @Serializable
 public data class GetSimilarItemsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarMoviesRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarMoviesRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets similar items.
+ * Similar items.
  */
 @Serializable
 public data class GetSimilarMoviesRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarShowsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarShowsRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets similar items.
+ * Similar items.
  */
 @Serializable
 public data class GetSimilarShowsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarTrailersRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSimilarTrailersRequest.kt
@@ -17,7 +17,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets similar items.
+ * Similar items.
  */
 @Serializable
 public data class GetSimilarTrailersRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetStudiosRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetStudiosRequest.kt
@@ -21,7 +21,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets all studios from a given item, folder, or the entire library.
+ * All studios from a given item, folder, or the entire library.
  */
 @Serializable
 public data class GetStudiosRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleDeprecatedRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleDeprecatedRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets subtitles in a specified format.
+ * Subtitles in a specified format.
  */
 @Serializable
 public data class GetSubtitleDeprecatedRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleRequest.kt
@@ -18,7 +18,7 @@ import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets subtitles in a specified format.
+ * Subtitles in a specified format.
  */
 @Serializable
 public data class GetSubtitleRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleWithTicksDeprecatedRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleWithTicksDeprecatedRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets subtitles in a specified format.
+ * Subtitles in a specified format.
  */
 @Serializable
 public data class GetSubtitleWithTicksDeprecatedRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleWithTicksRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSubtitleWithTicksRequest.kt
@@ -18,7 +18,7 @@ import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets subtitles in a specified format.
+ * Subtitles in a specified format.
  */
 @Serializable
 public data class GetSubtitleWithTicksRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSuggestionsRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetSuggestionsRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets suggestions.
+ * Suggestions.
  */
 @Serializable
 public data class GetSuggestionsRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetUniversalAudioStreamRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetUniversalAudioStreamRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets an audio stream.
+ * An audio stream.
  */
 @Serializable
 public data class GetUniversalAudioStreamRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetUpcomingEpisodesRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetUpcomingEpisodesRequest.kt
@@ -19,7 +19,7 @@ import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a list of upcoming episodes.
+ * A list of upcoming episodes.
  */
 @Serializable
 public data class GetUpcomingEpisodesRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVariantHlsAudioPlaylistRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVariantHlsAudioPlaylistRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets an audio stream using HTTP live streaming.
+ * An audio stream using HTTP live streaming.
  */
 @Serializable
 public data class GetVariantHlsAudioPlaylistRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVariantHlsVideoPlaylistRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVariantHlsVideoPlaylistRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a video stream using HTTP live streaming.
+ * A video stream using HTTP live streaming.
  */
 @Serializable
 public data class GetVariantHlsVideoPlaylistRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVideoStreamByContainerRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVideoStreamByContainerRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a video stream.
+ * A video stream.
  */
 @Serializable
 public data class GetVideoStreamByContainerRequest(

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVideoStreamRequest.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/request/GetVideoStreamRequest.kt
@@ -22,7 +22,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 
 /**
- * Gets a video stream.
+ * A video stream.
  */
 @Serializable
 public data class GetVideoStreamRequest(

--- a/openapi-generator/README.md
+++ b/openapi-generator/README.md
@@ -72,6 +72,10 @@ Hooks are classes that will modify the output of the generator. They should be r
     instance of `CustomDefaultValue` that contains the code builder. The generator will use the
     default value from the JSON schema if all hooks return null.
 
+  - **DescriptionHook**  
+    A hook that allows customization of generated descriptions for operations, parameters, models and
+    properties. The hook returns the new description or null if the description must be removed.
+
 ## Phases
 
 The conversion happens in multiple phases. The phases in order are:

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
@@ -61,5 +61,5 @@ val mainModule = module {
 	// Utilities
 	single { DeprecatedAnnotationSpecBuilder() }
 	single { TypeSerializerBuilder() }
-	single { DescriptionBuilder() }
+	single { DescriptionBuilder(getAll()) }
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -15,9 +15,9 @@ import org.jellyfin.openapi.constants.Classes
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
+import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.ApiServiceOperation
 import org.jellyfin.openapi.model.ApiServiceOperationParameter
-import org.jellyfin.openapi.model.DefaultValue
 import org.jellyfin.openapi.model.IntRangeValidation
 import org.jellyfin.openapi.model.ParameterValidation
 
@@ -30,7 +30,7 @@ open class OperationBuilder(
 		addModifiers(KModifier.SUSPEND)
 
 		// Add description
-		descriptionBuilder.build(data.description)?.let {
+		descriptionBuilder.build(DescriptionType.OPERATION, data.description)?.let {
 			addKdoc("%L", it)
 		}
 
@@ -47,7 +47,7 @@ open class OperationBuilder(
 		defaultValue(data)
 
 		// Add description
-		descriptionBuilder.build(data.description)?.let {
+		descriptionBuilder.build(DescriptionType.OPERATION_PARAMETER, data.description)?.let {
 			addKdoc("%L", it)
 		}
 	}.build()

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationParameterModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationParameterModelBuilder.kt
@@ -10,12 +10,13 @@ import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
 import org.jellyfin.openapi.builder.extra.DescriptionBuilder
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
+import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.ApiServiceOperation
 import org.jellyfin.openapi.model.ApiServiceOperationParameter
 import org.jellyfin.openapi.model.DefaultValue
 
 class OperationParameterModelBuilder(
-	descriptionBuilder: DescriptionBuilder,
+	private val descriptionBuilder: DescriptionBuilder,
 	deprecatedAnnotationSpecBuilder: DeprecatedAnnotationSpecBuilder,
 ) : OperationBuilder(descriptionBuilder, deprecatedAnnotationSpecBuilder) {
 	private fun FunSpec.Builder.addOperationCall(
@@ -44,7 +45,9 @@ class OperationParameterModelBuilder(
 		val parameters = data.pathParameters + data.queryParameters
 
 		ParameterSpec.builder(Strings.MODEL_REQUEST_PARAMETER_NAME, requestParameterType).apply {
-			addKdoc("%L", Strings.MODEL_REQUEST_PARAMETER_DESCRIPTION)
+			descriptionBuilder.build(DescriptionType.OPERATION_PARAMETER, Strings.MODEL_REQUEST_PARAMETER_DESCRIPTION)?.let {
+				addKdoc("%L", it)
+			}
 
 			// Add default value is all parameters have a default
 			if (parameters.all { it.containsDefault() }) defaultValue(

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationUrlBuilder.kt
@@ -6,6 +6,7 @@ import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
 import org.jellyfin.openapi.builder.extra.DescriptionBuilder
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
+import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.ApiServiceOperation
 
 class OperationUrlBuilder(
@@ -16,7 +17,7 @@ class OperationUrlBuilder(
 		buildFunctionName(data.name)
 	).apply {
 		// Add description
-		descriptionBuilder.build(data.description)?.let {
+		descriptionBuilder.build(DescriptionType.OPERATION, data.description)?.let {
 			addKdoc("%L", it)
 		}
 
@@ -37,7 +38,9 @@ class OperationUrlBuilder(
 
 		ParameterSpec.builder("includeCredentials", Types.BOOLEAN).apply {
 			defaultValue("%L", data.requireAuthentication)
-			addKdoc("%L", Strings.INCLUDE_CREDENTIALS_DESCRIPTION)
+			descriptionBuilder.build(DescriptionType.OPERATION_PARAMETER, Strings.INCLUDE_CREDENTIALS_DESCRIPTION)?.let {
+				addKdoc("%L", it)
+			}
 		}.build().let(::addParameter)
 
 		// Create parameter maps

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/DescriptionBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/extra/DescriptionBuilder.kt
@@ -1,26 +1,20 @@
 package org.jellyfin.openapi.builder.extra
 
-import org.jellyfin.openapi.builder.Builder
+import org.jellyfin.openapi.hooks.DescriptionHook
+import org.jellyfin.openapi.model.DescriptionType
 
-class DescriptionBuilder : Builder<String?, String?> {
-	private val replacements = mapOf(
-		// Replace CRLF with LF
-		Regex("""\r\n?""") to "\n",
-		// Replace <br /> elements with new line
-		Regex("""<br\s?/?>""") to "\n",
-		// Replace <seealso> elements with their value
-		Regex("""<seealso\s+cref="(.*?)"\s?/>""") to "`$1`",
-		Regex("""<seealso\s+cref="(.*?)"\s?>(.*?)</see>""") to "$2 (`$1`)",
-		// Replace <see> elements with their value
-		Regex("""<see\s+cref="(.*?)"\s?/>""") to "`$1`",
-		Regex("""<see\s+cref="(.*?)"\s?>(.*?)</see>""") to "$2 (`$1`)",
-	)
+class DescriptionBuilder(
+	private val descriptionsHooks: Collection<DescriptionHook>,
+) {
+	fun build(type: DescriptionType, description: String?): String? {
+		if (description == null) return null
 
-	override fun build(data: String?): String? {
-		if (data == null) return null
-
-		return replacements.entries.fold(data) { acc, (search, replace) ->
-			acc.replace(search, replace)
+		var modifiedDescription: String? = description
+		for (hook in descriptionsHooks) {
+			if (modifiedDescription == null) return null
+			modifiedDescription = hook.modify(type, modifiedDescription)
 		}
+
+		return modifiedDescription
 	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/EmptyModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/EmptyModelBuilder.kt
@@ -9,6 +9,7 @@ import org.jellyfin.openapi.builder.extra.DescriptionBuilder
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
+import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.EmptyApiModel
 import org.jellyfin.openapi.model.JellyFile
 
@@ -19,7 +20,7 @@ class EmptyModelBuilder(
 	override fun build(data: EmptyApiModel): JellyFile {
 		return TypeSpec.classBuilder(data.name.toPascalCase(from = CaseFormat.CAPITALIZED_CAMEL))
 			.apply {
-				descriptionBuilder.build(data.description)?.let {
+				descriptionBuilder.build(DescriptionType.MODEL, data.description)?.let {
 					addKdoc("%L", it)
 				}
 				if (data.deprecated) addAnnotation(deprecatedAnnotationSpecBuilder.build(Strings.DEPRECATED_CLASS))

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/EnumModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/EnumModelBuilder.kt
@@ -14,6 +14,7 @@ import org.jellyfin.openapi.builder.extra.DescriptionBuilder
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
+import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.EnumApiModel
 import org.jellyfin.openapi.model.JellyFile
 
@@ -51,7 +52,7 @@ class EnumModelBuilder(
 				}
 
 				// Header
-				descriptionBuilder.build(data.description)?.let {
+				descriptionBuilder.build(DescriptionType.MODEL, data.description)?.let {
 					addKdoc("%L", it)
 				}
 				if (data.deprecated) addAnnotation(deprecatedAnnotationSpecBuilder.build(Strings.DEPRECATED_CLASS))

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ObjectModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ObjectModelBuilder.kt
@@ -17,6 +17,7 @@ import org.jellyfin.openapi.builder.extra.defaultValue
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
+import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.JellyFile
 import org.jellyfin.openapi.model.ObjectApiModel
 
@@ -41,7 +42,7 @@ class ObjectModelBuilder(
 					.builder(property.name, property.type)
 					.initializer(property.name)
 					.apply {
-						descriptionBuilder.build(property.description)?.let {
+						descriptionBuilder.build(DescriptionType.MODEL_PROPERTY, property.description)?.let {
 							addKdoc("%L", it)
 						}
 
@@ -76,7 +77,7 @@ class ObjectModelBuilder(
 		return TypeSpec.classBuilder(data.name.toPascalCase(from = CaseFormat.CAPITALIZED_CAMEL))
 			.apply {
 				modifiers += KModifier.DATA
-				descriptionBuilder.build(data.description)?.let {
+				descriptionBuilder.build(DescriptionType.MODEL, data.description)?.let {
 					addKdoc("%L", it)
 				}
 				if (data.deprecated) addAnnotation(deprecatedAnnotationSpecBuilder.build(Strings.DEPRECATED_CLASS))

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/DescriptionHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/DescriptionHook.kt
@@ -1,0 +1,12 @@
+package org.jellyfin.openapi.hooks
+
+import org.jellyfin.openapi.model.DescriptionType
+
+interface DescriptionHook {
+	/**
+	 * Modify or drop a given description for API models and operations.
+	 *
+	 * @return The new description, null means removing the description.
+	 */
+	fun modify(type: DescriptionType, description: String): String?
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
@@ -5,7 +5,9 @@ import org.jellyfin.openapi.hooks.api.ClientLogOperationUrlHook
 import org.jellyfin.openapi.hooks.api.LargeOperationRequestModelHook
 import org.jellyfin.openapi.hooks.api.PlayStateServiceNameHook
 import org.jellyfin.openapi.hooks.model.DefaultUserIdHook
+import org.jellyfin.openapi.hooks.model.DotNetDescriptionHook
 import org.jellyfin.openapi.hooks.model.ImageMapsHook
+import org.jellyfin.openapi.hooks.model.SwashbuckleDescriptionHook
 import org.jellyfin.openapi.hooks.model.SyncPlayGroupUpdateHook
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -22,4 +24,7 @@ val hooksModule = module {
 	single { PlayStateServiceNameHook() } bind ServiceNameHook::class
 
 	single { DefaultUserIdHook() } bind DefaultValueHook::class
+
+	single { DotNetDescriptionHook() } bind DescriptionHook::class
+	single { SwashbuckleDescriptionHook() } bind DescriptionHook::class
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/DotNetDescriptionHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/DotNetDescriptionHook.kt
@@ -1,0 +1,19 @@
+package org.jellyfin.openapi.hooks.model
+
+import org.jellyfin.openapi.hooks.DescriptionHook
+import org.jellyfin.openapi.model.DescriptionType
+
+class DotNetDescriptionHook : DescriptionHook {
+	private companion object {
+		private val getsOrSetsRegex = Regex("""^(Gets or sets|Gets|Sets)\s+(.*)$""")
+	}
+
+	override fun modify(type: DescriptionType, description: String): String {
+		// Ignore API operations
+		if (type == DescriptionType.OPERATION) return description
+
+		return description.replace(getsOrSetsRegex) { result ->
+			result.groupValues[2].replaceFirstChar(Char::uppercase)
+		}
+	}
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/SwashbuckleDescriptionHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/SwashbuckleDescriptionHook.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.openapi.hooks.model
+
+import org.jellyfin.openapi.hooks.DescriptionHook
+import org.jellyfin.openapi.model.DescriptionType
+
+class SwashbuckleDescriptionHook : DescriptionHook {
+	private companion object {
+		private val replacements = mapOf(
+			// Replace CRLF with LF
+			Regex("""\r\n?""") to "\n",
+			// Replace <br /> elements with new line
+			Regex("""<br\s?/?>""") to "\n",
+			// Replace <seealso> elements with their value
+			Regex("""<seealso\s+cref="(.*?)"\s?/>""") to "`$1`",
+			Regex("""<seealso\s+cref="(.*?)"\s?>(.*?)</see>""") to "$2 (`$1`)",
+			// Replace <see> elements with their value
+			Regex("""<see\s+cref="(.*?)"\s?/>""") to "`$1`",
+			Regex("""<see\s+cref="(.*?)"\s?>(.*?)</see>""") to "$2 (`$1`)",
+		)
+	}
+
+	override fun modify(type: DescriptionType, description: String): String = replacements.entries
+		.fold(description) { acc, (search, replace) -> acc.replace(search, replace) }
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/DescriptionType.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/DescriptionType.kt
@@ -1,0 +1,8 @@
+package org.jellyfin.openapi.model
+
+enum class DescriptionType {
+	OPERATION,
+	OPERATION_PARAMETER,
+	MODEL,
+	MODEL_PROPERTY,
+}


### PR DESCRIPTION
The descriptions in the server always start with "Gets or sets", "Gets" or "Sets". Our models don't have setters so this doesn't make much sense.

This PR changes the existing DescriptionBuilder to use a new hook type that allows description modification. One hook contains the old replacements and one contains a new replacement for the above mentioned issue.