### PR TITLE
Add type to make generator aware of operation request body type

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -18,6 +18,7 @@ import org.jellyfin.openapi.constants.Strings
 import org.jellyfin.openapi.constants.Types
 import org.jellyfin.openapi.model.ApiServiceOperation
 import org.jellyfin.openapi.model.ApiServiceOperationParameter
+import org.jellyfin.openapi.model.ApiServiceOperationRequestBody
 import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.IntRangeValidation
 import org.jellyfin.openapi.model.ParameterValidation
@@ -127,10 +128,10 @@ open class OperationBuilder(
 		addParameterMapStatements("queryParameters", data.queryParameters)
 
 		// Add request body
-		if (data.bodyType != null) {
-			addParameter(ParameterSpec.builder("data", data.bodyType).apply {
+		if (data.body != ApiServiceOperationRequestBody.None) {
+			addParameter(ParameterSpec.builder("data", data.body.type).apply {
 				// Set default value to null if parameter is nullable
-				if (data.bodyType.isNullable) defaultValue("%L", "null")
+				if (data.body.type.isNullable) defaultValue("%L", "null")
 			}.build())
 		} else {
 			// No data parameter needed, use a null value

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationParameterModelBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationParameterModelBuilder.kt
@@ -10,10 +10,11 @@ import org.jellyfin.openapi.builder.extra.DeprecatedAnnotationSpecBuilder
 import org.jellyfin.openapi.builder.extra.DescriptionBuilder
 import org.jellyfin.openapi.constants.Packages
 import org.jellyfin.openapi.constants.Strings
-import org.jellyfin.openapi.model.DescriptionType
 import org.jellyfin.openapi.model.ApiServiceOperation
 import org.jellyfin.openapi.model.ApiServiceOperationParameter
+import org.jellyfin.openapi.model.ApiServiceOperationRequestBody
 import org.jellyfin.openapi.model.DefaultValue
+import org.jellyfin.openapi.model.DescriptionType
 
 class OperationParameterModelBuilder(
 	private val descriptionBuilder: DescriptionBuilder,
@@ -56,11 +57,11 @@ class OperationParameterModelBuilder(
 			)
 		}.build().let(::addParameter)
 
-		val includeData = data.bodyType != null
+		val includeData = data.body != ApiServiceOperationRequestBody.None
 		if (includeData) {
-			addParameter(ParameterSpec.builder("data", data.bodyType!!).apply {
+			addParameter(ParameterSpec.builder("data", data.body.type).apply {
 				// Set default value to null if parameter is nullable
-				if (data.bodyType.isNullable) defaultValue("%L", "null")
+				if (data.body.type.isNullable) defaultValue("%L", "null")
 			}.build())
 		}
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/compare/OperationComparator.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/compare/OperationComparator.kt
@@ -52,7 +52,7 @@ class OperationComparator {
 			detect({ method }, "Method")
 			detect({ requireAuthentication }, "Authentication")
 			detect({ returnType }, "Return type")
-			detect({ bodyType }, "Body type")
+			detect({ body }, "Body type")
 		},
 	)
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperation.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperation.kt
@@ -12,5 +12,5 @@ data class ApiServiceOperation(
 	val returnType: TypeName,
 	val pathParameters: Collection<ApiServiceOperationParameter> = emptyList(),
 	val queryParameters: Collection<ApiServiceOperationParameter> = emptyList(),
-	val bodyType: TypeName?
+	val body: ApiServiceOperationRequestBody,
 )

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationRequestBody.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationRequestBody.kt
@@ -1,0 +1,24 @@
+package org.jellyfin.openapi.model
+
+import com.squareup.kotlinpoet.TypeName
+import org.jellyfin.openapi.constants.Types
+
+sealed interface ApiServiceOperationRequestBody {
+	val type: TypeName
+
+	data class Json(
+		override val type: TypeName
+	) : ApiServiceOperationRequestBody
+
+	data object String : ApiServiceOperationRequestBody {
+		override val type: TypeName = Types.STRING
+	}
+
+	data object Binary : ApiServiceOperationRequestBody {
+		override val type: TypeName = Types.BYTE_ARRAY
+	}
+
+	data object None : ApiServiceOperationRequestBody {
+		override val type: TypeName = Types.NONE
+	}
+}


### PR DESCRIPTION
I was working on support for multipart / formdata in request bodies but it ended up being extremely difficult with how models are currently generated. One part of this change was to make OperationBuilder aware of the request body type. The changes for this makes the code slightly better as it replaces string usages with types in some places so I thought it was worth something to keep.
Perhaps in the future I'll attempt the form support again and this would make it a bit easier to get started again.