### PR TITLE
Optimize Regex object usage for parameter validation

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -24,6 +24,11 @@ public final class org/jellyfin/sdk/model/DeviceInfo {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/jellyfin/sdk/model/RegexValidator {
+	public static final field INSTANCE Lorg/jellyfin/sdk/model/RegexValidator;
+	public final fun matches (Ljava/lang/String;Ljava/lang/String;)Z
+}
+
 public final class org/jellyfin/sdk/model/ServerVersion : java/lang/Comparable {
 	public static final field Companion Lorg/jellyfin/sdk/model/ServerVersion$Companion;
 	public fun <init> (IIILjava/lang/Integer;)V

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/RegexValidator.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/RegexValidator.kt
@@ -1,0 +1,10 @@
+package org.jellyfin.sdk.model
+
+
+public object RegexValidator {
+	private val patterns = mutableMapOf<String, Regex>()
+
+	public fun matches(value: String, pattern: String): Boolean {
+		return patterns.getOrPut(pattern) { Regex(pattern) }.matches(value)
+	}
+}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -71,21 +71,21 @@ open class OperationBuilder(
 		is RegexValidation -> addCode(CodeBlock.builder().apply {
 			if (parameter.type.isNullable) {
 				addStatement(
-					"%M(%N·==·null·||·%M(%P).matches(%N))·{·%P·}",
+					"%M(%N·==·null·||·%M.matches(%N,%P))·{·%P·}",
 					MemberName("kotlin", "require"),
 					parameter.name,
-					MemberName("kotlin.text", "Regex"),
-					validation.pattern,
+					MemberName("org.jellyfin.sdk.model", "RegexValidator"),
 					parameter.name,
+					validation.pattern,
 					"Parameter \"${parameter.name}\" must match ${validation.pattern}."
 				)
 			} else {
 				addStatement(
-					"%M(%M(%P).matches(%N))·{·%P·}",
+					"%M(%M.matches(%N,%P))·{·%P·}",
 					MemberName("kotlin", "require"),
-					MemberName("kotlin.text", "Regex"),
-					validation.pattern,
+					MemberName("org.jellyfin.sdk.model", "RegexValidator"),
 					parameter.name,
+					validation.pattern,
 					"Parameter \"${parameter.name}\" must match ${validation.pattern}."
 				)
 			}


### PR DESCRIPTION
Use a new object to store requested Regex objects for parameter validation. When a parameter needs regex validation, retrieve the appropriate Regex from this object instead of creating a new one.

Resolves #864