### PR TITLE
Remove userId property from ApiClient

### DIFF
--- a/jellyfin-api-ktor/api/jellyfin-api-ktor.api
+++ b/jellyfin-api-ktor/api/jellyfin-api-ktor.api
@@ -1,18 +1,16 @@
 public class org/jellyfin/sdk/api/ktor/KtorClient : org/jellyfin/sdk/api/client/ApiClient {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAccessToken ()Ljava/lang/String;
 	public fun getBaseUrl ()Ljava/lang/String;
 	public fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
-	public fun getUserId ()Ljava/util/UUID;
 	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun setAccessToken (Ljava/lang/String;)V
 	public fun setBaseUrl (Ljava/lang/String;)V
 	public fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
-	public fun setUserId (Ljava/util/UUID;)V
 	public fun ws ()Lorg/jellyfin/sdk/api/sockets/SocketInstance;
 }
 

--- a/jellyfin-api-ktor/src/commonMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/commonMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -8,13 +8,11 @@ import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
-import org.jellyfin.sdk.model.UUID
 
 @Suppress("LongParameterList")
 public expect open class KtorClient(
 	baseUrl: String? = null,
 	accessToken: String? = null,
-	userId: UUID? = null,
 	clientInfo: ClientInfo,
 	deviceInfo: DeviceInfo,
 	httpClientOptions: HttpClientOptions,

--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -36,7 +36,6 @@ import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
-import org.jellyfin.sdk.model.UUID
 import java.io.IOException
 import java.net.ConnectException
 import java.net.UnknownHostException
@@ -51,7 +50,6 @@ import io.ktor.http.HttpMethod as KtorHttpMethod
 public actual open class KtorClient actual constructor(
 	override var baseUrl: String?,
 	override var accessToken: String?,
-	override var userId: UUID?,
 	override var clientInfo: ClientInfo,
 	override var deviceInfo: DeviceInfo,
 	override val httpClientOptions: HttpClientOptions,

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -11,14 +11,12 @@ public abstract class org/jellyfin/sdk/api/client/ApiClient {
 	public abstract fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public abstract fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
 	public final fun getOrCreateApi (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/api/operations/Api;
-	public abstract fun getUserId ()Ljava/util/UUID;
 	public abstract fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun request$default (Lorg/jellyfin/sdk/api/client/ApiClient;Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun setAccessToken (Ljava/lang/String;)V
 	public abstract fun setBaseUrl (Ljava/lang/String;)V
 	public abstract fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public abstract fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
-	public abstract fun setUserId (Ljava/util/UUID;)V
 	public abstract fun ws ()Lorg/jellyfin/sdk/api/sockets/SocketInstance;
 }
 
@@ -106,12 +104,6 @@ public final class org/jellyfin/sdk/api/client/exception/MissingPathVariableExce
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPath ()Ljava/lang/String;
-}
-
-public final class org/jellyfin/sdk/api/client/exception/MissingUserIdException : org/jellyfin/sdk/api/client/exception/ApiClientException {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public class org/jellyfin/sdk/api/client/exception/SecureConnectionException : org/jellyfin/sdk/api/client/exception/ApiClientException {

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
@@ -6,7 +6,6 @@ import org.jellyfin.sdk.api.operations.Api
 import org.jellyfin.sdk.api.sockets.SocketInstance
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
-import org.jellyfin.sdk.model.UUID
 import kotlin.reflect.KClass
 
 public abstract class ApiClient {
@@ -32,12 +31,6 @@ public abstract class ApiClient {
 	 * Access token to use for requests. Appended to all requests if set.
 	 */
 	public abstract var accessToken: String?
-
-	/**
-	 * User identifier that will automatically be used in user-specific API operations.
-	 * Should correspond to the same user as [accessToken].
-	 */
-	public abstract var userId: UUID?
 
 	/**
 	 * Information about the client / application send in all API requests.

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/exception/MissingUserIdException.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/exception/MissingUserIdException.kt
@@ -1,8 +1,0 @@
-package org.jellyfin.sdk.api.client.exception
-
-public class MissingUserIdException(
-	cause: Throwable? = null,
-) : ApiClientException(
-	"Required value userId is null. Provide it by setting ApiClient.userId or passing it in the function call.",
-	cause
-)

--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -5,11 +5,10 @@ public final class org/jellyfin/sdk/Jellyfin {
 	public final fun createApi ()Lorg/jellyfin/sdk/api/client/ApiClient;
 	public final fun createApi (Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/ApiClient;
 	public final fun createApi (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public static synthetic fun createApi$default (Lorg/jellyfin/sdk/Jellyfin;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;ILjava/lang/Object;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public static synthetic fun createApi$default (Lorg/jellyfin/sdk/Jellyfin;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;ILjava/lang/Object;)Lorg/jellyfin/sdk/api/client/ApiClient;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun getDiscovery ()Lorg/jellyfin/sdk/discovery/DiscoveryService;
@@ -272,6 +271,6 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$Unsupported
 }
 
 public abstract interface class org/jellyfin/sdk/util/ApiClientFactory {
-	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
 }
 

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -5,11 +5,10 @@ public final class org/jellyfin/sdk/Jellyfin {
 	public final fun createApi ()Lorg/jellyfin/sdk/api/client/ApiClient;
 	public final fun createApi (Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/ApiClient;
 	public final fun createApi (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;)Lorg/jellyfin/sdk/api/client/ApiClient;
-	public static synthetic fun createApi$default (Lorg/jellyfin/sdk/Jellyfin;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;ILjava/lang/Object;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public final fun createApi (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public static synthetic fun createApi$default (Lorg/jellyfin/sdk/Jellyfin;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;ILjava/lang/Object;)Lorg/jellyfin/sdk/api/client/ApiClient;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun getDiscovery ()Lorg/jellyfin/sdk/discovery/DiscoveryService;
@@ -264,6 +263,6 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$Unsupported
 }
 
 public abstract interface class org/jellyfin/sdk/util/ApiClientFactory {
-	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
 }
 

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -7,7 +7,6 @@ import org.jellyfin.sdk.discovery.DiscoveryService
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.ServerVersion
-import org.jellyfin.sdk.model.UUID
 
 public class Jellyfin(
 	public val options: JellyfinOptions,
@@ -43,7 +42,6 @@ public class Jellyfin(
 	public fun createApi(
 		baseUrl: String? = null,
 		accessToken: String? = null,
-		userId: UUID? = null,
 		clientInfo: ClientInfo? = options.clientInfo,
 		deviceInfo: DeviceInfo? = options.deviceInfo,
 		httpClientOptions: HttpClientOptions = HttpClientOptions(),
@@ -58,7 +56,6 @@ public class Jellyfin(
 		return options.apiClientFactory.create(
 			baseUrl = baseUrl,
 			accessToken = accessToken,
-			userId = userId,
 			clientInfo = clientInfo,
 			deviceInfo = deviceInfo,
 			httpClientOptions = httpClientOptions,

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/util/ApiClientFactory.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/util/ApiClientFactory.kt
@@ -5,14 +5,12 @@ import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
-import org.jellyfin.sdk.model.UUID
 
 public fun interface ApiClientFactory {
 	@Suppress("LongParameterList")
 	public fun create(
 		baseUrl: String?,
 		accessToken: String?,
-		userId: UUID?,
 		clientInfo: ClientInfo,
 		deviceInfo: DeviceInfo,
 		httpClientOptions: HttpClientOptions,

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Libraries.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Libraries.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.runBlocking
 import org.jellyfin.sample.cli.apiInstanceHolder
 import org.jellyfin.sample.cli.logger
 import org.jellyfin.sdk.Jellyfin
-import org.jellyfin.sdk.api.client.extensions.sessionApi
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 
 class Libraries(
@@ -15,11 +14,7 @@ class Libraries(
 	private val api by apiInstanceHolder(jellyfin)
 
 	override fun run(): Unit = runBlocking {
-		val sessionInfo = api.sessionApi.getSessions(deviceId = api.deviceInfo.id).content.firstOrNull()
-		if (sessionInfo == null) logger.info("Unknown session")
-		api.userId = sessionInfo?.userId
-
-		val libraries by api.userViewsApi.getUserViews(userId = requireNotNull(api.userId), includeHidden = false)
+		val libraries by api.userViewsApi.getUserViews(includeHidden = false)
 
 		if (libraries.items.isNullOrEmpty()) logger.info("No libraries found")
 


### PR DESCRIPTION
We removed the "DefaultUserIdHook" in #879. At that time I left the userId property in ApiClient but we don't actually use it in the SDK itself. As such it could be removed entirely.