### PR TITLE
Remove linebreaks in AuthorizationHeaderBuilder.encodeParameterValue

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder.kt
@@ -5,9 +5,10 @@ import io.ktor.http.encodeURLParameter
 public object AuthorizationHeaderBuilder {
 	public const val AUTHORIZATION_SCHEME: String = "MediaBrowser"
 
-	public fun encodeParameterValue(raw: String): String = raw.encodeURLParameter(
-		spaceToPlus = true
-	)
+	public fun encodeParameterValue(raw: String): String = raw
+		.trim()
+		.replace(Regex("\\n"), " ")
+		.encodeURLParameter(spaceToPlus = true)
 
 	public fun buildParameter(key: String, value: String): String {
 		// Check for bad strings to prevent endless hours debugging why the server throws http 500 errors

--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilderTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilderTests.kt
@@ -17,6 +17,15 @@ class AuthorizationHeaderBuilderTests : FunSpec({
 		) { a, b -> AuthorizationHeaderBuilder.encodeParameterValue(a) shouldBe b }
 	}
 
+	test("encodeParameter removes line breaks") {
+		forAll(
+			row("with\nnewline", "with+newline"),
+			row("with trailing newline\n", "with+trailing+newline"),
+			row("\nwith prefix newline\n", "with+prefix+newline"),
+			row("\nwith\na\nlot\nof\nnewline\n", "with+a+lot+of+newline"),
+		) { a, b -> AuthorizationHeaderBuilder.encodeParameterValue(a) shouldBe b }
+	}
+
 	test("buildParameter creates a valid header with access token") {
 		AuthorizationHeaderBuilder.buildParameter("key", "val") shouldBe """key="val""""
 		AuthorizationHeaderBuilder.buildParameter("one", "two") shouldBe """one="two""""


### PR DESCRIPTION
Reported on Telegram/[Reddit](https://www.reddit.com/r/jellyfin/comments/ypcvwf/jellyfin_for_android_tv_crashing/). Caused app crashes when device name was used in legacy apiclient.

I don't think this necessarily fixes the issue because this changes the SDK only, but it's still good to escape newlines.