### PR TITLE
Update JSON options in ApiSerializer

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.sdk.api.client.util
 
-import io.ktor.utils.io.*
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readRemaining
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -10,10 +11,16 @@ import org.jellyfin.sdk.model.api.OutboundWebSocketMessage
 
 public object ApiSerializer {
 	public val json: Json = Json {
+		// Require strict JSON syntax
 		isLenient = false
+		// Properties from newer API versions should be ignored
 		ignoreUnknownKeys = true
+		// Allow NaN and Infinity values for numbers
 		allowSpecialFloatingPointValues = true
-		useArrayPolymorphism = false
+		// Deprecated fields may be removed in a newer Jellyfin version, fall back to null if possible
+		explicitNulls = false
+		// Unknown enum members should fall back to a default value (null/other member)
+		coerceInputValues = true
 	}
 
 	@OptIn(InternalSerializationApi::class)


### PR DESCRIPTION
This pull request updates the JSON options in the ApiSerializer to more easily deal with new enum members and removed properties. I've added comments to the properties explaining why we're setting their values.

The useArrayPolymorphism option is removed because it is already disabled by default, it just enabled an old (obsolete) polymorphism implementation in the kotlinx.serialization library.

With this change we can more easily add new enum members if the properties using the enum has a default value. It does not work if the property is nullable without a default value though.