### PR TITLE
Add extensions to Long, Int and Double to create Duration from ticks

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -17792,6 +17792,12 @@ public final class org/jellyfin/sdk/model/extensions/PairExtensionsKt {
 	public static final fun toXmlAttribute (Lkotlin/Pair;)Lorg/jellyfin/sdk/model/api/XmlAttribute;
 }
 
+public final class org/jellyfin/sdk/model/extensions/TicksExtensionsKt {
+	public static final fun getTicks (D)J
+	public static final fun getTicks (I)J
+	public static final fun getTicks (J)J
+}
+
 public final class org/jellyfin/sdk/model/serializer/DateTimeSerializer : kotlinx/serialization/KSerializer {
 	public fun <init> ()V
 	public fun <init> (Ljava/time/ZoneId;)V

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/extensions/TicksExtensions.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/extensions/TicksExtensions.kt
@@ -1,0 +1,22 @@
+@file:Suppress("MagicNumber")
+
+package org.jellyfin.sdk.model.extensions
+
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+/**
+ * Returns a [Duration] equal to this [Long] number of ticks.
+ */
+public inline val Long.ticks: Duration get() = times(100L).toDuration(DurationUnit.NANOSECONDS)
+
+/**
+ * Returns a [Duration] equal to this [Int] number of ticks.
+ */
+public inline val Int.ticks: Duration get() = times(100).toDuration(DurationUnit.NANOSECONDS)
+
+/**
+ * Returns a [Duration] equal to this [Double] number of ticks.
+ */
+public inline val Double.ticks: Duration get() = times(100.0).toDuration(DurationUnit.NANOSECONDS)


### PR DESCRIPTION
Right now we have multiple places in jellyfin-androidtv that need to convert ticks->duration. It makes sense to move this to the SDK so SDK users don't need to add their own utility function for this.