### PR TITLE
Add RegexValidation to OpenAPI generator

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
@@ -15,6 +15,8 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
+import kotlin.require
+import kotlin.text.Regex
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -150,6 +152,11 @@ public class AudioApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(container == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(container)) { """Parameter "container" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(48) {
 			put("container", container)
 			put("static", static)
@@ -389,6 +396,11 @@ public class AudioApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(container == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(container)) { """Parameter "container" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(48) {
 			put("container", container)
 			put("static", static)
@@ -567,6 +579,10 @@ public class AudioApi(
 			put("itemId", itemId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(47) {
 			put("static", static)
 			put("params", params)
@@ -806,6 +822,10 @@ public class AudioApi(
 			put("itemId", itemId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(47) {
 			put("static", static)
 			put("params", params)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
@@ -15,6 +15,8 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlin.collections.buildMap
 import kotlin.collections.emptyMap
+import kotlin.require
+import kotlin.text.Regex
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -168,6 +170,10 @@ public class DynamicHlsApi(
 			put("segmentId", segmentId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(50) {
 			put("runtimeTicks", runtimeTicks)
 			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
@@ -428,6 +434,10 @@ public class DynamicHlsApi(
 			put("segmentId", segmentId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(50) {
 			put("runtimeTicks", runtimeTicks)
 			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
@@ -623,6 +633,10 @@ public class DynamicHlsApi(
 			put("segmentId", segmentId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(51) {
 			put("runtimeTicks", runtimeTicks)
 			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
@@ -888,6 +902,10 @@ public class DynamicHlsApi(
 			put("segmentId", segmentId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(51) {
 			put("runtimeTicks", runtimeTicks)
 			put("actualSegmentLengthTicks", actualSegmentLengthTicks)
@@ -1074,6 +1092,11 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(container == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(container)) { """Parameter "container" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(51) {
 			put("container", container)
 			put("static", static)
@@ -1325,6 +1348,11 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(container == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(container)) { """Parameter "container" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(51) {
 			put("container", container)
 			put("static", static)
@@ -1507,6 +1535,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(49) {
 			put("static", static)
 			put("params", params)
@@ -1750,6 +1782,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(49) {
 			put("static", static)
 			put("params", params)
@@ -1932,6 +1968,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(50) {
 			put("static", static)
 			put("params", params)
@@ -2179,6 +2219,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(50) {
 			put("static", static)
 			put("params", params)
@@ -2357,6 +2401,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(48) {
 			put("static", static)
 			put("params", params)
@@ -2595,6 +2643,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(48) {
 			put("static", static)
 			put("params", params)
@@ -2774,6 +2826,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(49) {
 			put("static", static)
 			put("params", params)
@@ -3017,6 +3073,10 @@ public class DynamicHlsApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(49) {
 			put("static", static)
 			put("params", params)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
@@ -14,6 +14,8 @@ import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.buildMap
 import kotlin.collections.emptyList
+import kotlin.require
+import kotlin.text.Regex
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -70,6 +72,8 @@ public class UniversalAudioApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(transcodingContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(transcodingContainer)) { """Parameter "transcodingContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(17) {
 			put("container", container)
 			put("mediaSourceId", mediaSourceId)
@@ -171,6 +175,8 @@ public class UniversalAudioApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(transcodingContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(transcodingContainer)) { """Parameter "transcodingContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(17) {
 			put("container", container)
 			put("mediaSourceId", mediaSourceId)

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
@@ -18,6 +18,8 @@ import kotlin.collections.Map
 import kotlin.collections.buildMap
 import kotlin.collections.emptyList
 import kotlin.collections.emptyMap
+import kotlin.require
+import kotlin.text.Regex
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
@@ -197,6 +199,11 @@ public class VideosApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(container == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(container)) { """Parameter "container" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(50) {
 			put("container", container)
 			put("static", static)
@@ -445,6 +452,11 @@ public class VideosApi(
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
+		require(container == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(container)) { """Parameter "container" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(50) {
 			put("container", container)
 			put("static", static)
@@ -630,6 +642,10 @@ public class VideosApi(
 			put("itemId", itemId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(49) {
 			put("static", static)
 			put("params", params)
@@ -878,6 +894,10 @@ public class VideosApi(
 			put("itemId", itemId)
 			put("container", container)
 		}
+		require(segmentContainer == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(segmentContainer)) { """Parameter "segmentContainer" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(audioCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(audioCodec)) { """Parameter "audioCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(videoCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(videoCodec)) { """Parameter "videoCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
+		require(subtitleCodec == null || Regex("""^[a-zA-Z0-9\-\._,|]{0,40}$""").matches(subtitleCodec)) { """Parameter "subtitleCodec" must match ^[a-zA-Z0-9\-\._,|]{0,40}$.""" }
 		val queryParameters = buildMap<String, Any?>(49) {
 			put("static", static)
 			put("params", params)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.Paths
 import io.swagger.v3.oas.models.media.IntegerSchema
 import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.parameters.RequestBody
 import mu.KotlinLogging
@@ -29,6 +30,7 @@ import org.jellyfin.openapi.model.GeneratorContext
 import org.jellyfin.openapi.model.HttpMethod
 import org.jellyfin.openapi.model.IntRangeValidation
 import org.jellyfin.openapi.model.ParameterValidation
+import org.jellyfin.openapi.model.RegexValidation
 
 private val logger = KotlinLogging.logger { }
 
@@ -86,6 +88,7 @@ class OpenApiApiServicesBuilder(
 			schema.minimum.intValueExact(),
 			schema.maximum.intValueExact()
 		)
+		schema is StringSchema && schema.pattern != null -> RegexValidation(schema.pattern)
 
 		else -> null
 	}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/RegexValidation.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/RegexValidation.kt
@@ -1,0 +1,5 @@
+package org.jellyfin.openapi.model
+
+data class RegexValidation(
+	val pattern: String,
+) : ParameterValidation


### PR DESCRIPTION
Jellyfin 10.8.13 introduces some security fixes that restrict the various codec parameters used in the API. This was done using regular expressions that are also added to the OpenAPI specification.

This pull request uses those regex patterns to also validate them client-side to get faster feedback with invalid requests. Just like the previously added IntRangeValidation.