### PR TITLE
Fix javadoc using wrong name

### DIFF
--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -47,7 +47,7 @@ enablePublishing {
 	val javadocJar by tasks.creating(Jar::class) {
 		dependsOn(tasks.dokkaHtml)
 		from(tasks.dokkaHtml.flatMap { it.outputDirectory })
-		archiveClassifier.set("html-docs")
+		archiveClassifier.set("javadoc")
 	}
 
 	publications.withType<MavenPublication> {

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -49,7 +49,7 @@ enablePublishing {
 	val javadocJar by tasks.creating(Jar::class) {
 		dependsOn(tasks.dokkaHtml)
 		from(tasks.dokkaHtml.flatMap { it.outputDirectory })
-		archiveClassifier.set("html-docs")
+		archiveClassifier.set("javadoc")
 	}
 
 	publications.withType<MavenPublication> {

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -93,7 +93,7 @@ enablePublishing {
 	val javadocJar by tasks.creating(Jar::class) {
 		dependsOn(tasks.dokkaHtml)
 		from(tasks.dokkaHtml.flatMap { it.outputDirectory })
-		archiveClassifier.set("html-docs")
+		archiveClassifier.set("javadoc")
 	}
 
 	publications.withType<MavenPublication> {

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -39,7 +39,7 @@ enablePublishing {
 	val javadocJar by tasks.creating(Jar::class) {
 		dependsOn(tasks.dokkaHtml)
 		from(tasks.dokkaHtml.flatMap { it.outputDirectory })
-		archiveClassifier.set("html-docs")
+		archiveClassifier.set("javadoc")
 	}
 
 	publications.withType<MavenPublication> {


### PR DESCRIPTION
Maven Central requires this name or it will reject publishing. Ask me how I know.