### PR TITLE
Remove release environment from sdk-publish.yaml

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -12,7 +12,6 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-22.04
-    environment: release
     if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.repository_owner, 'jellyfin') }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
(already cherrypicked to release branch)

GitHub broke stuff