### PR TITLE
Explicitly set Accept header in KtorClient

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1,5 +1,6 @@
 public abstract class org/jellyfin/sdk/api/client/ApiClient {
 	public static final field Companion Lorg/jellyfin/sdk/api/client/ApiClient$Companion;
+	public static final field HEADER_ACCEPT Ljava/lang/String;
 	public static final field QUERY_ACCESS_TOKEN Ljava/lang/String;
 	public fun <init> ()V
 	public fun createUrl (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Z)Ljava/lang/String;

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
@@ -16,6 +16,12 @@ public abstract class ApiClient {
 		 * true.
 		 */
 		public const val QUERY_ACCESS_TOKEN: String = "ApiKey"
+
+		/**
+		 * The recommended value for the accept header. It prefers JSON followed by octet stream and finally
+		 * everything. The "any MIME type" (* / *) is required for some endpoints in the server.
+		 */
+		public const val HEADER_ACCEPT: String = "application/json, application/octet-stream;q=0.9, */*;q=0.8"
 	}
 
 	/**

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/client/KtorClient.kt
@@ -78,6 +78,11 @@ public actual open class KtorClient actual constructor(
 				this.method = method.asKtorHttpMethod()
 
 				header(
+					key = HttpHeaders.Accept,
+					value = HEADER_ACCEPT,
+				)
+
+				header(
 					key = HttpHeaders.Authorization,
 					value = AuthorizationHeaderBuilder.buildHeader(
 						clientName = clientInfo.name,


### PR DESCRIPTION
Right now it was always set to `*/*`, which worked fine. But I wanted a constant so I can use the exact same value in Glide requests in jellyfin-androidtv.