### PR TITLE
Increase default socket timeout value to 30 seconds

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/HttpClientOptions.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/HttpClientOptions.kt
@@ -24,7 +24,7 @@ public data class HttpClientOptions(
 
 	/**
 	 * Timeout between receiving or writing messages in milliseconds.
-	 * Defaults to 10 seconds.
+	 * Defaults to 30 seconds.
 	 */
-	val socketTimeout: Long = 10_000,
+	val socketTimeout: Long = 30_000,
 )


### PR DESCRIPTION
Seeing a lot of users running on slow hardware getting hit by the 10 second timeout in the latest Android TV release, which migrated a bunch of stuff to the SDK. Increased the timeout to the 30 seconds that the old Java apiclient used. We'll need to revisit this number when the server database stuff is rewritten.