### PR TITLE
Configure core-android publishing

### DIFF
--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -86,6 +86,12 @@ android {
 		abortOnError = false
 		sarifReport = true
 	}
+
+	publishing {
+		multipleVariants {
+			withSourcesJar()
+		}
+	}
 }
 
 enablePublishing {


### PR DESCRIPTION
Fixes compiler warning:

> WARNING:Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0. To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.
