### PR TITLE
Fix Vitepress builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"description": "This file is used for the documentation only",
+	"type": "module",
 	"scripts": {
 		"start": "vitepress dev docs",
 		"build": "vitepress build docs"


### PR DESCRIPTION
Only supports ESM now but the default in esbuild is commonjs