### PR TITLE
Extend organization Node.js Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
+		"github>jellyfin/.github//renovate-presets/nodejs",
 		"github>jellyfin/.github//renovate-presets/gradle",
 		":semanticCommitsDisabled"
 	]


### PR DESCRIPTION
This should add the `npm` label to the Vitepress PR's