### PR TITLE
Migrate to new Kotlin Multiplatform source set layout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 android.useAndroidX=true
+kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.incremental=true
 kotlin.mpp.stability.nowarn=true
 org.gradle.jvmargs=-Xmx2048m

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -65,8 +65,6 @@ kotlin {
 android {
 	compileSdk = 32
 
-	sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-
 	defaultConfig {
 		minSdk = 19
 		targetSdk = 32


### PR DESCRIPTION
Fixes compiler warning:

> w: Multiplatform/Android-V1-SourceSetLayout: Multiplatform/Android-V1-SourceSetLayout is deprecated. Use Multiplatform/Android-V2-SourceSetLayout instead. 
To enable Multiplatform/Android-V2-SourceSetLayout: put the following in your gradle.properties: 
kotlin.mpp.androidSourceSetLayoutVersion=2
>
> To suppress this warning: put the following in your gradle.properties:
kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true

There's not much to change because the changes mainly apply to Android test sourcesets which we don't have. The manifest location we used is now a default path though, so that's nice.

