### PR TITLE
Set name of Gradle root project

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+rootProject.name = "jellyfin-sdk-kotlin"
+
 // Core
 include(":jellyfin-core")
 include(":jellyfin-model")


### PR DESCRIPTION
Fixes build warning:

> Project accessors enabled, but root project name not explicitly set for 'jellyfin-sdk-kotlin'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.