### PR TITLE
[1.4] Backport 10.9 enum changes to 10.8.13 API specification

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -2750,6 +2750,7 @@ public final class org/jellyfin/sdk/model/api/DlnaOptions$Companion {
 public final class org/jellyfin/sdk/model/api/DlnaProfileType : java/lang/Enum {
 	public static final field AUDIO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/DlnaProfileType$Companion;
+	public static final field LYRIC Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public static final field PHOTO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public static final field SUBTITLE Lorg/jellyfin/sdk/model/api/DlnaProfileType;
 	public static final field VIDEO Lorg/jellyfin/sdk/model/api/DlnaProfileType;
@@ -2993,6 +2994,7 @@ public final class org/jellyfin/sdk/model/api/ExternalIdMediaType : java/lang/En
 	public static final field ALBUM Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public static final field ALBUM_ARTIST Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public static final field ARTIST Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
+	public static final field BOOK Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public static final field BOX_SET Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/ExternalIdMediaType$Companion;
 	public static final field EPISODE Lorg/jellyfin/sdk/model/api/ExternalIdMediaType;
@@ -3324,6 +3326,7 @@ public final class org/jellyfin/sdk/model/api/GeneralCommandType : java/lang/Enu
 	public static final field SEND_STRING Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static final field SET_AUDIO_STREAM_INDEX Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static final field SET_MAX_STREAMING_BITRATE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
+	public static final field SET_PLAYBACK_ORDER Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static final field SET_REPEAT_MODE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static final field SET_SHUFFLE_QUEUE Lorg/jellyfin/sdk/model/api/GeneralCommandType;
 	public static final field SET_SUBTITLE_STREAM_INDEX Lorg/jellyfin/sdk/model/api/GeneralCommandType;
@@ -3588,6 +3591,7 @@ public final class org/jellyfin/sdk/model/api/HardwareEncodingType : java/lang/E
 	public static final field Companion Lorg/jellyfin/sdk/model/api/HardwareEncodingType$Companion;
 	public static final field NVENC Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
 	public static final field QSV Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
+	public static final field RKMPP Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
 	public static final field V4L2M2M Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
 	public static final field VAAPI Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
 	public static final field VIDEO_TOOL_BOX Lorg/jellyfin/sdk/model/api/HardwareEncodingType;
@@ -3769,6 +3773,7 @@ public final class org/jellyfin/sdk/model/api/ImageFormat : java/lang/Enum {
 	public static final field GIF Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public static final field JPG Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public static final field PNG Lorg/jellyfin/sdk/model/api/ImageFormat;
+	public static final field SVG Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public static final field WEBP Lorg/jellyfin/sdk/model/api/ImageFormat;
 	public final fun getSerialName ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
@@ -4121,6 +4126,7 @@ public final class org/jellyfin/sdk/model/api/ItemFields : java/lang/Enum {
 	public static final field TAGS Lorg/jellyfin/sdk/model/api/ItemFields;
 	public static final field THEME_SONG_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
 	public static final field THEME_VIDEO_IDS Lorg/jellyfin/sdk/model/api/ItemFields;
+	public static final field TRICKPLAY Lorg/jellyfin/sdk/model/api/ItemFields;
 	public static final field WIDTH Lorg/jellyfin/sdk/model/api/ItemFields;
 	public final fun getSerialName ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
@@ -5221,6 +5227,7 @@ public final class org/jellyfin/sdk/model/api/MediaStreamType : java/lang/Enum {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/MediaStreamType$Companion;
 	public static final field DATA Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public static final field EMBEDDED_IMAGE Lorg/jellyfin/sdk/model/api/MediaStreamType;
+	public static final field LYRIC Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public static final field SUBTITLE Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public static final field VIDEO Lorg/jellyfin/sdk/model/api/MediaStreamType;
 	public final fun getSerialName ()Ljava/lang/String;
@@ -8396,6 +8403,7 @@ public final class org/jellyfin/sdk/model/api/SeriesStatus : java/lang/Enum {
 	public static final field CONTINUING Lorg/jellyfin/sdk/model/api/SeriesStatus;
 	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesStatus$Companion;
 	public static final field ENDED Lorg/jellyfin/sdk/model/api/SeriesStatus;
+	public static final field UNRELEASED Lorg/jellyfin/sdk/model/api/SeriesStatus;
 	public final fun getSerialName ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesStatus;

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DlnaProfileType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/DlnaProfileType.kt
@@ -21,6 +21,8 @@ public enum class DlnaProfileType(
 	PHOTO("Photo"),
 	@SerialName("Subtitle")
 	SUBTITLE("Subtitle"),
+	@SerialName("Lyric")
+	LYRIC("Lyric"),
 	;
 
 	public override fun toString(): String = serialName

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdMediaType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ExternalIdMediaType.kt
@@ -40,6 +40,8 @@ public enum class ExternalIdMediaType(
 	SERIES("Series"),
 	@SerialName("Track")
 	TRACK("Track"),
+	@SerialName("Book")
+	BOOK("Book"),
 	;
 
 	public override fun toString(): String = serialName

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GeneralCommandType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/GeneralCommandType.kt
@@ -100,6 +100,8 @@ public enum class GeneralCommandType(
 	PLAY("Play"),
 	@SerialName("SetMaxStreamingBitrate")
 	SET_MAX_STREAMING_BITRATE("SetMaxStreamingBitrate"),
+	@SerialName("SetPlaybackOrder")
+	SET_PLAYBACK_ORDER("SetPlaybackOrder"),
 	;
 
 	public override fun toString(): String = serialName

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/HardwareEncodingType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/HardwareEncodingType.kt
@@ -28,6 +28,8 @@ public enum class HardwareEncodingType(
 	VAAPI("VAAPI"),
 	@SerialName("VideoToolBox")
 	VIDEO_TOOL_BOX("VideoToolBox"),
+	@SerialName("RKMPP")
+	RKMPP("RKMPP"),
 	;
 
 	public override fun toString(): String = serialName

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageFormat.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ImageFormat.kt
@@ -26,6 +26,8 @@ public enum class ImageFormat(
 	PNG("Png"),
 	@SerialName("Webp")
 	WEBP("Webp"),
+	@SerialName("Svg")
+	SVG("Svg"),
 	;
 
 	public override fun toString(): String = serialName

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemFields.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/ItemFields.kt
@@ -138,6 +138,8 @@ public enum class ItemFields(
 	IS_HD("IsHD"),
 	@SerialName("SpecialFeatureCount")
 	SPECIAL_FEATURE_COUNT("SpecialFeatureCount"),
+	@SerialName("Trickplay")
+	TRICKPLAY("Trickplay"),
 	;
 
 	public override fun toString(): String = serialName

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaStreamType.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/MediaStreamType.kt
@@ -26,6 +26,8 @@ public enum class MediaStreamType(
 	EMBEDDED_IMAGE("EmbeddedImage"),
 	@SerialName("Data")
 	DATA("Data"),
+	@SerialName("Lyric")
+	LYRIC("Lyric"),
 	;
 
 	public override fun toString(): String = serialName

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesStatus.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesStatus.kt
@@ -20,6 +20,8 @@ public enum class SeriesStatus(
 	CONTINUING("Continuing"),
 	@SerialName("Ended")
 	ENDED("Ended"),
+	@SerialName("Unreleased")
+	UNRELEASED("Unreleased"),
 	;
 
 	public override fun toString(): String = serialName

--- a/openapi.json
+++ b/openapi.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fc2ccc2479d66bf16ab7eb2d5205b0cffbbc5593dc70ae7d3c0e6942f6e3809
-size 1619454
+oid sha256:b518b82f91587c2f4b115a1dd7144671039af53349ae053da3736ff675fcff77
+size 1619624


### PR DESCRIPTION
**Note: Targets release-1.4.z branch**

When using a 10.8.z based SDK with a 10.9 server there are a few issues, all listed in the [10.9 on Android support issue](https://github.com/jellyfin/jellyfin-androidtv/issues/3467). While most problems can be fixed server-side, a few need changes in the SDK. More specifically: new enum members. When the SDK receives a response and expects an enum, an unknown member will cause deserialization issues.

This change adds all the new enum members from 10.9 to the 10.8.13 API specification. This prevents the deserialization issue and therefor allows a client to support both 10.8 and 10.9, although without the 10.9 specific features as those API's are not in the SDK.

By introducing this change in a 1.4 patch release we can have a smooth transition to 10.9 instead of abruptly dropping 10.8 support and requiring 10.9 support in our official clients.

The changes to the openapi.json file were made manually, with the openapi-generator diff code used to find new enum members. All other changes are generated automatically (second commit).