### PR TITLE
Flow on Dispatchers.IO by default in LocalServerDiscovery

### DIFF
--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
@@ -1,7 +1,9 @@
 package org.jellyfin.sdk.discovery
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.isActive
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -121,5 +123,5 @@ public actual class LocalServerDiscovery actual constructor(jellyfinOptions: Jel
 		socket.close()
 
 		logger.debug { "End" }
-	}
+	}.flowOn(Dispatchers.IO)
 }


### PR DESCRIPTION
Although most clients probably set the context already, it's good to have it safe by default. Discovery is a blocking operation and we want to make sure it is running on the IO dispatcher.