### PR TITLE
Use code-group in getting-started and v1.4 migration pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ java_*.hprof
 # Docs
 node_modules
 docs/.vitepress/dist
+docs/.vitepress/cache

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,33 +10,25 @@ platform.
 
 ![Latest version on Maven Central](https://img.shields.io/maven-central/v/org.jellyfin.sdk/jellyfin-core.svg)
 
-### Gradle with Kotlin DSL
+::: code-group
 
-```kotlin
+```kotlin [Gradle with Kotlin]
 implementation("org.jellyfin.sdk:jellyfin-core:$sdkVersion")
 ```
 
-<details>
-  <summary>Gradle with Groovy</summary>
+```groovy [Gradle with Groovy]
+implementation "org.jellyfin.sdk:jellyfin-core:$sdkVersion"
+```
 
-  ```groovy
-  implementation "org.jellyfin.sdk:jellyfin-core:$sdkVersion"
-   ```
+```xml [Maven]
+<dependency>
+  <groupId>org.jellyfin.sdk</groupId>
+  <artifactId>jellyfin-core</artifactId>
+  <version>$sdkVersion</version>
+</dependency>
+```
 
-</details>
-
-<details>
-  <summary>Maven</summary>
-
-  ```xml
-  <dependency>
-      <groupId>org.jellyfin.sdk</groupId>
-      <artifactId>jellyfin-core</artifactId>
-      <version>$sdkVersion</version>
-  </dependency>
-   ```
-
-</details>
+:::
 
 <details>
   <summary>Using SNAPSHOT versions</summary>

--- a/docs/migration/v1.4.md
+++ b/docs/migration/v1.4.md
@@ -11,9 +11,9 @@ replacing the parameters with a data class to hold all values instead.
 
 Here is an example for migrating a "getNextUp" API call from a parameter function to request model.
 
-### Parameter function
+::: code-group
 
-```kotlin
+```kotlin [Parameter function]
 val nextUp by api.tvShowsApi.getNextUp(
 	userId = api.userId,
 	imageTypeLimit = 1,
@@ -22,9 +22,7 @@ val nextUp by api.tvShowsApi.getNextUp(
 )
 ```
 
-### Request model
-
-```kotlin
+```kotlin [Request model]
 val nextUpQuery = GetNextUpRequest(
 	userId = api.userId,
 	imageTypeLimit = 1,
@@ -34,6 +32,8 @@ val nextUpQuery = GetNextUpRequest(
 
 val nextUp by api.tvShowsApi.getNextUp(nextUpQuery)
 ```
+
+:::
 
 Request models are data classes, which means the `copy()` function can be used to change values. Request models are
 available for all API calls that use five or more parameters. The parameter functions are still available. Both options


### PR DESCRIPTION
- Use code-group in getting-started and v1.4 migration pages
  Looks a lot better, see screenshots
- Add Vitepress cache to gitignore
  I think this dir was added in one of the recent updates


Before
![image](https://user-images.githubusercontent.com/2305178/208195014-fdc54a07-9a72-4a33-a9fe-d61701892c89.png)

After
![image](https://user-images.githubusercontent.com/2305178/208195024-493166ff-ad30-46c3-b0a3-76bc36f64ea6.png)
