### PR TITLE
Support readOnly properties in OpenAPI generator

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -10,14 +10,14 @@ import com.squareup.kotlinpoet.buildCodeBlock
 import org.jellyfin.openapi.builder.Builder
 import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
 import org.jellyfin.openapi.builder.extra.DescriptionBuilder
-import org.jellyfin.openapi.builder.extra.defaultValue
+import org.jellyfin.openapi.builder.extra.toCodeBlock
 import org.jellyfin.openapi.constants.Classes
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
-import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.ApiServiceOperation
 import org.jellyfin.openapi.model.ApiServiceOperationParameter
+import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.IntRangeValidation
 import org.jellyfin.openapi.model.ParameterValidation
 
@@ -44,7 +44,7 @@ open class OperationBuilder(
 	protected fun buildParameter(
 		data: ApiServiceOperationParameter,
 	) = ParameterSpec.builder(data.name, data.type).apply {
-		defaultValue(data)
+		defaultValue(data.defaultValue.toCodeBlock(data.type, true))
 
 		// Add description
 		descriptionBuilder.build(DescriptionType.OPERATION_PARAMETER, data.description)?.let {

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/RequestModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/RequestModelBuilder.kt
@@ -32,6 +32,7 @@ class RequestModelBuilder(
 					},
 					description = parameter.description,
 					deprecated = parameter.deprecated,
+					static = false,
 				)
 			}.toSet()
 		)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiModelBuilder.kt
@@ -98,13 +98,15 @@ class OpenApiModelBuilder(
 		interfaces = emptySet(),
 		properties = data.properties.map { (originalName, property) ->
 			val name = originalName.toCamelCase(from = CaseFormat.CAPITALIZED_CAMEL)
+			val defaultValue = openApiDefaultValueBuilder.build(context, property)
 			ObjectApiModelProperty(
 				name = name,
 				originalName = originalName,
-				defaultValue = openApiDefaultValueBuilder.build(context, property),
+				defaultValue = defaultValue,
 				type = openApiTypeBuilder.build(ModelTypePath(data.name, name), property),
 				description = property.description,
 				deprecated = property.deprecated == true,
+				static = property.readOnly == true && defaultValue != null,
 			)
 		}.toSet()
 	)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ObjectApiModelProperty.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ObjectApiModelProperty.kt
@@ -9,4 +9,5 @@ data class ObjectApiModelProperty(
 	val type: TypeName,
 	val description: String?,
 	val deprecated: Boolean,
+	val static: Boolean,
 )


### PR DESCRIPTION
- Add support for schema properties with readOnly set to true and a default value
  - They will be generated as class property so the serializer will add them and the deserializer ignores them
  - Value can be read by SDK users
  - Will be used for polymorphic discriminator values

This is needed to fully support jellyfin/jellyfin#9682. Sample output: https://github.com/nielsvanvelzen/jellyfin-sdk-kotlin/commit/73ae6251e6cb304f76bee1ebf2992b698a09ab80

Diff for KeepAliveMessage:
```diff
@@ -14,9 +14,10 @@ public data class KeepAliveMessage(
         */
        @SerialName("Data")
        public val `data`: Int,
+) : InboundWebSocketMessage, OutboundWebSocketMessage {
        /**
         * The different kinds of messages that are used in the WebSocket api.
         */
        @SerialName("MessageType")
-       public override val messageType: SessionMessageType = SessionMessageType.KEEP_ALIVE,
-) : InboundWebSocketMessage, OutboundWebSocketMessage
+       public override val messageType: SessionMessageType = SessionMessageType.KEEP_ALIVE
+}
```