### PR TITLE
Migrate Android namespace to build file, remove deprecated target SDK

### DIFF
--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -63,11 +63,11 @@ kotlin {
 }
 
 android {
+	namespace = "org.jellyfin.sdk"
 	compileSdk = libs.versions.android.sdk.get().toInt()
 
 	defaultConfig {
 		minSdk = 19
-		targetSdk = libs.versions.android.sdk.get().toInt()
 		multiDexEnabled = true
 
 		consumerProguardFiles("proguard-rules.pro")

--- a/jellyfin-core/src/androidMain/AndroidManifest.xml
+++ b/jellyfin-core/src/androidMain/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="org.jellyfin.sdk">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
- Migrate Android namespace to build file

- Remove deprecated target SDK
  Android libraries don't use the value, property will be removed in AGP9