### PR TITLE
Fix a kdoc typo

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/exception/ssl/HandshakeCertificateException.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/exception/ssl/HandshakeCertificateException.kt
@@ -2,7 +2,7 @@ package org.jellyfin.sdk.api.client.exception.ssl
 
 import org.jellyfin.sdk.api.client.exception.SecureConnectionException
 
-/***
+/**
  * An error occurred while attempting to establish a secure connection.
  * Indicates that the client and server could not negotiate the desired level of security or the certificate was
  * revoked.


### PR DESCRIPTION
This extra `*` causes Android Studio to render a markdown list item.

![image](https://github.com/jellyfin/jellyfin-sdk-kotlin/assets/2305178/4101783d-9525-4649-b601-c4e677e12f46)
