### PR TITLE
Add builders for device profile and related models

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -17614,6 +17614,193 @@ public final class org/jellyfin/sdk/model/constant/PersonType {
 	public static final field Writer Ljava/lang/String;
 }
 
+public final class org/jellyfin/sdk/model/deviceprofile/CodecProfileBuilder {
+	public fun <init> ()V
+	public final fun applyConditions (Lkotlin/jvm/functions/Function1;)V
+	public final fun build ()Lorg/jellyfin/sdk/model/api/CodecProfile;
+	public final fun condition ([Lorg/jellyfin/sdk/model/api/ProfileCondition;)V
+	public final fun conditions (Lkotlin/jvm/functions/Function1;)V
+	public final fun getCodec ()Ljava/lang/String;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/CodecType;
+	public final fun setCodec (Ljava/lang/String;)V
+	public final fun setContainer (Ljava/lang/String;)V
+	public final fun setType (Lorg/jellyfin/sdk/model/api/CodecType;)V
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/CodecProfileBuilderKt {
+	public static final fun buildCodecProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/CodecProfile;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/ContainerProfileBuilder {
+	public fun <init> ()V
+	public final fun build ()Lorg/jellyfin/sdk/model/api/ContainerProfile;
+	public final fun conditions (Lkotlin/jvm/functions/Function1;)V
+	public final fun container ([Ljava/lang/String;)V
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/ContainerProfileBuilderKt {
+	public static final fun buildContainerProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/ContainerProfile;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/DeviceProfileBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/jellyfin/sdk/model/api/DeviceProfile;)V
+	public synthetic fun <init> (Lorg/jellyfin/sdk/model/api/DeviceProfile;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun add (Lorg/jellyfin/sdk/model/api/CodecProfile;)Lorg/jellyfin/sdk/model/api/CodecProfile;
+	public final fun add (Lorg/jellyfin/sdk/model/api/ContainerProfile;)Lorg/jellyfin/sdk/model/api/ContainerProfile;
+	public final fun add (Lorg/jellyfin/sdk/model/api/DirectPlayProfile;)Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
+	public final fun add (Lorg/jellyfin/sdk/model/api/SubtitleProfile;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public final fun add (Lorg/jellyfin/sdk/model/api/TranscodingProfile;)Lorg/jellyfin/sdk/model/api/TranscodingProfile;
+	public final fun build ()Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public final fun codecProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/CodecProfile;
+	public final fun containerProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/ContainerProfile;
+	public final fun directPlayProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
+	public final fun getCodecProfiles ()Ljava/util/Collection;
+	public final fun getContainerProfiles ()Ljava/util/Collection;
+	public final fun getDirectPlayProfiles ()Ljava/util/Collection;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxStaticBitrate ()Ljava/lang/Integer;
+	public final fun getMaxStaticMusicBitrate ()Ljava/lang/Integer;
+	public final fun getMaxStreamingBitrate ()Ljava/lang/Integer;
+	public final fun getMusicStreamingTranscodingBitrate ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSubtitleProfiles ()Ljava/util/Collection;
+	public final fun getTranscodingProfiles ()Ljava/util/Collection;
+	public final fun setId (Ljava/lang/String;)V
+	public final fun setMaxStaticBitrate (Ljava/lang/Integer;)V
+	public final fun setMaxStaticMusicBitrate (Ljava/lang/Integer;)V
+	public final fun setMaxStreamingBitrate (Ljava/lang/Integer;)V
+	public final fun setMusicStreamingTranscodingBitrate (Ljava/lang/Integer;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun subtitleProfile (Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public final fun subtitleProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public static synthetic fun subtitleProfile$default (Lorg/jellyfin/sdk/model/deviceprofile/DeviceProfileBuilder;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public final fun transcodingProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/TranscodingProfile;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/DeviceProfileBuilderKt {
+	public static final fun buildDeviceProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/DeviceProfile;
+	public static final fun buildUpon (Lorg/jellyfin/sdk/model/api/DeviceProfile;Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/DeviceProfile;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/DirectPlayProfileBuilder {
+	public fun <init> ()V
+	public final fun audioCodec ([Ljava/lang/String;)V
+	public final fun build ()Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
+	public final fun container ([Ljava/lang/String;)V
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun setType (Lorg/jellyfin/sdk/model/api/DlnaProfileType;)V
+	public final fun videoCodec ([Ljava/lang/String;)V
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/DirectPlayProfileBuilderKt {
+	public static final fun buildDirectPlayProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/DirectPlayProfile;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Collection;)V
+	public synthetic fun <init> (Ljava/util/Collection;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun add (Lorg/jellyfin/sdk/model/api/ProfileCondition;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun add (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Lorg/jellyfin/sdk/model/api/ProfileConditionType;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun addAll (Ljava/util/Collection;)Ljava/util/Collection;
+	public final fun build ()Ljava/util/Collection;
+	public final fun equals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun equals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun equals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun equals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun equals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun equals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;ZZ)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun equals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun equals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun equals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;ZZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun greaterThanOrEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun greaterThanOrEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun greaterThanOrEquals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun inBooleanCollection (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun inBooleanCollection (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun inBooleanCollection$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun inNumberCollection (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun inNumberCollection (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun inNumberCollection$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun inStringCollection (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun inStringCollection (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun inStringCollection$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/util/Collection;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun lowerThanOrEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun lowerThanOrEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun lowerThanOrEquals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun notEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun notEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun notEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun notEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun notEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Z)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public final fun notEquals (Lorg/jellyfin/sdk/model/api/ProfileConditionValue;ZZ)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun notEquals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/Number;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun notEquals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+	public static synthetic fun notEquals$default (Lorg/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder;Lorg/jellyfin/sdk/model/api/ProfileConditionValue;ZZILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/ProfileCondition;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilderKt {
+	public static final fun buildProfileConditions (Lkotlin/jvm/functions/Function1;)Ljava/util/Collection;
+	public static final fun buildUpon (Ljava/util/Collection;Lkotlin/jvm/functions/Function1;)Ljava/util/Collection;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/SubtitleProfileBuilder {
+	public fun <init> ()V
+	public final fun build ()Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getMethod ()Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;
+	public final fun setContainer (Ljava/lang/String;)V
+	public final fun setFormat (Ljava/lang/String;)V
+	public final fun setLanguage (Ljava/lang/String;)V
+	public final fun setMethod (Lorg/jellyfin/sdk/model/api/SubtitleDeliveryMethod;)V
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/SubtitleProfileBuilderKt {
+	public static final fun buildSubtitleProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/SubtitleProfile;
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/TranscodingProfileBuilder {
+	public fun <init> ()V
+	public final fun audioCodec ([Ljava/lang/String;)V
+	public final fun build ()Lorg/jellyfin/sdk/model/api/TranscodingProfile;
+	public final fun conditions (Lkotlin/jvm/functions/Function1;)V
+	public final fun getBreakOnNonKeyFrames ()Z
+	public final fun getContainer ()Ljava/lang/String;
+	public final fun getContext ()Lorg/jellyfin/sdk/model/api/EncodingContext;
+	public final fun getCopyTimestamps ()Z
+	public final fun getEnableMpegtsM2TsMode ()Z
+	public final fun getEnableSubtitlesInManifest ()Z
+	public final fun getEstimateContentLength ()Z
+	public final fun getMaxAudioChannels ()Ljava/lang/String;
+	public final fun getMinSegments ()I
+	public final fun getProtocol ()Ljava/lang/String;
+	public final fun getSegmentLength ()I
+	public final fun getTranscodeSeekInfo ()Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;
+	public final fun getType ()Lorg/jellyfin/sdk/model/api/DlnaProfileType;
+	public final fun setBreakOnNonKeyFrames (Z)V
+	public final fun setContainer (Ljava/lang/String;)V
+	public final fun setContext (Lorg/jellyfin/sdk/model/api/EncodingContext;)V
+	public final fun setCopyTimestamps (Z)V
+	public final fun setEnableMpegtsM2TsMode (Z)V
+	public final fun setEnableSubtitlesInManifest (Z)V
+	public final fun setEstimateContentLength (Z)V
+	public final fun setMaxAudioChannels (Ljava/lang/String;)V
+	public final fun setMinSegments (I)V
+	public final fun setProtocol (Ljava/lang/String;)V
+	public final fun setSegmentLength (I)V
+	public final fun setTranscodeSeekInfo (Lorg/jellyfin/sdk/model/api/TranscodeSeekInfo;)V
+	public final fun setType (Lorg/jellyfin/sdk/model/api/DlnaProfileType;)V
+	public final fun videoCodec ([Ljava/lang/String;)V
+}
+
+public final class org/jellyfin/sdk/model/deviceprofile/TranscodingProfileBuilderKt {
+	public static final fun buildTranscodingProfile (Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/model/api/TranscodingProfile;
+}
+
 public final class org/jellyfin/sdk/model/extensions/GeneralCommandMessageExtensionsKt {
 	public static final fun contains (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Ljava/lang/String;)Z
 	public static final fun get (Lorg/jellyfin/sdk/model/socket/GeneralCommandMessage;Ljava/lang/String;)Ljava/lang/String;

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/CodecProfileBuilder.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/CodecProfileBuilder.kt
@@ -1,0 +1,53 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+import org.jellyfin.sdk.model.api.CodecProfile
+import org.jellyfin.sdk.model.api.CodecType
+import org.jellyfin.sdk.model.api.ProfileCondition
+
+@DeviceProfileBuilderDsl
+public class CodecProfileBuilder {
+	private var conditions = mutableListOf<ProfileCondition>()
+	private var applyConditions = mutableListOf<ProfileCondition>()
+
+	/**
+	 * @see [CodecProfile.type]
+	 */
+	public var type: CodecType = CodecType.VIDEO_AUDIO
+
+	/**
+	 * @see [CodecProfile.container]
+	 */
+	public var container: String? = null
+
+	/**
+	 * @see [CodecProfile.codec]
+	 */
+	public var codec: String? = null
+
+	public fun condition(vararg condition: ProfileCondition) {
+		conditions.addAll(condition)
+	}
+
+	public fun conditions(body: ProfileConditionsBuilder.() -> Unit) {
+		conditions.addAll(ProfileConditionsBuilder().apply(body).build())
+	}
+
+	public fun applyConditions(body: ProfileConditionsBuilder.() -> Unit) {
+		applyConditions.addAll(ProfileConditionsBuilder().apply(body).build())
+	}
+
+	public fun build(): CodecProfile = CodecProfile(
+		type = type,
+		conditions = conditions,
+		applyConditions = applyConditions,
+		codec = codec,
+		container = container,
+	)
+}
+
+@DeviceProfileBuilderDsl
+public fun buildCodecProfile(
+	body: CodecProfileBuilder.() -> Unit,
+): CodecProfile = CodecProfileBuilder()
+	.apply(body)
+	.build()

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/ContainerProfileBuilder.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/ContainerProfileBuilder.kt
@@ -1,0 +1,33 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+import org.jellyfin.sdk.model.api.ContainerProfile
+import org.jellyfin.sdk.model.api.DlnaProfileType
+import org.jellyfin.sdk.model.api.ProfileCondition
+
+@DeviceProfileBuilderDsl
+public class ContainerProfileBuilder {
+	private var containers = mutableListOf<String>()
+	private var conditions = mutableListOf<ProfileCondition>()
+
+	public fun container(vararg container: String) {
+		containers.addAll(container)
+	}
+
+	public fun conditions(body: ProfileConditionsBuilder.() -> Unit) {
+		conditions.addAll(ProfileConditionsBuilder().apply(body).build())
+	}
+
+	public fun build(): ContainerProfile = ContainerProfile(
+		// Server only uses container profiles with video type so the builder only supports that
+		type = DlnaProfileType.VIDEO,
+		conditions = conditions,
+		container = containers.joinToString(","),
+	)
+}
+
+@DeviceProfileBuilderDsl
+public fun buildContainerProfile(
+	body: ContainerProfileBuilder.() -> Unit,
+): ContainerProfile = ContainerProfileBuilder()
+	.apply(body)
+	.build()

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/DeviceProfileBuilder.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/DeviceProfileBuilder.kt
@@ -1,0 +1,161 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+import org.jellyfin.sdk.model.api.CodecProfile
+import org.jellyfin.sdk.model.api.ContainerProfile
+import org.jellyfin.sdk.model.api.DeviceProfile
+import org.jellyfin.sdk.model.api.DirectPlayProfile
+import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
+import org.jellyfin.sdk.model.api.SubtitleProfile
+import org.jellyfin.sdk.model.api.TranscodingProfile
+
+@DeviceProfileBuilderDsl
+public class DeviceProfileBuilder(
+	parent: DeviceProfile? = null,
+) {
+	/**
+	 * @see [DeviceProfile.id].
+	 */
+	public var id: String? = null
+
+	/**
+	 * @see [DeviceProfile.name].
+	 */
+	public var name: String? = null
+
+	/**
+	 * @see [DeviceProfile.maxStreamingBitrate].
+	 */
+	public var maxStreamingBitrate: Int? = parent?.maxStreamingBitrate
+
+	/**
+	 * @see [DeviceProfile.maxStaticBitrate].
+	 */
+	public var maxStaticBitrate: Int? = parent?.maxStaticBitrate
+
+	/**
+	 * @see [DeviceProfile.musicStreamingTranscodingBitrate].
+	 */
+	public var musicStreamingTranscodingBitrate: Int? = parent?.musicStreamingTranscodingBitrate
+
+	/**
+	 * @see [DeviceProfile.maxStaticMusicBitrate].
+	 */
+	public var maxStaticMusicBitrate: Int? = parent?.maxStaticMusicBitrate
+
+	/**
+	 * @see [DeviceProfile.directPlayProfiles].
+	 */
+	public val directPlayProfiles: MutableCollection<DirectPlayProfile> =
+		parent?.directPlayProfiles?.toMutableList() ?: mutableListOf()
+
+	/**
+	 * @see [DeviceProfile.transcodingProfiles].
+	 */
+	public val transcodingProfiles: MutableCollection<TranscodingProfile> =
+		parent?.transcodingProfiles?.toMutableList() ?: mutableListOf()
+
+	/**
+	 * @see [DeviceProfile.containerProfiles].
+	 */
+	public val containerProfiles: MutableCollection<ContainerProfile> =
+		parent?.containerProfiles?.toMutableList() ?: mutableListOf()
+
+	/**
+	 * @see [DeviceProfile.codecProfiles].
+	 */
+	public val codecProfiles: MutableCollection<CodecProfile> =
+		parent?.codecProfiles?.toMutableList() ?: mutableListOf()
+
+	/**
+	 * @see [DeviceProfile.subtitleProfiles].
+	 */
+	public val subtitleProfiles: MutableCollection<SubtitleProfile> =
+		parent?.subtitleProfiles?.toMutableList() ?: mutableListOf()
+
+	public fun directPlayProfile(
+		body: DirectPlayProfileBuilder.() -> Unit,
+	): DirectPlayProfile = add(buildDirectPlayProfile(body))
+
+	public fun add(profile: DirectPlayProfile): DirectPlayProfile {
+		directPlayProfiles.add(profile)
+		return profile
+	}
+
+	public fun transcodingProfile(
+		body: TranscodingProfileBuilder.() -> Unit,
+	): TranscodingProfile = add(buildTranscodingProfile(body))
+
+	public fun add(profile: TranscodingProfile): TranscodingProfile {
+		transcodingProfiles.add(profile)
+		return profile
+	}
+
+	public fun containerProfile(
+		body: ContainerProfileBuilder.() -> Unit,
+	): ContainerProfile = add(buildContainerProfile(body))
+
+	public fun add(profile: ContainerProfile): ContainerProfile {
+		containerProfiles.add(profile)
+		return profile
+	}
+
+	public fun codecProfile(
+		body: CodecProfileBuilder.() -> Unit,
+	): CodecProfile = add(buildCodecProfile(body))
+
+	public fun add(profile: CodecProfile): CodecProfile {
+		codecProfiles.add(profile)
+		return profile
+	}
+
+	public fun subtitleProfile(
+		body: SubtitleProfileBuilder.() -> Unit,
+	): SubtitleProfile = add(buildSubtitleProfile(body))
+
+	public fun subtitleProfile(
+		format: String,
+		method: SubtitleDeliveryMethod,
+		language: String? = null,
+	): SubtitleProfile = add(buildSubtitleProfile {
+		this.format = format
+		this.method = method
+		this.language = language
+	})
+
+	public fun add(profile: SubtitleProfile): SubtitleProfile {
+		subtitleProfiles.add(profile)
+		return profile
+	}
+
+	public fun build(): DeviceProfile = DeviceProfile(
+		name = name,
+		id = id,
+		maxStreamingBitrate = maxStreamingBitrate,
+		maxStaticBitrate = maxStaticBitrate,
+		musicStreamingTranscodingBitrate = musicStreamingTranscodingBitrate,
+		maxStaticMusicBitrate = maxStaticMusicBitrate,
+		directPlayProfiles = directPlayProfiles.toList(),
+		transcodingProfiles = transcodingProfiles.toList(),
+		containerProfiles = containerProfiles.toList(),
+		codecProfiles = codecProfiles.toList(),
+		subtitleProfiles = subtitleProfiles.toList(),
+		// DLNA only options that can be ignored
+		supportedMediaTypes = "",
+		xmlRootAttributes = emptyList(),
+		responseProfiles = emptyList(),
+	)
+}
+
+@DeviceProfileBuilderDsl
+public fun buildDeviceProfile(
+	body: DeviceProfileBuilder.() -> Unit,
+): DeviceProfile = DeviceProfileBuilder()
+	.apply(body)
+	.build()
+
+@DeviceProfileBuilderDsl
+public fun DeviceProfile.buildUpon(
+	body: DeviceProfileBuilder.() -> Unit,
+): DeviceProfile = DeviceProfileBuilder(this)
+	.apply(body)
+	.build()

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/DeviceProfileBuilderDsl.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/DeviceProfileBuilderDsl.kt
@@ -1,0 +1,4 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+@DslMarker
+internal annotation class DeviceProfileBuilderDsl

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/DirectPlayProfileBuilder.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/DirectPlayProfileBuilder.kt
@@ -1,0 +1,42 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+import org.jellyfin.sdk.model.api.DirectPlayProfile
+import org.jellyfin.sdk.model.api.DlnaProfileType
+
+@DeviceProfileBuilderDsl
+public class DirectPlayProfileBuilder {
+	private val containers = mutableListOf<String>()
+	private val videoCodecs = mutableListOf<String>()
+	private val audioCodecs = mutableListOf<String>()
+
+	/**
+	 * @see [DirectPlayProfile.type]
+	 */
+	public var type: DlnaProfileType = DlnaProfileType.VIDEO
+
+	public fun container(vararg container: String) {
+		containers.addAll(container)
+	}
+
+	public fun videoCodec(vararg codec: String) {
+		videoCodecs.addAll(codec)
+	}
+
+	public fun audioCodec(vararg codec: String) {
+		audioCodecs.addAll(codec)
+	}
+
+	public fun build(): DirectPlayProfile = DirectPlayProfile(
+		type = type,
+		container = containers.joinToString(","),
+		videoCodec = videoCodecs.joinToString(","),
+		audioCodec = audioCodecs.joinToString(","),
+	)
+}
+
+@DeviceProfileBuilderDsl
+public fun buildDirectPlayProfile(
+	body: DirectPlayProfileBuilder.() -> Unit,
+): DirectPlayProfile = DirectPlayProfileBuilder()
+	.apply(body)
+	.build()

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/ProfileConditionsBuilder.kt
@@ -1,0 +1,194 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+import org.jellyfin.sdk.model.api.ProfileCondition
+import org.jellyfin.sdk.model.api.ProfileConditionType
+import org.jellyfin.sdk.model.api.ProfileConditionValue
+
+@DeviceProfileBuilderDsl
+public class ProfileConditionsBuilder(parent: Collection<ProfileCondition>? = null) {
+	private val conditions = parent?.toMutableList() ?: mutableListOf()
+
+	// Equals
+	public fun equals(property: ProfileConditionValue, value: String?, required: Boolean = false): ProfileCondition =
+		add(
+			operator = ProfileConditionType.EQUALS,
+			property = property,
+			value = value,
+			required = required,
+		)
+
+	public infix fun ProfileConditionValue.equals(value: String?): ProfileCondition = equals(this, value, false)
+
+	public fun equals(property: ProfileConditionValue, value: Number, required: Boolean = false): ProfileCondition =
+		add(
+			operator = ProfileConditionType.EQUALS,
+			property = property,
+			value = value.toString(),
+			required = required,
+		)
+
+	public infix fun ProfileConditionValue.equals(value: Number): ProfileCondition = equals(this, value, false)
+
+	public fun equals(property: ProfileConditionValue, value: Boolean, required: Boolean = false): ProfileCondition =
+		add(
+			operator = ProfileConditionType.EQUALS,
+			property = property,
+			value = value.toString(),
+			required = required,
+		)
+
+	public infix fun ProfileConditionValue.equals(value: Boolean): ProfileCondition = equals(this, value, false)
+
+	// Not equals
+	public fun notEquals(property: ProfileConditionValue, value: String, required: Boolean = false): ProfileCondition =
+		add(
+			operator = ProfileConditionType.NOT_EQUALS,
+			property = property,
+			value = value,
+			required = required,
+		)
+
+	public infix fun ProfileConditionValue.notEquals(value: String): ProfileCondition = notEquals(this, value, false)
+
+	public fun notEquals(property: ProfileConditionValue, value: Number, required: Boolean = false): ProfileCondition =
+		add(
+			operator = ProfileConditionType.NOT_EQUALS,
+			property = property,
+			value = value.toString(),
+			required = required,
+		)
+
+	public infix fun ProfileConditionValue.notEquals(value: Number): ProfileCondition = notEquals(this, value, false)
+
+	public fun notEquals(property: ProfileConditionValue, value: Boolean, required: Boolean = false): ProfileCondition =
+		add(
+			operator = ProfileConditionType.NOT_EQUALS,
+			property = property,
+			value = value.toString(),
+			required = required,
+		)
+
+	public infix fun ProfileConditionValue.notEquals(value: Boolean): ProfileCondition = notEquals(this, value, false)
+
+	// Greater than or equals
+	public fun greaterThanOrEquals(
+		property: ProfileConditionValue,
+		value: Number,
+		required: Boolean = false
+	): ProfileCondition = add(
+		operator = ProfileConditionType.GREATER_THAN_EQUAL,
+		property = property,
+		value = value.toString(),
+		required = required,
+	)
+
+	public infix fun ProfileConditionValue.greaterThanOrEquals(value: Number): ProfileCondition =
+		greaterThanOrEquals(this, value, false)
+
+	// Lower than or equals
+	public fun lowerThanOrEquals(
+		property: ProfileConditionValue,
+		value: Number,
+		required: Boolean = false
+	): ProfileCondition = add(
+		operator = ProfileConditionType.LESS_THAN_EQUAL,
+		property = property,
+		value = value.toString(),
+		required = required,
+	)
+
+	public infix fun ProfileConditionValue.lowerThanOrEquals(value: Number): ProfileCondition =
+		lowerThanOrEquals(this, value, false)
+
+	// In collection
+	@JvmName("inStringCollection")
+	public fun inCollection(
+		property: ProfileConditionValue,
+		value: Collection<String>,
+		required: Boolean = false
+	): ProfileCondition =
+		add(
+			operator = ProfileConditionType.EQUALS_ANY,
+			property = property,
+			value = value.joinToString("|"),
+			required = required,
+		)
+
+	@JvmName("inStringCollection")
+	public infix fun ProfileConditionValue.inCollection(value: Collection<String>): ProfileCondition =
+		inCollection(this, value, false)
+
+	@JvmName("inBooleanCollection")
+	public fun inCollection(
+		property: ProfileConditionValue,
+		value: Collection<Boolean>,
+		required: Boolean = false
+	): ProfileCondition =
+		add(
+			operator = ProfileConditionType.EQUALS_ANY,
+			property = property,
+			value = value.joinToString("|") { it.toString() },
+			required = required,
+		)
+
+	@JvmName("inBooleanCollection")
+	public infix fun ProfileConditionValue.inCollection(value: Collection<Boolean>): ProfileCondition =
+		inCollection(this, value, false)
+
+	@JvmName("inNumberCollection")
+	public fun inCollection(
+		property: ProfileConditionValue,
+		value: Collection<Number>,
+		required: Boolean = false
+	): ProfileCondition =
+		add(
+			operator = ProfileConditionType.EQUALS_ANY,
+			property = property,
+			value = value.joinToString("|") { it.toString() },
+			required = required,
+		)
+
+	@JvmName("inNumberCollection")
+	public infix fun ProfileConditionValue.inCollection(value: Collection<Number>): ProfileCondition =
+		inCollection(this, value, false)
+
+	public fun add(
+		property: ProfileConditionValue,
+		operator: ProfileConditionType,
+		value: String?,
+		required: Boolean,
+	): ProfileCondition = add(
+		condition = ProfileCondition(
+			condition = operator,
+			property = property,
+			value = value,
+			isRequired = required,
+		)
+	)
+
+	public fun add(condition: ProfileCondition): ProfileCondition {
+		conditions.add(condition)
+		return condition
+	}
+
+	public fun addAll(conditions: Collection<ProfileCondition>): Collection<ProfileCondition> {
+		this.conditions.addAll(conditions)
+		return conditions
+	}
+
+	public fun build(): Collection<ProfileCondition> = conditions.toList()
+}
+
+@DeviceProfileBuilderDsl
+public fun buildProfileConditions(
+	body: ProfileConditionsBuilder.() -> Unit,
+): Collection<ProfileCondition> = ProfileConditionsBuilder()
+	.apply(body)
+	.build()
+
+@DeviceProfileBuilderDsl
+public fun Collection<ProfileCondition>.buildUpon(
+	body: ProfileConditionsBuilder.() -> Unit,
+): Collection<ProfileCondition> = ProfileConditionsBuilder(this)
+	.apply(body)
+	.build()

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/SubtitleProfileBuilder.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/SubtitleProfileBuilder.kt
@@ -1,0 +1,41 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
+import org.jellyfin.sdk.model.api.SubtitleProfile
+
+@DeviceProfileBuilderDsl
+public class SubtitleProfileBuilder {
+	/**
+	 * @see [SubtitleProfile.method]
+	 */
+	public var method: SubtitleDeliveryMethod = SubtitleDeliveryMethod.EMBED
+
+	/**
+	 * @see [SubtitleProfile.format]
+	 */
+	public var format: String? = null
+
+	/**
+	 * @see [SubtitleProfile.language]
+	 */
+	public var language: String? = null
+
+	/**
+	 * @see [SubtitleProfile.container]
+	 */
+	public var container: String? = null
+
+	public fun build(): SubtitleProfile = SubtitleProfile(
+		format = format,
+		method = method,
+		language = language,
+		container = container,
+	)
+}
+
+@DeviceProfileBuilderDsl
+public fun buildSubtitleProfile(
+	body: SubtitleProfileBuilder.() -> Unit,
+): SubtitleProfile = SubtitleProfileBuilder()
+	.apply(body)
+	.build()

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/TranscodingProfileBuilder.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/deviceprofile/TranscodingProfileBuilder.kt
@@ -1,0 +1,117 @@
+package org.jellyfin.sdk.model.deviceprofile
+
+import org.jellyfin.sdk.model.api.DlnaProfileType
+import org.jellyfin.sdk.model.api.EncodingContext
+import org.jellyfin.sdk.model.api.ProfileCondition
+import org.jellyfin.sdk.model.api.TranscodeSeekInfo
+import org.jellyfin.sdk.model.api.TranscodingProfile
+
+@DeviceProfileBuilderDsl
+public class TranscodingProfileBuilder {
+	private val videoCodecs = mutableListOf<String>()
+	private val audioCodecs = mutableListOf<String>()
+	private var conditions = mutableListOf<ProfileCondition>()
+
+	/**
+	 * @see [TranscodingProfile.type]
+	 */
+	public var type: DlnaProfileType = DlnaProfileType.VIDEO
+
+	/**
+	 * @see [TranscodingProfile.context]
+	 */
+	public var context: EncodingContext = EncodingContext.STREAMING
+
+	/**
+	 * @see [TranscodingProfile.protocol]
+	 */
+	public var protocol: String = "http"
+
+	/**
+	 * @see [TranscodingProfile.container]
+	 */
+	public var container: String = ""
+
+	/**
+	 * @see [TranscodingProfile.estimateContentLength]
+	 */
+	public var estimateContentLength: Boolean = false
+
+	/**
+	 * @see [TranscodingProfile.enableMpegtsM2TsMode]
+	 */
+	public var enableMpegtsM2TsMode: Boolean = false
+
+	/**
+	 * @see [TranscodingProfile.transcodeSeekInfo]
+	 */
+	public var transcodeSeekInfo: TranscodeSeekInfo = TranscodeSeekInfo.AUTO
+
+	/**
+	 * @see [TranscodingProfile.copyTimestamps]
+	 */
+	public var copyTimestamps: Boolean = false
+
+	/**
+	 * @see [TranscodingProfile.enableSubtitlesInManifest]
+	 */
+	public var enableSubtitlesInManifest: Boolean = false
+
+	/**
+	 * @see [TranscodingProfile.maxAudioChannels]
+	 */
+	public var maxAudioChannels: String? = null
+
+	/**
+	 * @see [TranscodingProfile.minSegments]
+	 */
+	public var minSegments: Int = 0
+
+	/**
+	 * @see [TranscodingProfile.segmentLength]
+	 */
+	public var segmentLength: Int = 0
+
+	/**
+	 * @see [TranscodingProfile.breakOnNonKeyFrames]
+	 */
+	public var breakOnNonKeyFrames: Boolean = false
+
+	public fun videoCodec(vararg codec: String) {
+		videoCodecs.addAll(codec)
+	}
+
+	public fun audioCodec(vararg codec: String) {
+		audioCodecs.addAll(codec)
+	}
+
+	public fun conditions(body: ProfileConditionsBuilder.() -> Unit) {
+		conditions.addAll(ProfileConditionsBuilder().apply(body).build())
+	}
+
+	public fun build(): TranscodingProfile = TranscodingProfile(
+		type = type,
+		context = context,
+		protocol = protocol,
+		container = container,
+		videoCodec = videoCodecs.joinToString(","),
+		audioCodec = audioCodecs.joinToString(","),
+		estimateContentLength = estimateContentLength,
+		enableMpegtsM2TsMode = enableMpegtsM2TsMode,
+		transcodeSeekInfo = transcodeSeekInfo,
+		copyTimestamps = copyTimestamps,
+		enableSubtitlesInManifest = enableSubtitlesInManifest,
+		maxAudioChannels = maxAudioChannels,
+		minSegments = minSegments,
+		segmentLength = segmentLength,
+		breakOnNonKeyFrames = breakOnNonKeyFrames,
+		conditions = conditions,
+	)
+}
+
+@DeviceProfileBuilderDsl
+public fun buildTranscodingProfile(
+	body: TranscodingProfileBuilder.() -> Unit,
+): TranscodingProfile = TranscodingProfileBuilder()
+	.apply(body)
+	.build()


### PR DESCRIPTION
This change adds builders for the device profile and related classes. All DLNA only properties are hidden in the builders as they have no value for clients using this SDK.

I didn't feel like writing a documentation page (for now) so that might (or might not) come in a future PR.

Closes #131