### PR TITLE
Replace property setters in ApiClient with new update function

### DIFF
--- a/jellyfin-api-ktor/api/jellyfin-api-ktor.api
+++ b/jellyfin-api-ktor/api/jellyfin-api-ktor.api
@@ -11,6 +11,7 @@ public class org/jellyfin/sdk/api/ktor/KtorClient : org/jellyfin/sdk/api/client/
 	public fun setBaseUrl (Ljava/lang/String;)V
 	public fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public fun update (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)V
 	public fun ws ()Lorg/jellyfin/sdk/api/sockets/SocketInstance;
 }
 

--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -66,6 +66,13 @@ public actual open class KtorClient actual constructor(
 		}
 	}
 
+	override fun update(baseUrl: String?, accessToken: String?, clientInfo: ClientInfo, deviceInfo: DeviceInfo) {
+		this.baseUrl = baseUrl
+		this.accessToken = accessToken
+		this.clientInfo = clientInfo
+		this.deviceInfo = deviceInfo
+	}
+
 	@Suppress("ThrowsCount")
 	public actual override suspend fun request(
 		method: HttpMethod,

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -17,6 +17,8 @@ public abstract class org/jellyfin/sdk/api/client/ApiClient {
 	public abstract fun setBaseUrl (Ljava/lang/String;)V
 	public abstract fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public abstract fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public abstract fun update (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)V
+	public static synthetic fun update$default (Lorg/jellyfin/sdk/api/client/ApiClient;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;ILjava/lang/Object;)V
 	public abstract fun ws ()Lorg/jellyfin/sdk/api/sockets/SocketInstance;
 }
 

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
@@ -8,6 +8,10 @@ import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import kotlin.reflect.KClass
 
+private const val UPDATE_DEPRECATION_MESSAGE =
+	"This property should not be set directly as changes are not propagated to the WebSocket connection." +
+		" Migrate to using the update() function instead."
+
 public abstract class ApiClient {
 	public companion object {
 		/**
@@ -26,27 +30,41 @@ public abstract class ApiClient {
 	 * URL to use as base for API endpoints. Should include the protocol and may contain a path.
 	 */
 	public abstract var baseUrl: String?
+		@Deprecated(UPDATE_DEPRECATION_MESSAGE) set
 
 	/**
 	 * Access token to use for requests. Appended to all requests if set.
 	 */
 	public abstract var accessToken: String?
+		@Deprecated(UPDATE_DEPRECATION_MESSAGE) set
 
 	/**
 	 * Information about the client / application send in all API requests.
 	 */
 	public abstract var clientInfo: ClientInfo
+		@Deprecated(UPDATE_DEPRECATION_MESSAGE) set
 
 	/**
 	 * Information about the device send in all API requests. Only a single session is allowed per
 	 * device id.
 	 */
 	public abstract var deviceInfo: DeviceInfo
+		@Deprecated(UPDATE_DEPRECATION_MESSAGE) set
 
 	/**
 	 * HTTP Options for this ApiClient.
 	 */
 	public abstract val httpClientOptions: HttpClientOptions
+
+	/**
+	 * Change the authorization values used in this ApiClient instance.
+	 */
+	public abstract fun update(
+		baseUrl: String? = this.baseUrl,
+		accessToken: String? = this.accessToken,
+		clientInfo: ClientInfo = this.clientInfo,
+		deviceInfo: DeviceInfo = this.deviceInfo,
+	)
 
 	/**
 	 * Create a complete url based on the [baseUrl] and given parameters.


### PR DESCRIPTION
I've been working on a new WebSocket client implementation for some weeks now and updating credentials for the socket has always been annoying (you need to manually call an `updateCredentials()` function).

This pull request adds the initial changes required to fix this problem. The update function will make the websocket  (if active) reconnect in my wip branch. The property setters are deprecated and should be removed in 1.6.

The reason for adding an update function instead of doing it from the setters it that in most cases you will be updating multiple properties at the same time, which would cause the WebSocket connection to initiate a reconnect multiple times if no extra code was added to prevent that.

Depends on #910