### PR TITLE
Revert "Downgrade AGP to IntelliJ compatible 7.4.0-beta02"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-gradle = "7.4.0-beta02"
+android-gradle = "7.4.2"
 android-sdk = "33"
 androidx-annotation = "1.6.0"
 androidx-core = "1.9.0"


### PR DESCRIPTION
Reverts jellyfin/jellyfin-sdk-kotlin#698

IntelliJ 2023.1 is now available and supports AGP 7.4.1 >=