### PR TITLE
Only use ByteReadChannel for API responses

### DIFF
--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiTypeBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiTypeBuilder.kt
@@ -57,7 +57,7 @@ class OpenApiTypeBuilder(
 			// UUID
 			is UUIDSchema -> buildUUIDType()
 			// Binary
-			is BinarySchema -> buildBinary()
+			is BinarySchema -> buildBinary(path)
 			// Collections
 			is ArraySchema -> buildArrayType(path, schema)
 			is MapSchema -> buildMapType(path, schema)
@@ -116,7 +116,10 @@ class OpenApiTypeBuilder(
 			.toPascalCase(from = CaseFormat.CAPITALIZED_CAMEL)
 	)
 
-	fun buildBinary() = Types.BINARY
+	fun buildBinary(path: TypePath) = when {
+		path is ApiTypePath && path.isReturnType() -> Types.BINARY
+		else -> Types.BYTE_ARRAY
+	}
 
 	fun buildJsonElement() = Types.JSON_ELEMENT
 


### PR DESCRIPTION
The jellyfin-model module does not have a dependency on Ktor. If the binary type was used in a model it would use the ByteReadChannel class as type, causing a compiler error.

This change updates the OpenApiTypeBuilder to only use ByteReadChannel for operation return types.
