### PR TITLE
Don't add @SerialName annotation to polymorphic discriminator property in ObjectModelBuilder

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ObjectModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/model/ObjectModelBuilder.kt
@@ -82,9 +82,12 @@ class ObjectModelBuilder(
 						if (property.name in superPropertyNames) modifiers += KModifier.OVERRIDE
 
 						if (property.deprecated) addAnnotation(deprecatedAnnotationSpecBuilder.build(Strings.DEPRECATED_MEMBER))
-						addAnnotation(
-							AnnotationSpec.builder(Types.SERIAL_NAME).addMember("%S", property.originalName).build()
-						)
+						if (property.originalName != polymorphicProperty) {
+							AnnotationSpec.builder(Types.SERIAL_NAME)
+								.addMember("%S", property.originalName)
+								.build()
+								.let(::addAnnotation)
+						}
 					}
 					.build()
 				)


### PR DESCRIPTION
This fixes an issue where kotlinx.serialization would try to add the discriminator twice (once by library and once due to our definition)