### PR TITLE
Lower Java toolchain version to 8

### DIFF
--- a/buildSrc/src/main/kotlin/Properties.kt
+++ b/buildSrc/src/main/kotlin/Properties.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Project
  */
 fun Project.getProperty(name: String): String? {
 	// sample.var --> SAMPLE_VAR
-	val environmentName = name.toUpperCase().replace(".", "_")
+	val environmentName = name.uppercase().replace(".", "_")
 	val value = findProperty(name)?.toString() ?: System.getenv(environmentName) ?: null
 	logger.debug("getProperty($name): $environmentName - found=${!value.isNullOrBlank()}")
 	return value

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(17)
+	jvmToolchain(8)
 
 	sourceSets {
 		all {

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(17)
+	jvmToolchain(8)
 
 	sourceSets {
 		all {

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
 		publishAllLibraryVariants()
 	}
 
-	jvmToolchain(17)
+	jvmToolchain(8)
 
 	applyDefaultHierarchyTemplate()
 

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(17)
+	jvmToolchain(8)
 
 	sourceSets {
 		all {

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(17)
+	jvmToolchain(8)
 
 	sourceSets {
 		all {


### PR DESCRIPTION
Fixes Android support (our apps are built for Java 8)

![95100002a7](https://github.com/jellyfin/jellyfin-sdk-kotlin/assets/2305178/087c0d08-e807-4c8d-bf69-6f762422fc32)
