### PR TITLE
Add fromNameOrNull and fromName functions to generated enum models

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -406,6 +406,8 @@ public final class org/jellyfin/sdk/model/api/Architecture : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/Architecture$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Architecture;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Architecture;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1115,6 +1117,8 @@ public final class org/jellyfin/sdk/model/api/BaseItemKind : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/BaseItemKind$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/BaseItemKind;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/BaseItemKind;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1491,6 +1495,8 @@ public final class org/jellyfin/sdk/model/api/ChannelItemSortField : java/lang/E
 }
 
 public final class org/jellyfin/sdk/model/api/ChannelItemSortField$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelItemSortField;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1547,6 +1553,8 @@ public final class org/jellyfin/sdk/model/api/ChannelMediaContentType : java/lan
 }
 
 public final class org/jellyfin/sdk/model/api/ChannelMediaContentType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaContentType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1562,6 +1570,8 @@ public final class org/jellyfin/sdk/model/api/ChannelMediaType : java/lang/Enum 
 }
 
 public final class org/jellyfin/sdk/model/api/ChannelMediaType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelMediaType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1576,6 +1586,8 @@ public final class org/jellyfin/sdk/model/api/ChannelType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/ChannelType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ChannelType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1792,6 +1804,8 @@ public final class org/jellyfin/sdk/model/api/CodecType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/CodecType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CodecType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CodecType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1841,6 +1855,8 @@ public final class org/jellyfin/sdk/model/api/CollectionTypeOptions : java/lang/
 }
 
 public final class org/jellyfin/sdk/model/api/CollectionTypeOptions$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/CollectionTypeOptions;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2154,6 +2170,8 @@ public final class org/jellyfin/sdk/model/api/DayOfWeek : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/DayOfWeek$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayOfWeek;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayOfWeek;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2169,6 +2187,8 @@ public final class org/jellyfin/sdk/model/api/DayPattern : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/DayPattern$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayPattern;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DayPattern;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2549,6 +2569,8 @@ public final class org/jellyfin/sdk/model/api/DeviceProfileType : java/lang/Enum
 }
 
 public final class org/jellyfin/sdk/model/api/DeviceProfileType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DeviceProfileType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DeviceProfileType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2707,6 +2729,8 @@ public final class org/jellyfin/sdk/model/api/DlnaProfileType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/DlnaProfileType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2729,6 +2753,8 @@ public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek : java/lang/Enum 
 }
 
 public final class org/jellyfin/sdk/model/api/DynamicDayOfWeek$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/DynamicDayOfWeek;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2745,6 +2771,8 @@ public final class org/jellyfin/sdk/model/api/EmbeddedSubtitleOptions : java/lan
 }
 
 public final class org/jellyfin/sdk/model/api/EmbeddedSubtitleOptions$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/EmbeddedSubtitleOptions;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/EmbeddedSubtitleOptions;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2759,6 +2787,8 @@ public final class org/jellyfin/sdk/model/api/EncodingContext : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/EncodingContext$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/EncodingContext;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2954,6 +2984,8 @@ public final class org/jellyfin/sdk/model/api/ExternalIdMediaType : java/lang/En
 }
 
 public final class org/jellyfin/sdk/model/api/ExternalIdMediaType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3003,6 +3035,8 @@ public final class org/jellyfin/sdk/model/api/FFmpegLocation : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/FFmpegLocation$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FFmpegLocation;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FFmpegLocation;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3052,6 +3086,8 @@ public final class org/jellyfin/sdk/model/api/FileSystemEntryType : java/lang/En
 }
 
 public final class org/jellyfin/sdk/model/api/FileSystemEntryType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/FileSystemEntryType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3103,6 +3139,8 @@ public final class org/jellyfin/sdk/model/api/ForgotPasswordAction : java/lang/E
 }
 
 public final class org/jellyfin/sdk/model/api/ForgotPasswordAction$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ForgotPasswordAction;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3282,6 +3320,8 @@ public final class org/jellyfin/sdk/model/api/GeneralCommandType : java/lang/Enu
 }
 
 public final class org/jellyfin/sdk/model/api/GeneralCommandType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3415,6 +3455,8 @@ public final class org/jellyfin/sdk/model/api/GroupQueueMode : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/GroupQueueMode$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupQueueMode;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupQueueMode;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3430,6 +3472,8 @@ public final class org/jellyfin/sdk/model/api/GroupRepeatMode : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/GroupRepeatMode$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupRepeatMode;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3444,6 +3488,8 @@ public final class org/jellyfin/sdk/model/api/GroupShuffleMode : java/lang/Enum 
 }
 
 public final class org/jellyfin/sdk/model/api/GroupShuffleMode$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupShuffleMode;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3460,6 +3506,8 @@ public final class org/jellyfin/sdk/model/api/GroupStateType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/GroupStateType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupStateType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupStateType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3483,6 +3531,8 @@ public final class org/jellyfin/sdk/model/api/GroupUpdateType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/GroupUpdateType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupUpdateType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/GroupUpdateType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3532,6 +3582,8 @@ public final class org/jellyfin/sdk/model/api/HardwareEncodingType : java/lang/E
 }
 
 public final class org/jellyfin/sdk/model/api/HardwareEncodingType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3547,6 +3599,8 @@ public final class org/jellyfin/sdk/model/api/HeaderMatchType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/HeaderMatchType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/HeaderMatchType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/HeaderMatchType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3707,6 +3761,8 @@ public final class org/jellyfin/sdk/model/api/ImageFormat : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/ImageFormat$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3804,6 +3860,8 @@ public final class org/jellyfin/sdk/model/api/ImageOrientation : java/lang/Enum 
 }
 
 public final class org/jellyfin/sdk/model/api/ImageOrientation$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageOrientation;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageOrientation;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3849,6 +3907,8 @@ public final class org/jellyfin/sdk/model/api/ImageSavingConvention : java/lang/
 }
 
 public final class org/jellyfin/sdk/model/api/ImageSavingConvention$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageSavingConvention;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3874,6 +3934,8 @@ public final class org/jellyfin/sdk/model/api/ImageType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/ImageType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ImageType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3930,6 +3992,8 @@ public final class org/jellyfin/sdk/model/api/IsoType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/IsoType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/IsoType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/IsoType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4054,6 +4118,8 @@ public final class org/jellyfin/sdk/model/api/ItemFields : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/ItemFields$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFields;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFields;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4075,6 +4141,8 @@ public final class org/jellyfin/sdk/model/api/ItemFilter : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/ItemFilter$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFilter;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ItemFilter;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4120,6 +4188,8 @@ public final class org/jellyfin/sdk/model/api/KeepUntil : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/KeepUntil$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/KeepUntil;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/KeepUntil;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4586,6 +4656,8 @@ public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus : java/lang/En
 }
 
 public final class org/jellyfin/sdk/model/api/LiveTvServiceStatus$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LiveTvServiceStatus;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4635,6 +4707,8 @@ public final class org/jellyfin/sdk/model/api/LocationType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/LocationType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LocationType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LocationType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4690,6 +4764,8 @@ public final class org/jellyfin/sdk/model/api/LogLevel : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/LogLevel$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LogLevel;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/LogLevel;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4848,6 +4924,8 @@ public final class org/jellyfin/sdk/model/api/MediaProtocol : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/MediaProtocol$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaProtocol;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaProtocol;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -4975,6 +5053,8 @@ public final class org/jellyfin/sdk/model/api/MediaSourceType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/MediaSourceType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaSourceType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaSourceType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -5136,6 +5216,8 @@ public final class org/jellyfin/sdk/model/api/MediaStreamType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/MediaStreamType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -5355,6 +5437,8 @@ public final class org/jellyfin/sdk/model/api/MetadataField : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/MetadataField$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataField;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataField;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -5414,6 +5498,8 @@ public final class org/jellyfin/sdk/model/api/MetadataRefreshMode : java/lang/En
 }
 
 public final class org/jellyfin/sdk/model/api/MetadataRefreshMode$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/MetadataRefreshMode;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -5928,6 +6014,8 @@ public final class org/jellyfin/sdk/model/api/NotificationLevel : java/lang/Enum
 }
 
 public final class org/jellyfin/sdk/model/api/NotificationLevel$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/NotificationLevel;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/NotificationLevel;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -6454,6 +6542,8 @@ public final class org/jellyfin/sdk/model/api/PlayAccess : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/PlayAccess$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayAccess;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayAccess;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -6471,6 +6561,8 @@ public final class org/jellyfin/sdk/model/api/PlayCommand : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/PlayCommand$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayCommand;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayCommand;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -6486,6 +6578,8 @@ public final class org/jellyfin/sdk/model/api/PlayMethod : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/PlayMethod$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayMethod;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlayMethod;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -6578,6 +6672,8 @@ public final class org/jellyfin/sdk/model/api/PlaybackErrorCode : java/lang/Enum
 }
 
 public final class org/jellyfin/sdk/model/api/PlaybackErrorCode$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaybackErrorCode;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -6957,6 +7053,8 @@ public final class org/jellyfin/sdk/model/api/PlaystateCommand : java/lang/Enum 
 }
 
 public final class org/jellyfin/sdk/model/api/PlaystateCommand$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaystateCommand;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PlaystateCommand;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7054,6 +7152,8 @@ public final class org/jellyfin/sdk/model/api/PluginStatus : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/PluginStatus$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PluginStatus;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/PluginStatus;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7175,6 +7275,8 @@ public final class org/jellyfin/sdk/model/api/ProfileConditionType : java/lang/E
 }
 
 public final class org/jellyfin/sdk/model/api/ProfileConditionType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7211,6 +7313,8 @@ public final class org/jellyfin/sdk/model/api/ProfileConditionValue : java/lang/
 }
 
 public final class org/jellyfin/sdk/model/api/ProfileConditionValue$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileConditionValue;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7229,6 +7333,8 @@ public final class org/jellyfin/sdk/model/api/ProgramAudio : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/ProgramAudio$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProgramAudio;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProgramAudio;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7491,6 +7597,8 @@ public final class org/jellyfin/sdk/model/api/RatingType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/RatingType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RatingType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RatingType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7580,6 +7688,8 @@ public final class org/jellyfin/sdk/model/api/RecommendationType : java/lang/Enu
 }
 
 public final class org/jellyfin/sdk/model/api/RecommendationType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecommendationType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecommendationType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7599,6 +7709,8 @@ public final class org/jellyfin/sdk/model/api/RecordingStatus : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/RecordingStatus$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecordingStatus;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RecordingStatus;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7833,6 +7945,8 @@ public final class org/jellyfin/sdk/model/api/RepeatMode : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/RepeatMode$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RepeatMode;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/RepeatMode;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -7923,6 +8037,8 @@ public final class org/jellyfin/sdk/model/api/ScrollDirection : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/ScrollDirection$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ScrollDirection;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ScrollDirection;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -8125,6 +8241,8 @@ public final class org/jellyfin/sdk/model/api/SendCommandType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/SendCommandType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SendCommandType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SendCommandType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -8140,6 +8258,8 @@ public final class org/jellyfin/sdk/model/api/SendToUserType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/SendToUserType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SendToUserType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SendToUserType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -8240,6 +8360,8 @@ public final class org/jellyfin/sdk/model/api/SeriesStatus : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/SeriesStatus$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesStatus;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesStatus;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -8664,6 +8786,8 @@ public final class org/jellyfin/sdk/model/api/SessionMessageType : java/lang/Enu
 }
 
 public final class org/jellyfin/sdk/model/api/SessionMessageType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SessionMessageType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SessionMessageType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -8886,6 +9010,8 @@ public final class org/jellyfin/sdk/model/api/SortOrder : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/SortOrder$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SortOrder;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SortOrder;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9035,6 +9161,8 @@ public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod : java/lang
 }
 
 public final class org/jellyfin/sdk/model/api/SubtitleDeliveryMethod$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9098,6 +9226,8 @@ public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode : java/lang/E
 }
 
 public final class org/jellyfin/sdk/model/api/SubtitlePlaybackMode$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitlePlaybackMode;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9151,6 +9281,8 @@ public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType : java/lang
 }
 
 public final class org/jellyfin/sdk/model/api/SyncPlayUserAccessType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SyncPlayUserAccessType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9247,6 +9379,8 @@ public final class org/jellyfin/sdk/model/api/TaskCompletionStatus : java/lang/E
 }
 
 public final class org/jellyfin/sdk/model/api/TaskCompletionStatus$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskCompletionStatus;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9354,6 +9488,8 @@ public final class org/jellyfin/sdk/model/api/TaskState : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/TaskState$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskState;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TaskState;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9702,6 +9838,8 @@ public final class org/jellyfin/sdk/model/api/TranscodeReason : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/TranscodeReason$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeReason;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeReason;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9716,6 +9854,8 @@ public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo : java/lang/Enum
 }
 
 public final class org/jellyfin/sdk/model/api/TranscodeSeekInfo$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9845,6 +9985,8 @@ public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp : java/la
 }
 
 public final class org/jellyfin/sdk/model/api/TransportStreamTimestamp$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/TransportStreamTimestamp;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -9994,6 +10136,8 @@ public final class org/jellyfin/sdk/model/api/UnratedItem : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/UnratedItem$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/UnratedItem;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/UnratedItem;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -10560,6 +10704,8 @@ public final class org/jellyfin/sdk/model/api/Video3dFormat : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/Video3dFormat$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Video3dFormat;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/Video3dFormat;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -10576,6 +10722,8 @@ public final class org/jellyfin/sdk/model/api/VideoType : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/model/api/VideoType$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/VideoType;
