### PR TITLE
Increase minimum supported Jellyfin version to 10.9.0

### DIFF
--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -70,7 +70,7 @@ public class Jellyfin(
 		/**
 		 * The minimum server version expected to work. Lower versions may work but are not supported.
 		 */
-		public val minimumVersion: ServerVersion = ServerVersion(10, 8, 1, 0)
+		public val minimumVersion: ServerVersion = ServerVersion(10, 9, 0, 0)
 
 		/**
 		 * The exact server version used to generate the API. Should be equal or higher than [minimumVersion].


### PR DESCRIPTION
10.9 spec requires a 10.9 server