### PR TITLE
Add command line option to disable hooks in openapi-generator

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/MainModule.kt
@@ -69,7 +69,7 @@ val mainModule = module {
 	single { DescriptionBuilder(getAll()) }
 
 	// CLI
-	single { MainCommand(getAll()) }
+	single { MainCommand(getAll(), getKoin()) }
 	single { GenerateCommand(get()) } bind CliktCommand::class
 	single { VerifyCommand(get()) } bind CliktCommand::class
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/cli/MainCommand.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/cli/MainCommand.kt
@@ -2,13 +2,25 @@ package org.jellyfin.openapi.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import org.jellyfin.openapi.hooks.hooksModule
+import org.koin.core.Koin
 
 class MainCommand(
 	commands: List<CliktCommand>,
+	private val koin: Koin,
 ) : CliktCommand() {
+	private val noHooks by option(
+		"--no-hooks",
+		help = "Disable all hooks"
+	).flag()
+
 	init {
 		subcommands(commands)
 	}
 
-	override fun run() = Unit
+	override fun run() {
+		if (noHooks) koin.unloadModules(listOf(hooksModule))
+	}
 }


### PR DESCRIPTION
The option disable all hooks by unloading the Koin hooks module