### PR TITLE
Add Duration.inWholeTicks to convert a Duration to ticks

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -17793,6 +17793,7 @@ public final class org/jellyfin/sdk/model/extensions/PairExtensionsKt {
 }
 
 public final class org/jellyfin/sdk/model/extensions/TicksExtensionsKt {
+	public static final fun getInWholeTicks-LRDsOJo (J)J
 	public static final fun getTicks (D)J
 	public static final fun getTicks (I)J
 	public static final fun getTicks (J)J

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/extensions/TicksExtensions.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/extensions/TicksExtensions.kt
@@ -20,3 +20,8 @@ public inline val Int.ticks: Duration get() = times(100).toDuration(DurationUnit
  * Returns a [Duration] equal to this [Double] number of ticks.
  */
 public inline val Double.ticks: Duration get() = times(100.0).toDuration(DurationUnit.NANOSECONDS)
+
+/**
+ * The value of this duration expressed as a [Long] number of ticks.
+ */
+public val Duration.inWholeTicks: Long get() = toLong(DurationUnit.NANOSECONDS).div(100L)


### PR DESCRIPTION
Follow up on #616, adds `inWholeTicks` to Duration.