### PR TITLE
Split KtorClient to separate module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlinx-coroutines = "1.7.0"
 kotlinx-serialization = "1.5.0"
 ktor = "1.6.8"
 nexuspublish = "1.3.0"
+okhttp = "4.10.0"
 slf4j = "2.0.7"
 swagger-parser = "2.1.13"
 
@@ -33,17 +34,19 @@ android-gradle = { module = "com.android.tools.build:gradle", version.ref = "and
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 kasechange = { module = "net.pearx.kasechange:kasechange", version.ref = "kasechange" }
 koin = { module = "io.insert-koin:koin-core", version.ref = "koin" }
-kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 swagger-parser = { module = "io.swagger.parser.v3:swagger-parser", version.ref = "swagger-parser" }

--- a/jellyfin-api-ktor/api/jellyfin-api-ktor.api
+++ b/jellyfin-api-ktor/api/jellyfin-api-ktor.api
@@ -1,0 +1,18 @@
+public class org/jellyfin/sdk/api/ktor/KtorClient : org/jellyfin/sdk/api/client/ApiClient {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getAccessToken ()Ljava/lang/String;
+	public fun getBaseUrl ()Ljava/lang/String;
+	public fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
+	public fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
+	public fun getUserId ()Ljava/util/UUID;
+	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setAccessToken (Ljava/lang/String;)V
+	public fun setBaseUrl (Ljava/lang/String;)V
+	public fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
+	public fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public fun setUserId (Ljava/util/UUID;)V
+	public fun ws ()Lorg/jellyfin/sdk/api/sockets/SocketInstance;
+}
+

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -15,14 +15,12 @@ kotlin {
 		}
 
 		val commonMain by getting {
-			kotlin.srcDir("src/commonMain/kotlin-generated")
-
 			dependencies {
+				implementation(projects.jellyfinApi)
 				implementation(projects.jellyfinModel)
 
-				implementation(libs.kotlinx.coroutines)
-				implementation(libs.kotlinx.serialization.json)
-				implementation(libs.ktor.http)
+				implementation(libs.kotlinx.serialization.core)
+				implementation(libs.ktor.core)
 
 				implementation(libs.kotlin.logging)
 			}
@@ -30,7 +28,7 @@ kotlin {
 
 		val jvmMain by getting {
 			dependencies {
-				implementation(libs.okhttp)
+				implementation(libs.ktor.okhttp)
 			}
 		}
 

--- a/jellyfin-api-ktor/src/commonMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/commonMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -1,5 +1,9 @@
-package org.jellyfin.sdk.api.client
+package org.jellyfin.sdk.api.ktor
 
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.client.HttpMethod
+import org.jellyfin.sdk.api.client.RawResponse
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.model.ClientInfo

--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.sdk.api.client
+package org.jellyfin.sdk.api.ktor
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.NoTransformationFoundException
@@ -17,6 +17,10 @@ import io.ktor.network.sockets.SocketTimeoutException
 import io.ktor.util.toMap
 import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.client.HttpMethod
+import org.jellyfin.sdk.api.client.RawResponse
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.jellyfin.sdk.api.client.exception.InvalidContentException
 import org.jellyfin.sdk.api.client.exception.InvalidStatusException

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -51,24 +51,6 @@ public final class org/jellyfin/sdk/api/client/HttpMethod : java/lang/Enum {
 	public static fun values ()[Lorg/jellyfin/sdk/api/client/HttpMethod;
 }
 
-public class org/jellyfin/sdk/api/client/KtorClient : org/jellyfin/sdk/api/client/ApiClient {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getAccessToken ()Ljava/lang/String;
-	public fun getBaseUrl ()Ljava/lang/String;
-	public fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
-	public fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
-	public fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
-	public fun getUserId ()Ljava/util/UUID;
-	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun setAccessToken (Ljava/lang/String;)V
-	public fun setBaseUrl (Ljava/lang/String;)V
-	public fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
-	public fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
-	public fun setUserId (Ljava/util/UUID;)V
-	public fun ws ()Lorg/jellyfin/sdk/api/sockets/SocketInstance;
-}
-
 public final class org/jellyfin/sdk/api/client/RawResponse {
 	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;ILjava/util/Map;)V
 	public final fun getBody ()Lio/ktor/utils/io/ByteReadChannel;
@@ -1384,6 +1366,8 @@ public abstract interface class org/jellyfin/sdk/api/sockets/SocketConnectionFac
 }
 
 public final class org/jellyfin/sdk/api/sockets/SocketInstance {
+	public fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lkotlin/coroutines/CoroutineContext;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/api/client/ApiClient;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addListenerDefinition (Lorg/jellyfin/sdk/api/sockets/listener/SocketListenerDefinition;)Lorg/jellyfin/sdk/api/sockets/listener/SocketListener;
 	public final fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun publish (Lorg/jellyfin/sdk/model/socket/OutgoingSocketMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketInstance.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketInstance.kt
@@ -32,7 +32,7 @@ import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
 
-public class SocketInstance internal constructor(
+public class SocketInstance(
 	private val api: ApiClient,
 	private val socketConnectionFactory: SocketConnectionFactory,
 	context: CoroutineContext = Dispatchers.Default,

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
 		val commonMain by getting {
 			dependencies {
 				api(projects.jellyfinApi)
+				api(projects.jellyfinApiKtor)
 				api(projects.jellyfinModel)
 
 				implementation(libs.kotlinx.coroutines)

--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -2,7 +2,7 @@ package org.jellyfin.sdk
 
 import android.content.Context
 import org.jellyfin.sdk.android.androidDevice
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.ktor.KtorClient
 import org.jellyfin.sdk.api.sockets.OkHttpWebsocketSession
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo

--- a/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.sdk
 
-import org.jellyfin.sdk.api.client.KtorClient
+import org.jellyfin.sdk.api.ktor.KtorClient
 import org.jellyfin.sdk.api.sockets.OkHttpWebsocketSession
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ rootProject.name = "jellyfin-sdk-kotlin"
 include(":jellyfin-core")
 include(":jellyfin-model")
 include(":jellyfin-api")
+include(":jellyfin-api-ktor")
 
 // Code generation
 include(":openapi-generator")


### PR DESCRIPTION
The jellyfin-api module currently hard-depends on Ktor which makes it hard to use, for example, okhttp 5. This is the initial PR to splitting the HTTP implementation to a separate package. We still have some parts of the code depending on Ktor (like the AuthorizationHeaderBuilder, UrlBuilder and de ByteReadChannel we use for binary responses in the generated API's) which will be fixed in upcoming pull requests.

The jellyfin-core module now also depends on jellyfin-api-ktor so for SDK users nothing will change.