### PR TITLE
Ignore failure of apiDump task in OpenAPI update workflows

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Run apiDump task
         run: ./gradlew apiDump
       - name: Commit changes
+        if: always()
         run: |
           git config user.name jellyfin-bot
           git config user.email team@jellyfin.org

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -29,6 +29,7 @@ jobs:
           ./gradlew :openapi-generator:updateApiSpecStable
           ./gradlew apiDump
       - name: Create pull request
+        if: always()
         uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6.0.0
         with:
           token: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
Currently the unstable branch is not running because it is failing, so I disabled it over 8 months ago. This is not ideal as I normally use the diff to keep an eye on API changes, I prefer reading them in Kotlin instead of JSON.

This PR changes the workflows to ignore the failure of the `apiDump` task, committing code that will fail to build and when pushed, fails various CI tasks. It does allow me to use the unstable branch for diffing though.