+	public final fun fromNameOrNull (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/VideoType;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/Architecture.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/Architecture.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -28,4 +29,19 @@ public enum class Architecture(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): Architecture? = when (serialName) {
+			"X86" -> X86
+			"X64" -> X64
+			"Arm" -> ARM
+			"Arm64" -> ARM_64
+			"Wasm" -> WASM
+			"S390x" -> S39_0X
+			else -> null
+		}
+
+		public fun fromName(serialName: String): Architecture =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemKind.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/BaseItemKind.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -93,4 +94,50 @@ public enum class BaseItemKind(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): BaseItemKind? = when (serialName) {
+			"AggregateFolder" -> AGGREGATE_FOLDER
+			"Audio" -> AUDIO
+			"AudioBook" -> AUDIO_BOOK
+			"BasePluginFolder" -> BASE_PLUGIN_FOLDER
+			"Book" -> BOOK
+			"BoxSet" -> BOX_SET
+			"Channel" -> CHANNEL
+			"ChannelFolderItem" -> CHANNEL_FOLDER_ITEM
+			"CollectionFolder" -> COLLECTION_FOLDER
+			"Episode" -> EPISODE
+			"Folder" -> FOLDER
+			"Genre" -> GENRE
+			"ManualPlaylistsFolder" -> MANUAL_PLAYLISTS_FOLDER
+			"Movie" -> MOVIE
+			"LiveTvChannel" -> LIVE_TV_CHANNEL
+			"LiveTvProgram" -> LIVE_TV_PROGRAM
+			"MusicAlbum" -> MUSIC_ALBUM
+			"MusicArtist" -> MUSIC_ARTIST
+			"MusicGenre" -> MUSIC_GENRE
+			"MusicVideo" -> MUSIC_VIDEO
+			"Person" -> PERSON
+			"Photo" -> PHOTO
+			"PhotoAlbum" -> PHOTO_ALBUM
+			"Playlist" -> PLAYLIST
+			"PlaylistsFolder" -> PLAYLISTS_FOLDER
+			"Program" -> PROGRAM
+			"Recording" -> RECORDING
+			"Season" -> SEASON
+			"Series" -> SERIES
+			"Studio" -> STUDIO
+			"Trailer" -> TRAILER
+			"TvChannel" -> TV_CHANNEL
+			"TvProgram" -> TV_PROGRAM
+			"UserRootFolder" -> USER_ROOT_FOLDER
+			"UserView" -> USER_VIEW
+			"Video" -> VIDEO
+			"Year" -> YEAR
+			else -> null
+		}
+
+		public fun fromName(serialName: String): BaseItemKind =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelItemSortField.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelItemSortField.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -30,4 +31,20 @@ public enum class ChannelItemSortField(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ChannelItemSortField? = when (serialName) {
+			"Name" -> NAME
+			"CommunityRating" -> COMMUNITY_RATING
+			"PremiereDate" -> PREMIERE_DATE
+			"DateCreated" -> DATE_CREATED
+			"Runtime" -> RUNTIME
+			"PlayCount" -> PLAY_COUNT
+			"CommunityPlayCount" -> COMMUNITY_PLAY_COUNT
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ChannelItemSortField =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaContentType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaContentType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -32,4 +33,21 @@ public enum class ChannelMediaContentType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ChannelMediaContentType? = when (serialName) {
+			"Clip" -> CLIP
+			"Podcast" -> PODCAST
+			"Trailer" -> TRAILER
+			"Movie" -> MOVIE
+			"Episode" -> EPISODE
+			"Song" -> SONG
+			"MovieExtra" -> MOVIE_EXTRA
+			"TvExtra" -> TV_EXTRA
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ChannelMediaContentType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelMediaType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class ChannelMediaType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ChannelMediaType? = when (serialName) {
+			"Audio" -> AUDIO
+			"Video" -> VIDEO
+			"Photo" -> PHOTO
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ChannelMediaType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ChannelType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,4 +24,15 @@ public enum class ChannelType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ChannelType? = when (serialName) {
+			"TV" -> TV
+			"Radio" -> RADIO
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ChannelType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CodecType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CodecType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class CodecType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): CodecType? = when (serialName) {
+			"Video" -> VIDEO
+			"VideoAudio" -> VIDEO_AUDIO
+			"Audio" -> AUDIO
+			else -> null
+		}
+
+		public fun fromName(serialName: String): CodecType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CollectionTypeOptions.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/CollectionTypeOptions.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -32,4 +33,21 @@ public enum class CollectionTypeOptions(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): CollectionTypeOptions? = when (serialName) {
+			"Movies" -> MOVIES
+			"TvShows" -> TV_SHOWS
+			"Music" -> MUSIC
+			"MusicVideos" -> MUSIC_VIDEOS
+			"HomeVideos" -> HOME_VIDEOS
+			"BoxSets" -> BOX_SETS
+			"Books" -> BOOKS
+			"Mixed" -> MIXED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): CollectionTypeOptions =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DayOfWeek.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DayOfWeek.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -30,4 +31,20 @@ public enum class DayOfWeek(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): DayOfWeek? = when (serialName) {
+			"Sunday" -> SUNDAY
+			"Monday" -> MONDAY
+			"Tuesday" -> TUESDAY
+			"Wednesday" -> WEDNESDAY
+			"Thursday" -> THURSDAY
+			"Friday" -> FRIDAY
+			"Saturday" -> SATURDAY
+			else -> null
+		}
+
+		public fun fromName(serialName: String): DayOfWeek =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DayPattern.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DayPattern.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class DayPattern(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): DayPattern? = when (serialName) {
+			"Daily" -> DAILY
+			"Weekdays" -> WEEKDAYS
+			"Weekends" -> WEEKENDS
+			else -> null
+		}
+
+		public fun fromName(serialName: String): DayPattern =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfileType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DeviceProfileType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,15 @@ public enum class DeviceProfileType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): DeviceProfileType? = when (serialName) {
+			"System" -> SYSTEM
+			"User" -> USER
+			else -> null
+		}
+
+		public fun fromName(serialName: String): DeviceProfileType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DlnaProfileType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DlnaProfileType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -24,4 +25,17 @@ public enum class DlnaProfileType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): DlnaProfileType? = when (serialName) {
+			"Audio" -> AUDIO
+			"Video" -> VIDEO
+			"Photo" -> PHOTO
+			"Subtitle" -> SUBTITLE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): DlnaProfileType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DynamicDayOfWeek.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DynamicDayOfWeek.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -39,4 +40,23 @@ public enum class DynamicDayOfWeek(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): DynamicDayOfWeek? = when (serialName) {
+			"Sunday" -> SUNDAY
+			"Monday" -> MONDAY
+			"Tuesday" -> TUESDAY
+			"Wednesday" -> WEDNESDAY
+			"Thursday" -> THURSDAY
+			"Friday" -> FRIDAY
+			"Saturday" -> SATURDAY
+			"Everyday" -> EVERYDAY
+			"Weekday" -> WEEKDAY
+			"Weekend" -> WEEKEND
+			else -> null
+		}
+
+		public fun fromName(serialName: String): DynamicDayOfWeek =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/EmbeddedSubtitleOptions.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/EmbeddedSubtitleOptions.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class EmbeddedSubtitleOptions(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): EmbeddedSubtitleOptions? = when (serialName) {
+			"AllowAll" -> ALLOW_ALL
+			"AllowText" -> ALLOW_TEXT
+			"AllowImage" -> ALLOW_IMAGE
+			"AllowNone" -> ALLOW_NONE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): EmbeddedSubtitleOptions =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/EncodingContext.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/EncodingContext.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,15 @@ public enum class EncodingContext(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): EncodingContext? = when (serialName) {
+			"Streaming" -> STREAMING
+			"Static" -> STATIC
+			else -> null
+		}
+
+		public fun fromName(serialName: String): EncodingContext =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdMediaType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdMediaType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -43,4 +44,25 @@ public enum class ExternalIdMediaType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ExternalIdMediaType? = when (serialName) {
+			"Album" -> ALBUM
+			"AlbumArtist" -> ALBUM_ARTIST
+			"Artist" -> ARTIST
+			"BoxSet" -> BOX_SET
+			"Episode" -> EPISODE
+			"Movie" -> MOVIE
+			"OtherArtist" -> OTHER_ARTIST
+			"Person" -> PERSON
+			"ReleaseGroup" -> RELEASE_GROUP
+			"Season" -> SEASON
+			"Series" -> SERIES
+			"Track" -> TRACK
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ExternalIdMediaType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FFmpegLocation.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FFmpegLocation.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class FFmpegLocation(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): FFmpegLocation? = when (serialName) {
+			"NotFound" -> NOT_FOUND
+			"SetByArgument" -> SET_BY_ARGUMENT
+			"Custom" -> CUSTOM
+			"System" -> SYSTEM
+			else -> null
+		}
+
+		public fun fromName(serialName: String): FFmpegLocation =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FileSystemEntryType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/FileSystemEntryType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class FileSystemEntryType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): FileSystemEntryType? = when (serialName) {
+			"File" -> FILE
+			"Directory" -> DIRECTORY
+			"NetworkComputer" -> NETWORK_COMPUTER
+			"NetworkShare" -> NETWORK_SHARE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): FileSystemEntryType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordAction.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ForgotPasswordAction.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class ForgotPasswordAction(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ForgotPasswordAction? = when (serialName) {
+			"ContactAdmin" -> CONTACT_ADMIN
+			"PinCode" -> PIN_CODE
+			"InNetworkRequired" -> IN_NETWORK_REQUIRED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ForgotPasswordAction =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GeneralCommandType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GeneralCommandType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -103,4 +104,55 @@ public enum class GeneralCommandType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): GeneralCommandType? = when (serialName) {
+			"MoveUp" -> MOVE_UP
+			"MoveDown" -> MOVE_DOWN
+			"MoveLeft" -> MOVE_LEFT
+			"MoveRight" -> MOVE_RIGHT
+			"PageUp" -> PAGE_UP
+			"PageDown" -> PAGE_DOWN
+			"PreviousLetter" -> PREVIOUS_LETTER
+			"NextLetter" -> NEXT_LETTER
+			"ToggleOsd" -> TOGGLE_OSD
+			"ToggleContextMenu" -> TOGGLE_CONTEXT_MENU
+			"Select" -> SELECT
+			"Back" -> BACK
+			"TakeScreenshot" -> TAKE_SCREENSHOT
+			"SendKey" -> SEND_KEY
+			"SendString" -> SEND_STRING
+			"GoHome" -> GO_HOME
+			"GoToSettings" -> GO_TO_SETTINGS
+			"VolumeUp" -> VOLUME_UP
+			"VolumeDown" -> VOLUME_DOWN
+			"Mute" -> MUTE
+			"Unmute" -> UNMUTE
+			"ToggleMute" -> TOGGLE_MUTE
+			"SetVolume" -> SET_VOLUME
+			"SetAudioStreamIndex" -> SET_AUDIO_STREAM_INDEX
+			"SetSubtitleStreamIndex" -> SET_SUBTITLE_STREAM_INDEX
+			"ToggleFullscreen" -> TOGGLE_FULLSCREEN
+			"DisplayContent" -> DISPLAY_CONTENT
+			"GoToSearch" -> GO_TO_SEARCH
+			"DisplayMessage" -> DISPLAY_MESSAGE
+			"SetRepeatMode" -> SET_REPEAT_MODE
+			"ChannelUp" -> CHANNEL_UP
+			"ChannelDown" -> CHANNEL_DOWN
+			"Guide" -> GUIDE
+			"ToggleStats" -> TOGGLE_STATS
+			"PlayMediaSource" -> PLAY_MEDIA_SOURCE
+			"PlayTrailers" -> PLAY_TRAILERS
+			"SetShuffleQueue" -> SET_SHUFFLE_QUEUE
+			"PlayState" -> PLAY_STATE
+			"PlayNext" -> PLAY_NEXT
+			"ToggleOsdMenu" -> TOGGLE_OSD_MENU
+			"Play" -> PLAY
+			"SetMaxStreamingBitrate" -> SET_MAX_STREAMING_BITRATE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): GeneralCommandType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupQueueMode.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupQueueMode.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,4 +24,15 @@ public enum class GroupQueueMode(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): GroupQueueMode? = when (serialName) {
+			"Queue" -> QUEUE
+			"QueueNext" -> QUEUE_NEXT
+			else -> null
+		}
+
+		public fun fromName(serialName: String): GroupQueueMode =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupRepeatMode.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupRepeatMode.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -25,4 +26,16 @@ public enum class GroupRepeatMode(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): GroupRepeatMode? = when (serialName) {
+			"RepeatOne" -> REPEAT_ONE
+			"RepeatAll" -> REPEAT_ALL
+			"RepeatNone" -> REPEAT_NONE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): GroupRepeatMode =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupShuffleMode.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupShuffleMode.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,4 +24,15 @@ public enum class GroupShuffleMode(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): GroupShuffleMode? = when (serialName) {
+			"Sorted" -> SORTED
+			"Shuffle" -> SHUFFLE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): GroupShuffleMode =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupStateType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupStateType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class GroupStateType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): GroupStateType? = when (serialName) {
+			"Idle" -> IDLE
+			"Waiting" -> WAITING
+			"Paused" -> PAUSED
+			"Playing" -> PLAYING
+			else -> null
+		}
+
+		public fun fromName(serialName: String): GroupStateType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupUpdateType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GroupUpdateType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -41,4 +42,24 @@ public enum class GroupUpdateType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): GroupUpdateType? = when (serialName) {
+			"UserJoined" -> USER_JOINED
+			"UserLeft" -> USER_LEFT
+			"GroupJoined" -> GROUP_JOINED
+			"GroupLeft" -> GROUP_LEFT
+			"StateUpdate" -> STATE_UPDATE
+			"PlayQueue" -> PLAY_QUEUE
+			"NotInGroup" -> NOT_IN_GROUP
+			"GroupDoesNotExist" -> GROUP_DOES_NOT_EXIST
+			"CreateGroupDenied" -> CREATE_GROUP_DENIED
+			"JoinGroupDenied" -> JOIN_GROUP_DENIED
+			"LibraryAccessDenied" -> LIBRARY_ACCESS_DENIED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): GroupUpdateType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/HardwareEncodingType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/HardwareEncodingType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -31,4 +32,19 @@ public enum class HardwareEncodingType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): HardwareEncodingType? = when (serialName) {
+			"AMF" -> AMF
+			"QSV" -> QSV
+			"NVENC" -> NVENC
+			"V4L2M2M" -> V4L2M2M
+			"VAAPI" -> VAAPI
+			"VideoToolBox" -> VIDEO_TOOL_BOX
+			else -> null
+		}
+
+		public fun fromName(serialName: String): HardwareEncodingType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/HeaderMatchType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/HeaderMatchType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class HeaderMatchType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): HeaderMatchType? = when (serialName) {
+			"Equals" -> EQUALS
+			"Regex" -> REGEX
+			"Substring" -> SUBSTRING
+			else -> null
+		}
+
+		public fun fromName(serialName: String): HeaderMatchType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageFormat.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageFormat.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,4 +30,18 @@ public enum class ImageFormat(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ImageFormat? = when (serialName) {
+			"Bmp" -> BMP
+			"Gif" -> GIF
+			"Jpg" -> JPG
+			"Png" -> PNG
+			"Webp" -> WEBP
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ImageFormat =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageOrientation.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageOrientation.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -32,4 +33,21 @@ public enum class ImageOrientation(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ImageOrientation? = when (serialName) {
+			"TopLeft" -> TOP_LEFT
+			"TopRight" -> TOP_RIGHT
+			"BottomRight" -> BOTTOM_RIGHT
+			"BottomLeft" -> BOTTOM_LEFT
+			"LeftTop" -> LEFT_TOP
+			"RightTop" -> RIGHT_TOP
+			"RightBottom" -> RIGHT_BOTTOM
+			"LeftBottom" -> LEFT_BOTTOM
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ImageOrientation =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageSavingConvention.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageSavingConvention.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,15 @@ public enum class ImageSavingConvention(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ImageSavingConvention? = when (serialName) {
+			"Legacy" -> LEGACY
+			"Compatible" -> COMPATIBLE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ImageSavingConvention =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -45,4 +46,26 @@ public enum class ImageType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ImageType? = when (serialName) {
+			"Primary" -> PRIMARY
+			"Art" -> ART
+			"Backdrop" -> BACKDROP
+			"Banner" -> BANNER
+			"Logo" -> LOGO
+			"Thumb" -> THUMB
+			"Disc" -> DISC
+			"Box" -> BOX
+			"Screenshot" -> SCREENSHOT
+			"Menu" -> MENU
+			"Chapter" -> CHAPTER
+			"BoxRear" -> BOX_REAR
+			"Profile" -> PROFILE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ImageType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/IsoType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/IsoType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,4 +24,15 @@ public enum class IsoType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): IsoType? = when (serialName) {
+			"Dvd" -> DVD
+			"BluRay" -> BLU_RAY
+			else -> null
+		}
+
+		public fun fromName(serialName: String): IsoType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemFields.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemFields.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -141,4 +142,74 @@ public enum class ItemFields(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ItemFields? = when (serialName) {
+			"AirTime" -> AIR_TIME
+			"CanDelete" -> CAN_DELETE
+			"CanDownload" -> CAN_DOWNLOAD
+			"ChannelInfo" -> CHANNEL_INFO
+			"Chapters" -> CHAPTERS
+			"ChildCount" -> CHILD_COUNT
+			"CumulativeRunTimeTicks" -> CUMULATIVE_RUN_TIME_TICKS
+			"CustomRating" -> CUSTOM_RATING
+			"DateCreated" -> DATE_CREATED
+			"DateLastMediaAdded" -> DATE_LAST_MEDIA_ADDED
+			"DisplayPreferencesId" -> DISPLAY_PREFERENCES_ID
+			"Etag" -> ETAG
+			"ExternalUrls" -> EXTERNAL_URLS
+			"Genres" -> GENRES
+			"HomePageUrl" -> HOME_PAGE_URL
+			"ItemCounts" -> ITEM_COUNTS
+			"MediaSourceCount" -> MEDIA_SOURCE_COUNT
+			"MediaSources" -> MEDIA_SOURCES
+			"OriginalTitle" -> ORIGINAL_TITLE
+			"Overview" -> OVERVIEW
+			"ParentId" -> PARENT_ID
+			"Path" -> PATH
+			"People" -> PEOPLE
+			"PlayAccess" -> PLAY_ACCESS
+			"ProductionLocations" -> PRODUCTION_LOCATIONS
+			"ProviderIds" -> PROVIDER_IDS
+			"PrimaryImageAspectRatio" -> PRIMARY_IMAGE_ASPECT_RATIO
+			"RecursiveItemCount" -> RECURSIVE_ITEM_COUNT
+			"Settings" -> SETTINGS
+			"ScreenshotImageTags" -> SCREENSHOT_IMAGE_TAGS
+			"SeriesPrimaryImage" -> SERIES_PRIMARY_IMAGE
+			"SeriesStudio" -> SERIES_STUDIO
+			"SortName" -> SORT_NAME
+			"SpecialEpisodeNumbers" -> SPECIAL_EPISODE_NUMBERS
+			"Studios" -> STUDIOS
+			"BasicSyncInfo" -> BASIC_SYNC_INFO
+			"SyncInfo" -> SYNC_INFO
+			"Taglines" -> TAGLINES
+			"Tags" -> TAGS
+			"RemoteTrailers" -> REMOTE_TRAILERS
+			"MediaStreams" -> MEDIA_STREAMS
+			"SeasonUserData" -> SEASON_USER_DATA
+			"ServiceName" -> SERVICE_NAME
+			"ThemeSongIds" -> THEME_SONG_IDS
+			"ThemeVideoIds" -> THEME_VIDEO_IDS
+			"ExternalEtag" -> EXTERNAL_ETAG
+			"PresentationUniqueKey" -> PRESENTATION_UNIQUE_KEY
+			"InheritedParentalRatingValue" -> INHERITED_PARENTAL_RATING_VALUE
+			"ExternalSeriesId" -> EXTERNAL_SERIES_ID
+			"SeriesPresentationUniqueKey" -> SERIES_PRESENTATION_UNIQUE_KEY
+			"DateLastRefreshed" -> DATE_LAST_REFRESHED
+			"DateLastSaved" -> DATE_LAST_SAVED
+			"RefreshState" -> REFRESH_STATE
+			"ChannelImage" -> CHANNEL_IMAGE
+			"EnableMediaSourceDisplay" -> ENABLE_MEDIA_SOURCE_DISPLAY
+			"Width" -> WIDTH
+			"Height" -> HEIGHT
+			"ExtraIds" -> EXTRA_IDS
+			"LocalTrailerCount" -> LOCAL_TRAILER_COUNT
+			"IsHD" -> IS_HD
+			"SpecialFeatureCount" -> SPECIAL_FEATURE_COUNT
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ItemFields =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemFilter.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemFilter.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -37,4 +38,22 @@ public enum class ItemFilter(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ItemFilter? = when (serialName) {
+			"IsFolder" -> IS_FOLDER
+			"IsNotFolder" -> IS_NOT_FOLDER
+			"IsUnplayed" -> IS_UNPLAYED
+			"IsPlayed" -> IS_PLAYED
+			"IsFavorite" -> IS_FAVORITE
+			"IsResumable" -> IS_RESUMABLE
+			"Likes" -> LIKES
+			"Dislikes" -> DISLIKES
+			"IsFavoriteOrLikes" -> IS_FAVORITE_OR_LIKES
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ItemFilter =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/KeepUntil.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/KeepUntil.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -24,4 +25,17 @@ public enum class KeepUntil(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): KeepUntil? = when (serialName) {
+			"UntilDeleted" -> UNTIL_DELETED
+			"UntilSpaceNeeded" -> UNTIL_SPACE_NEEDED
+			"UntilWatched" -> UNTIL_WATCHED
+			"UntilDate" -> UNTIL_DATE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): KeepUntil =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvServiceStatus.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LiveTvServiceStatus.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,15 @@ public enum class LiveTvServiceStatus(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): LiveTvServiceStatus? = when (serialName) {
+			"Ok" -> OK
+			"Unavailable" -> UNAVAILABLE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): LiveTvServiceStatus =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LocationType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LocationType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class LocationType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): LocationType? = when (serialName) {
+			"FileSystem" -> FILE_SYSTEM
+			"Remote" -> REMOTE
+			"Virtual" -> VIRTUAL
+			"Offline" -> OFFLINE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): LocationType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LogLevel.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/LogLevel.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -30,4 +31,20 @@ public enum class LogLevel(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): LogLevel? = when (serialName) {
+			"Trace" -> TRACE
+			"Debug" -> DEBUG
+			"Information" -> INFORMATION
+			"Warning" -> WARNING
+			"Error" -> ERROR
+			"Critical" -> CRITICAL
+			"None" -> NONE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): LogLevel =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaProtocol.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaProtocol.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -30,4 +31,20 @@ public enum class MediaProtocol(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): MediaProtocol? = when (serialName) {
+			"File" -> FILE
+			"Http" -> HTTP
+			"Rtmp" -> RTMP
+			"Rtsp" -> RTSP
+			"Udp" -> UDP
+			"Rtp" -> RTP
+			"Ftp" -> FTP
+			else -> null
+		}
+
+		public fun fromName(serialName: String): MediaProtocol =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaSourceType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaSourceType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class MediaSourceType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): MediaSourceType? = when (serialName) {
+			"Default" -> DEFAULT
+			"Grouping" -> GROUPING
+			"Placeholder" -> PLACEHOLDER
+			else -> null
+		}
+
+		public fun fromName(serialName: String): MediaSourceType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaStreamType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaStreamType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,4 +30,18 @@ public enum class MediaStreamType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): MediaStreamType? = when (serialName) {
+			"Audio" -> AUDIO
+			"Video" -> VIDEO
+			"Subtitle" -> SUBTITLE
+			"EmbeddedImage" -> EMBEDDED_IMAGE
+			"Data" -> DATA
+			else -> null
+		}
+
+		public fun fromName(serialName: String): MediaStreamType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MetadataField.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MetadataField.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -37,4 +38,22 @@ public enum class MetadataField(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): MetadataField? = when (serialName) {
+			"Cast" -> CAST
+			"Genres" -> GENRES
+			"ProductionLocations" -> PRODUCTION_LOCATIONS
+			"Studios" -> STUDIOS
+			"Tags" -> TAGS
+			"Name" -> NAME
+			"Overview" -> OVERVIEW
+			"Runtime" -> RUNTIME
+			"OfficialRating" -> OFFICIAL_RATING
+			else -> null
+		}
+
+		public fun fromName(serialName: String): MetadataField =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MetadataRefreshMode.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MetadataRefreshMode.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -24,4 +25,17 @@ public enum class MetadataRefreshMode(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): MetadataRefreshMode? = when (serialName) {
+			"None" -> NONE
+			"ValidationOnly" -> VALIDATION_ONLY
+			"Default" -> DEFAULT
+			"FullRefresh" -> FULL_REFRESH
+			else -> null
+		}
+
+		public fun fromName(serialName: String): MetadataRefreshMode =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationLevel.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/NotificationLevel.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class NotificationLevel(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): NotificationLevel? = when (serialName) {
+			"Normal" -> NORMAL
+			"Warning" -> WARNING
+			"Error" -> ERROR
+			else -> null
+		}
+
+		public fun fromName(serialName: String): NotificationLevel =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayAccess.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayAccess.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,15 @@ public enum class PlayAccess(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): PlayAccess? = when (serialName) {
+			"Full" -> FULL
+			"None" -> NONE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): PlayAccess =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayCommand.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayCommand.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,4 +30,18 @@ public enum class PlayCommand(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): PlayCommand? = when (serialName) {
+			"PlayNow" -> PLAY_NOW
+			"PlayNext" -> PLAY_NEXT
+			"PlayLast" -> PLAY_LAST
+			"PlayInstantMix" -> PLAY_INSTANT_MIX
+			"PlayShuffle" -> PLAY_SHUFFLE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): PlayCommand =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayMethod.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlayMethod.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class PlayMethod(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): PlayMethod? = when (serialName) {
+			"Transcode" -> TRANSCODE
+			"DirectStream" -> DIRECT_STREAM
+			"DirectPlay" -> DIRECT_PLAY
+			else -> null
+		}
+
+		public fun fromName(serialName: String): PlayMethod =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackErrorCode.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaybackErrorCode.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class PlaybackErrorCode(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): PlaybackErrorCode? = when (serialName) {
+			"NotAllowed" -> NOT_ALLOWED
+			"NoCompatibleStream" -> NO_COMPATIBLE_STREAM
+			"RateLimitExceeded" -> RATE_LIMIT_EXCEEDED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): PlaybackErrorCode =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaystateCommand.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PlaystateCommand.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -37,4 +38,22 @@ public enum class PlaystateCommand(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): PlaystateCommand? = when (serialName) {
+			"Stop" -> STOP
+			"Pause" -> PAUSE
+			"Unpause" -> UNPAUSE
+			"NextTrack" -> NEXT_TRACK
+			"PreviousTrack" -> PREVIOUS_TRACK
+			"Seek" -> SEEK
+			"Rewind" -> REWIND
+			"FastForward" -> FAST_FORWARD
+			"PlayPause" -> PLAY_PAUSE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): PlaystateCommand =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PluginStatus.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/PluginStatus.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -33,4 +34,20 @@ public enum class PluginStatus(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): PluginStatus? = when (serialName) {
+			"Active" -> ACTIVE
+			"Restart" -> RESTART
+			"Deleted" -> DELETED
+			"Superceded" -> SUPERCEDED
+			"Malfunctioned" -> MALFUNCTIONED
+			"NotSupported" -> NOT_SUPPORTED
+			"Disabled" -> DISABLED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): PluginStatus =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -26,4 +27,18 @@ public enum class ProfileConditionType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ProfileConditionType? = when (serialName) {
+			"Equals" -> EQUALS
+			"NotEquals" -> NOT_EQUALS
+			"LessThanEqual" -> LESS_THAN_EQUAL
+			"GreaterThanEqual" -> GREATER_THAN_EQUAL
+			"EqualsAny" -> EQUALS_ANY
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ProfileConditionType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionValue.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ProfileConditionValue.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -64,4 +65,37 @@ public enum class ProfileConditionValue(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ProfileConditionValue? = when (serialName) {
+			"AudioChannels" -> AUDIO_CHANNELS
+			"AudioBitrate" -> AUDIO_BITRATE
+			"AudioProfile" -> AUDIO_PROFILE
+			"Width" -> WIDTH
+			"Height" -> HEIGHT
+			"Has64BitOffsets" -> HAS_64_BIT_OFFSETS
+			"PacketLength" -> PACKET_LENGTH
+			"VideoBitDepth" -> VIDEO_BIT_DEPTH
+			"VideoBitrate" -> VIDEO_BITRATE
+			"VideoFramerate" -> VIDEO_FRAMERATE
+			"VideoLevel" -> VIDEO_LEVEL
+			"VideoProfile" -> VIDEO_PROFILE
+			"VideoTimestamp" -> VIDEO_TIMESTAMP
+			"IsAnamorphic" -> IS_ANAMORPHIC
+			"RefFrames" -> REF_FRAMES
+			"NumAudioStreams" -> NUM_AUDIO_STREAMS
+			"NumVideoStreams" -> NUM_VIDEO_STREAMS
+			"IsSecondaryAudio" -> IS_SECONDARY_AUDIO
+			"VideoCodecTag" -> VIDEO_CODEC_TAG
+			"IsAvc" -> IS_AVC
+			"IsInterlaced" -> IS_INTERLACED
+			"AudioSampleRate" -> AUDIO_SAMPLE_RATE
+			"AudioBitDepth" -> AUDIO_BIT_DEPTH
+			"VideoRangeType" -> VIDEO_RANGE_TYPE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ProfileConditionValue =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ProgramAudio.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ProgramAudio.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -28,4 +29,19 @@ public enum class ProgramAudio(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ProgramAudio? = when (serialName) {
+			"Mono" -> MONO
+			"Stereo" -> STEREO
+			"Dolby" -> DOLBY
+			"DolbyDigital" -> DOLBY_DIGITAL
+			"Thx" -> THX
+			"Atmos" -> ATMOS
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ProgramAudio =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RatingType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RatingType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,15 @@ public enum class RatingType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): RatingType? = when (serialName) {
+			"Score" -> SCORE
+			"Likes" -> LIKES
+			else -> null
+		}
+
+		public fun fromName(serialName: String): RatingType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RecommendationType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RecommendationType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -28,4 +29,19 @@ public enum class RecommendationType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): RecommendationType? = when (serialName) {
+			"SimilarToRecentlyPlayed" -> SIMILAR_TO_RECENTLY_PLAYED
+			"SimilarToLikedItem" -> SIMILAR_TO_LIKED_ITEM
+			"HasDirectorFromRecentlyPlayed" -> HAS_DIRECTOR_FROM_RECENTLY_PLAYED
+			"HasActorFromRecentlyPlayed" -> HAS_ACTOR_FROM_RECENTLY_PLAYED
+			"HasLikedDirector" -> HAS_LIKED_DIRECTOR
+			"HasLikedActor" -> HAS_LIKED_ACTOR
+			else -> null
+		}
+
+		public fun fromName(serialName: String): RecommendationType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RecordingStatus.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RecordingStatus.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -30,4 +31,20 @@ public enum class RecordingStatus(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): RecordingStatus? = when (serialName) {
+			"New" -> NEW
+			"InProgress" -> IN_PROGRESS
+			"Completed" -> COMPLETED
+			"Cancelled" -> CANCELLED
+			"ConflictedOk" -> CONFLICTED_OK
+			"ConflictedNotOk" -> CONFLICTED_NOT_OK
+			"Error" -> ERROR
+			else -> null
+		}
+
+		public fun fromName(serialName: String): RecordingStatus =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RepeatMode.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/RepeatMode.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class RepeatMode(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): RepeatMode? = when (serialName) {
+			"RepeatNone" -> REPEAT_NONE
+			"RepeatAll" -> REPEAT_ALL
+			"RepeatOne" -> REPEAT_ONE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): RepeatMode =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ScrollDirection.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ScrollDirection.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,4 +24,15 @@ public enum class ScrollDirection(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): ScrollDirection? = when (serialName) {
+			"Horizontal" -> HORIZONTAL
+			"Vertical" -> VERTICAL
+			else -> null
+		}
+
+		public fun fromName(serialName: String): ScrollDirection =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SendCommandType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SendCommandType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class SendCommandType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SendCommandType? = when (serialName) {
+			"Unpause" -> UNPAUSE
+			"Pause" -> PAUSE
+			"Stop" -> STOP
+			"Seek" -> SEEK
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SendCommandType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SendToUserType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SendToUserType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class SendToUserType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SendToUserType? = when (serialName) {
+			"All" -> ALL
+			"Admins" -> ADMINS
+			"Custom" -> CUSTOM
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SendToUserType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesStatus.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesStatus.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,4 +24,15 @@ public enum class SeriesStatus(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SeriesStatus? = when (serialName) {
+			"Continuing" -> CONTINUING
+			"Ended" -> ENDED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SeriesStatus =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SessionMessageType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SessionMessageType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -87,4 +88,47 @@ public enum class SessionMessageType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SessionMessageType? = when (serialName) {
+			"ForceKeepAlive" -> FORCE_KEEP_ALIVE
+			"GeneralCommand" -> GENERAL_COMMAND
+			"UserDataChanged" -> USER_DATA_CHANGED
+			"Sessions" -> SESSIONS
+			"Play" -> PLAY
+			"SyncPlayCommand" -> SYNC_PLAY_COMMAND
+			"SyncPlayGroupUpdate" -> SYNC_PLAY_GROUP_UPDATE
+			"Playstate" -> PLAYSTATE
+			"RestartRequired" -> RESTART_REQUIRED
+			"ServerShuttingDown" -> SERVER_SHUTTING_DOWN
+			"ServerRestarting" -> SERVER_RESTARTING
+			"LibraryChanged" -> LIBRARY_CHANGED
+			"UserDeleted" -> USER_DELETED
+			"UserUpdated" -> USER_UPDATED
+			"SeriesTimerCreated" -> SERIES_TIMER_CREATED
+			"TimerCreated" -> TIMER_CREATED
+			"SeriesTimerCancelled" -> SERIES_TIMER_CANCELLED
+			"TimerCancelled" -> TIMER_CANCELLED
+			"RefreshProgress" -> REFRESH_PROGRESS
+			"ScheduledTaskEnded" -> SCHEDULED_TASK_ENDED
+			"PackageInstallationCancelled" -> PACKAGE_INSTALLATION_CANCELLED
+			"PackageInstallationFailed" -> PACKAGE_INSTALLATION_FAILED
+			"PackageInstallationCompleted" -> PACKAGE_INSTALLATION_COMPLETED
+			"PackageInstalling" -> PACKAGE_INSTALLING
+			"PackageUninstalled" -> PACKAGE_UNINSTALLED
+			"ActivityLogEntry" -> ACTIVITY_LOG_ENTRY
+			"ScheduledTasksInfo" -> SCHEDULED_TASKS_INFO
+			"ActivityLogEntryStart" -> ACTIVITY_LOG_ENTRY_START
+			"ActivityLogEntryStop" -> ACTIVITY_LOG_ENTRY_STOP
+			"SessionsStart" -> SESSIONS_START
+			"SessionsStop" -> SESSIONS_STOP
+			"ScheduledTasksInfoStart" -> SCHEDULED_TASKS_INFO_START
+			"ScheduledTasksInfoStop" -> SCHEDULED_TASKS_INFO_STOP
+			"KeepAlive" -> KEEP_ALIVE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SessionMessageType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SortOrder.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SortOrder.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,4 +24,15 @@ public enum class SortOrder(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SortOrder? = when (serialName) {
+			"Ascending" -> ASCENDING
+			"Descending" -> DESCENDING
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SortOrder =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SubtitleDeliveryMethod.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SubtitleDeliveryMethod.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,4 +30,18 @@ public enum class SubtitleDeliveryMethod(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SubtitleDeliveryMethod? = when (serialName) {
+			"Encode" -> ENCODE
+			"Embed" -> EMBED
+			"External" -> EXTERNAL
+			"Hls" -> HLS
+			"Drop" -> DROP
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SubtitleDeliveryMethod =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SubtitlePlaybackMode.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SubtitlePlaybackMode.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,4 +30,18 @@ public enum class SubtitlePlaybackMode(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SubtitlePlaybackMode? = when (serialName) {
+			"Default" -> DEFAULT
+			"Always" -> ALWAYS
+			"OnlyForced" -> ONLY_FORCED
+			"None" -> NONE
+			"Smart" -> SMART
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SubtitlePlaybackMode =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SyncPlayUserAccessType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SyncPlayUserAccessType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -25,4 +26,16 @@ public enum class SyncPlayUserAccessType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): SyncPlayUserAccessType? = when (serialName) {
+			"CreateAndJoinGroups" -> CREATE_AND_JOIN_GROUPS
+			"JoinGroups" -> JOIN_GROUPS
+			"None" -> NONE
+			else -> null
+		}
+
+		public fun fromName(serialName: String): SyncPlayUserAccessType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskCompletionStatus.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskCompletionStatus.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class TaskCompletionStatus(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): TaskCompletionStatus? = when (serialName) {
+			"Completed" -> COMPLETED
+			"Failed" -> FAILED
+			"Cancelled" -> CANCELLED
+			"Aborted" -> ABORTED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): TaskCompletionStatus =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskState.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TaskState.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -25,4 +26,16 @@ public enum class TaskState(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): TaskState? = when (serialName) {
+			"Idle" -> IDLE
+			"Cancelling" -> CANCELLING
+			"Running" -> RUNNING
+			else -> null
+		}
+
+		public fun fromName(serialName: String): TaskState =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeReason.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeReason.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -66,4 +67,38 @@ public enum class TranscodeReason(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): TranscodeReason? = when (serialName) {
+			"ContainerNotSupported" -> CONTAINER_NOT_SUPPORTED
+			"VideoCodecNotSupported" -> VIDEO_CODEC_NOT_SUPPORTED
+			"AudioCodecNotSupported" -> AUDIO_CODEC_NOT_SUPPORTED
+			"SubtitleCodecNotSupported" -> SUBTITLE_CODEC_NOT_SUPPORTED
+			"AudioIsExternal" -> AUDIO_IS_EXTERNAL
+			"SecondaryAudioNotSupported" -> SECONDARY_AUDIO_NOT_SUPPORTED
+			"VideoProfileNotSupported" -> VIDEO_PROFILE_NOT_SUPPORTED
+			"VideoLevelNotSupported" -> VIDEO_LEVEL_NOT_SUPPORTED
+			"VideoResolutionNotSupported" -> VIDEO_RESOLUTION_NOT_SUPPORTED
+			"VideoBitDepthNotSupported" -> VIDEO_BIT_DEPTH_NOT_SUPPORTED
+			"VideoFramerateNotSupported" -> VIDEO_FRAMERATE_NOT_SUPPORTED
+			"RefFramesNotSupported" -> REF_FRAMES_NOT_SUPPORTED
+			"AnamorphicVideoNotSupported" -> ANAMORPHIC_VIDEO_NOT_SUPPORTED
+			"InterlacedVideoNotSupported" -> INTERLACED_VIDEO_NOT_SUPPORTED
+			"AudioChannelsNotSupported" -> AUDIO_CHANNELS_NOT_SUPPORTED
+			"AudioProfileNotSupported" -> AUDIO_PROFILE_NOT_SUPPORTED
+			"AudioSampleRateNotSupported" -> AUDIO_SAMPLE_RATE_NOT_SUPPORTED
+			"AudioBitDepthNotSupported" -> AUDIO_BIT_DEPTH_NOT_SUPPORTED
+			"ContainerBitrateExceedsLimit" -> CONTAINER_BITRATE_EXCEEDS_LIMIT
+			"VideoBitrateNotSupported" -> VIDEO_BITRATE_NOT_SUPPORTED
+			"AudioBitrateNotSupported" -> AUDIO_BITRATE_NOT_SUPPORTED
+			"UnknownVideoStreamInfo" -> UNKNOWN_VIDEO_STREAM_INFO
+			"UnknownAudioStreamInfo" -> UNKNOWN_AUDIO_STREAM_INFO
+			"DirectPlayError" -> DIRECT_PLAY_ERROR
+			"VideoRangeTypeNotSupported" -> VIDEO_RANGE_TYPE_NOT_SUPPORTED
+			else -> null
+		}
+
+		public fun fromName(serialName: String): TranscodeReason =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeSeekInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TranscodeSeekInfo.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,15 @@ public enum class TranscodeSeekInfo(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): TranscodeSeekInfo? = when (serialName) {
+			"Auto" -> AUTO
+			"Bytes" -> BYTES
+			else -> null
+		}
+
+		public fun fromName(serialName: String): TranscodeSeekInfo =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TransportStreamTimestamp.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TransportStreamTimestamp.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,16 @@ public enum class TransportStreamTimestamp(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): TransportStreamTimestamp? = when (serialName) {
+			"None" -> NONE
+			"Zero" -> ZERO
+			"Valid" -> VALID
+			else -> null
+		}
+
+		public fun fromName(serialName: String): TransportStreamTimestamp =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UnratedItem.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/UnratedItem.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -37,4 +38,22 @@ public enum class UnratedItem(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): UnratedItem? = when (serialName) {
+			"Movie" -> MOVIE
+			"Trailer" -> TRAILER
+			"Series" -> SERIES
+			"Music" -> MUSIC
+			"Book" -> BOOK
+			"LiveTvChannel" -> LIVE_TV_CHANNEL
+			"LiveTvProgram" -> LIVE_TV_PROGRAM
+			"ChannelContent" -> CHANNEL_CONTENT
+			"Other" -> OTHER
+			else -> null
+		}
+
+		public fun fromName(serialName: String): UnratedItem =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/Video3dFormat.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/Video3dFormat.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -26,4 +27,18 @@ public enum class Video3dFormat(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): Video3dFormat? = when (serialName) {
+			"HalfSideBySide" -> HALF_SIDE_BY_SIDE
+			"FullSideBySide" -> FULL_SIDE_BY_SIDE
+			"FullTopAndBottom" -> FULL_TOP_AND_BOTTOM
+			"HalfTopAndBottom" -> HALF_TOP_AND_BOTTOM
+			"MVC" -> MVC
+			else -> null
+		}
+
+		public fun fromName(serialName: String): Video3dFormat =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/VideoType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/VideoType.kt
@@ -6,6 +6,7 @@
 package org.jellyfin.sdk.model.api
 
 import kotlin.String
+import kotlin.requireNotNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,4 +28,17 @@ public enum class VideoType(
 	;
 
 	public override fun toString(): String = serialName
+
+	public companion object {
+		public fun fromNameOrNull(serialName: String): VideoType? = when (serialName) {
+			"VideoFile" -> VIDEO_FILE
+			"Iso" -> ISO
+			"Dvd" -> DVD
+			"BluRay" -> BLU_RAY
+			else -> null
+		}
+
+		public fun fromName(serialName: String): VideoType =
+				requireNotNull(fromNameOrNull(serialName)) { """Unknown value $serialName""" }
+	}
 }

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Strings.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Strings.kt
@@ -66,4 +66,9 @@ object Strings {
 	 * Description of the parameter used for the generated request model containing operation parameters.
 	 */
 	const val MODEL_REQUEST_PARAMETER_DESCRIPTION = "The request paramaters"
+
+	/**
+	 * Message used in the exception thrown when the serialName is invalid. Use $serialName for the input value.
+	 */
+	const val MODEL_ENUM_MEMBER_EXCEPTION_MESSAGE = "Unknown value \$serialName"
 }


### PR DESCRIPTION
The Jellyfin API is a bit messy when working with BaseItemDto. One such case is the "BaseItemDto.status" property which is a different enum based on the item type. For series it refers to `SeriesStatus`. However, we can't use `SeriesStatus.valueOf` because that matches with the SCREAMING_SNAKE_CASE name instead of the PascalCase name.

This PR adds two functions to the companion object of all generated enum members:

- `fromNameOrNull`
  Returns the enum member with the given name using the PascalCase name

- `fromName`
  Calls `fromNameOrNull` and throws when null

~~Additionally this PR fixes a typo in the `MODEL_REQUEST_PARAMETER_DESCRIPTION` string.~~ < moving this one to a separate PR
