### PR TITLE
Add ignorePathParameters option to UrlBuilder

### DIFF
--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -214,9 +214,10 @@ public final class org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder {
 
 public final class org/jellyfin/sdk/api/client/util/UrlBuilder {
 	public static final field INSTANCE Lorg/jellyfin/sdk/api/client/util/UrlBuilder;
-	public final fun buildPath (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
-	public final fun buildUrl (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/String;
-	public static synthetic fun buildUrl$default (Lorg/jellyfin/sdk/api/client/util/UrlBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun buildPath (Ljava/lang/String;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun buildPath$default (Lorg/jellyfin/sdk/api/client/util/UrlBuilder;Ljava/lang/String;Ljava/util/Map;ZILjava/lang/Object;)Ljava/lang/String;
+	public final fun buildUrl (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Z)Ljava/lang/String;
+	public static synthetic fun buildUrl$default (Lorg/jellyfin/sdk/api/client/util/UrlBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jellyfin/sdk/api/client/util/UrlBuilderKt {

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilder.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilder.kt
@@ -19,13 +19,14 @@ public object UrlBuilder {
 		pathTemplate: String = "/",
 		pathParameters: Map<String, Any?> = mapOf(),
 		queryParameters: Map<String, Any?> = mapOf(),
+		ignorePathParameters: Boolean = false,
 	): String {
 		return URLBuilder(baseUrl).apply {
 			// Create from base URL
 			takeFrom(baseUrl)
 
 			// Replace path variables
-			val path = buildPath(pathTemplate, pathParameters)
+			val path = buildPath(pathTemplate, pathParameters, ignorePathParameters)
 			// Assign path making sure to remove duplicated slashes between the base and appended path
 			encodedPath = "${encodedPath.trimEnd('/')}/${path.trimStart('/')}"
 
@@ -45,7 +46,11 @@ public object UrlBuilder {
 		}.buildString()
 	}
 
-	public fun buildPath(template: String, parameters: Map<String, Any?>): String = buildString {
+	public fun buildPath(
+		template: String,
+		parameters: Map<String, Any?>,
+		ignorePathParameters: Boolean = false,
+	): String = buildString {
 		var lastStart = -1
 		var lastEnd = -1
 
@@ -64,7 +69,11 @@ public object UrlBuilder {
 
 					lastEnd = i
 				}
+
 				TOKEN_BRACKET_OPEN -> {
+					// Don't do anything when ignorePathParameters is set
+					if (ignorePathParameters) continue
+
 					check(lastStart < 0) {
 						"Nested path variable at $i in path $template"
 					}
@@ -75,7 +84,11 @@ public object UrlBuilder {
 					// Set path variable start index (exclude opening brace)
 					lastStart = i + 1
 				}
+
 				TOKEN_BRACKET_CLOSE -> {
+					// Don't do anything when ignorePathParameters is set
+					if (ignorePathParameters) continue
+
 					check(lastStart >= 0) {
 						"End of path variable without start at $i in path $template"
 					}

--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilderTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilderTests.kt
@@ -187,4 +187,38 @@ class UrlBuilderTests : FunSpec({
 			queryParameters = parameters,
 		) shouldBe "${baseUrl}test?example=value1&example=value2&example2=value3"
 	}
+
+	test("buildUrl keeps query parameters in pathTemplate") {
+		val baseUrl = "https://demo.jellyfin.org/stable/"
+
+		UrlBuilder.buildUrl(
+			baseUrl = baseUrl,
+			pathTemplate = "/example?foo=bar"
+		) shouldBe "${baseUrl}example?foo=bar"
+	}
+
+	test("buildUrl prevents host from changing") {
+		val baseUrl = "https://demo.jellyfin.org/stable/"
+
+		UrlBuilder.buildUrl(
+			baseUrl = baseUrl,
+			pathTemplate = "https://second.example"
+		) shouldBe "${baseUrl}https:/second.example"
+
+		UrlBuilder.buildUrl(
+			baseUrl = baseUrl,
+			pathTemplate = "https://second.example",
+			ignorePathParameters = true,
+		) shouldBe "${baseUrl}https:/second.example"
+	}
+
+	test("buildUrl ignores path parameters when ignorePathParameters is set") {
+		val baseUrl = "https://demo.jellyfin.org/stable/"
+
+		UrlBuilder.buildUrl(
+			baseUrl = baseUrl,
+			pathTemplate = "{foo}/{foo/{bar",
+			ignorePathParameters = true,
+		) shouldBe "${baseUrl}{foo}/{foo/{bar"
+	}
 })


### PR DESCRIPTION
Sometimes you have a string that you don't fully trust and want to build a URL with it. To prevent this string from causing issues there needs to be a way to disable path templates, that way no matter what characters it contains it shouldn't throw an error while keeping the other benefits of the URL builder like properly adding the base URL, fixing double slashes and adding query parameters.

This change is especially useful when working with the `transcodingUrl` returned by the server to construct a URL for the transcoded media.

API changed in a backwards-compatible way.