### PR TITLE
Downgrade AGP to IntelliJ compatible 7.4.0-beta02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-gradle = "7.4.2"
+android-gradle = "7.4.0-beta02"
 android-sdk = "33"
 androidx-annotation = "1.6.0"
 androidx-core = "1.9.0"


### PR DESCRIPTION
Current stable version of IntelliJ only supports 7.4.0-beta02 or lower. The next version (which will likely release in a few weeks) will support 7.4.2 so we can revert this PR when that happens.