### PR TITLE
Head requests for server discovery

### DIFF
--- a/jellyfin-api-ktor/api/jellyfin-api-ktor.api
+++ b/jellyfin-api-ktor/api/jellyfin-api-ktor.api
@@ -7,7 +7,7 @@ public class org/jellyfin/sdk/api/ktor/KtorClient : org/jellyfin/sdk/api/client/
 	public fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
 	public fun getWebSocket ()Lorg/jellyfin/sdk/api/sockets/SocketApi;
-	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/ranges/IntRange;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun setAccessToken (Ljava/lang/String;)V
 	public fun setBaseUrl (Ljava/lang/String;)V
 	public fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V

--- a/jellyfin-api-ktor/src/commonMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/commonMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -23,5 +23,6 @@ public expect open class KtorClient(
 		pathParameters: Map<String, Any?>,
 		queryParameters: Map<String, Any?>,
 		requestBody: Any?,
+		expectedResponse: IntRange,
 	): RawResponse
 }

--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -127,7 +127,7 @@ public actual open class KtorClient actual constructor(
 			}
 
 			// Check HTTP status
-			if (!response.status.isSuccess()) throw InvalidStatusException(response.status.value)
+			if (response.status.value !in expectedResponse) throw InvalidStatusException(response.status.value)
 			// Return custom response instance
 			return RawResponse(response.bodyAsChannel(), response.status.value, response.headers.toMap())
 		} catch (err: UnknownHostException) {
@@ -166,5 +166,6 @@ public actual open class KtorClient actual constructor(
 		HttpMethod.GET -> KtorHttpMethod.Get
 		HttpMethod.POST -> KtorHttpMethod.Post
 		HttpMethod.DELETE -> KtorHttpMethod.Delete
+		HttpMethod.HEAD -> KtorHttpMethod.Head
 	}
 }

--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -83,6 +83,7 @@ public actual open class KtorClient actual constructor(
 		pathParameters: Map<String, Any?>,
 		queryParameters: Map<String, Any?>,
 		requestBody: Any?,
+		expectedResponse: IntRange,
 	): RawResponse {
 		val url = createUrl(pathTemplate, pathParameters, queryParameters)
 

--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -14,7 +14,6 @@ import io.ktor.content.ByteArrayContent
 import io.ktor.content.TextContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import io.ktor.http.isSuccess
 import io.ktor.util.toMap
 import kotlinx.serialization.SerializationException
 import mu.KotlinLogging

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -12,8 +12,8 @@ public abstract class org/jellyfin/sdk/api/client/ApiClient {
 	public abstract fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
 	public final fun getOrCreateApi (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lorg/jellyfin/sdk/api/operations/Api;
 	public abstract fun getWebSocket ()Lorg/jellyfin/sdk/api/sockets/SocketApi;
-	public abstract fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun request$default (Lorg/jellyfin/sdk/api/client/ApiClient;Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/ranges/IntRange;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun request$default (Lorg/jellyfin/sdk/api/client/ApiClient;Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/ranges/IntRange;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun setAccessToken (Ljava/lang/String;)V
 	public abstract fun setBaseUrl (Ljava/lang/String;)V
 	public abstract fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
@@ -48,6 +48,7 @@ public final class org/jellyfin/sdk/api/client/HttpClientOptions {
 public final class org/jellyfin/sdk/api/client/HttpMethod : java/lang/Enum {
 	public static final field DELETE Lorg/jellyfin/sdk/api/client/HttpMethod;
 	public static final field GET Lorg/jellyfin/sdk/api/client/HttpMethod;
+	public static final field HEAD Lorg/jellyfin/sdk/api/client/HttpMethod;
 	public static final field POST Lorg/jellyfin/sdk/api/client/HttpMethod;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jellyfin/sdk/api/client/HttpMethod;

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClient.kt
@@ -91,6 +91,7 @@ public abstract class ApiClient {
 		pathParameters: Map<String, Any?> = emptyMap(),
 		queryParameters: Map<String, Any?> = emptyMap(),
 		requestBody: Any? = null,
+		expectedResponse: IntRange = 200 until 300,
 	): RawResponse
 
 	/**

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/HttpMethod.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/HttpMethod.kt
@@ -4,4 +4,5 @@ public enum class HttpMethod {
 	GET,
 	POST,
 	DELETE,
+	HEAD,
 }

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
@@ -53,5 +53,6 @@ public suspend inline fun <reified T : Any> ApiClient.head(
 	pathTemplate = pathTemplate,
 	pathParameters = pathParameters,
 	queryParameters = queryParameters,
-	requestBody = requestBody
+	requestBody = requestBody,
+	expectedResponse = 300 until 400
 ).createResponse()

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/extensions/HttpMethodExtensions.kt
@@ -42,3 +42,16 @@ public suspend inline fun <reified T : Any> ApiClient.delete(
 	queryParameters = queryParameters,
 	requestBody = requestBody
 ).createResponse()
+
+public suspend inline fun <reified T : Any> ApiClient.head(
+	pathTemplate: String,
+	pathParameters: Map<String, Any?> = emptyMap(),
+	queryParameters: Map<String, Any?> = emptyMap(),
+	requestBody: Any? = null,
+): Response<T> = request(
+	method = HttpMethod.HEAD,
+	pathTemplate = pathTemplate,
+	pathParameters = pathParameters,
+	queryParameters = queryParameters,
+	requestBody = requestBody
+).createResponse()

--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -130,9 +130,9 @@ public final class org/jellyfin/sdk/discovery/DiscoveryService {
 	public static synthetic fun discoverLocalServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;IIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/Collection;
 	public final fun getRecommendedServers (Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRecommendedServers (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/LocalServerDiscovery {
@@ -152,26 +152,31 @@ public final class org/jellyfin/sdk/discovery/LocalServerDiscovery$Companion {
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerDiscovery {
 	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
-	public final fun discover (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discover (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun discover$default (Lorg/jellyfin/sdk/discovery/RecommendedServerDiscovery;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerInfo {
-	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
 	public final fun component3 ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public final fun component4 ()Ljava/util/Collection;
 	public final fun component5-d1pmJ48 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Lkotlin/Result;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Lkotlin/Result;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun firstIssueOrNull ()Lorg/jellyfin/sdk/discovery/RecommendedServerIssue;
 	public final fun getAddress ()Ljava/lang/String;
 	public final fun getIssues ()Ljava/util/Collection;
+	public final fun getOriginalAddress ()Ljava/lang/String;
 	public final fun getResponseTime ()J
 	public final fun getScore ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public final fun getSystemInfo-d1pmJ48 ()Ljava/lang/Object;
 	public fun hashCode ()I
+	public final fun isRedirect ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -224,6 +229,19 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedSer
 	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFinalAddress ()Ljava/lang/String;
+	public final fun getOriginalAddress ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -122,9 +122,9 @@ public final class org/jellyfin/sdk/discovery/DiscoveryService {
 	public static synthetic fun discoverLocalServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;IIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getAddressCandidates (Ljava/lang/String;)Ljava/util/Collection;
 	public final fun getRecommendedServers (Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRecommendedServers (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecommendedServers (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/lang/String;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getRecommendedServers$default (Lorg/jellyfin/sdk/discovery/DiscoveryService;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/LocalServerDiscovery {
@@ -144,26 +144,31 @@ public final class org/jellyfin/sdk/discovery/LocalServerDiscovery$Companion {
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerDiscovery {
 	public fun <init> (Lorg/jellyfin/sdk/Jellyfin;)V
-	public final fun discover (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discover (Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun discover$default (Lorg/jellyfin/sdk/discovery/RecommendedServerDiscovery;Ljava/util/Collection;Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/discovery/RecommendedServerInfo {
-	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
 	public final fun component3 ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public final fun component4 ()Ljava/util/Collection;
 	public final fun component5-d1pmJ48 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Lkotlin/Result;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Ljava/lang/Object;Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;Ljava/lang/String;JLorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;Ljava/util/Collection;Lkotlin/Result;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun firstIssueOrNull ()Lorg/jellyfin/sdk/discovery/RecommendedServerIssue;
 	public final fun getAddress ()Ljava/lang/String;
 	public final fun getIssues ()Ljava/util/Collection;
+	public final fun getOriginalAddress ()Ljava/lang/String;
 	public final fun getResponseTime ()J
 	public final fun getScore ()Lorg/jellyfin/sdk/discovery/RecommendedServerInfoScore;
 	public final fun getSystemInfo-d1pmJ48 ()Ljava/lang/Object;
 	public fun hashCode ()I
+	public final fun isRedirect ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -216,6 +221,19 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedSer
 	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$OutdatedServerVersion;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse : org/jellyfin/sdk/discovery/RecommendedServerIssue {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/discovery/RecommendedServerIssue$RedirectedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFinalAddress ()Ljava/lang/String;
+	public final fun getOriginalAddress ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/DiscoveryService.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/DiscoveryService.kt
@@ -45,9 +45,11 @@ public class DiscoveryService(
 	public suspend fun getRecommendedServers(
 		servers: Collection<String>,
 		minimumScore: RecommendedServerInfoScore = RecommendedServerInfoScore.BAD,
+		followRedirects: Boolean = false,
 	): Collection<RecommendedServerInfo> = recommendedServerDiscovery.discover(
 		servers = servers,
-		minimumScore = minimumScore
+		minimumScore = minimumScore,
+		followRedirects = followRedirects
 	)
 
 	/**

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
@@ -129,6 +129,7 @@ public class RecommendedServerDiscovery constructor(
 			score,
 			issues,
 			result.systemInfo,
+			if (result.address.isRedirect()) result.address.originalAddress else null,
 		)
 	}
 

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerDiscovery.kt
@@ -188,7 +188,6 @@ public class RecommendedServerDiscovery constructor(
 
 		val info = try {
 			val response = client.head<Unit>(pathTemplate = "")
-			logger.debug { "response = $response" }
 			Result.success(response)
 		} catch (err: TimeoutException) {
 			logger.debug(err) { "Could not connect to $address" }
@@ -199,7 +198,7 @@ public class RecommendedServerDiscovery constructor(
 		}
 
 		// get the Location header or exit
-		val location = info.getOrElse { return null }.getHeader(HttpHeaders.Location) ?: return null
+		val location = info.getOrElse { return null }.getHeader(HttpHeaders.Location.lowercase()) ?: return null
 
 		// only follow the redirect if on the same host
 		val locationUrl = URLBuilder(location).build()

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfo.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerInfo.kt
@@ -8,10 +8,13 @@ public data class RecommendedServerInfo(
 	val score: RecommendedServerInfoScore,
 	val issues: Collection<RecommendedServerIssue>,
 	val systemInfo: Result<PublicSystemInfo>,
+	val originalAddress: String? = null,
 ) {
 	/**
 	 * The issues are ordered by importance. When showing a single issue to an end user you
 	 * normally want to show the first one.
 	 */
 	public fun firstIssueOrNull(): RecommendedServerIssue? = issues.firstOrNull()
+
+	public fun isRedirect(): Boolean = originalAddress != null && originalAddress != address
 }

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerIssue.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/RecommendedServerIssue.kt
@@ -50,4 +50,9 @@ public sealed interface RecommendedServerIssue {
 	 * The system information response was slow.
 	 */
 	public data class SlowResponse(public val responseTime: Long) : RecommendedServerIssue
+
+	/**
+	 * The address was the result of a redirect
+	 */
+	public data class RedirectedResponse(public val originalAddress: String, public val finalAddress: String) : RecommendedServerIssue
 }

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
@@ -39,7 +39,7 @@ class Discover(
 		val candidates = jellyfin.discovery.getAddressCandidates(address)
 		logger.info("Found ${candidates.size} candidates")
 
-		val servers = jellyfin.discovery.getRecommendedServers(candidates)
+		val servers = jellyfin.discovery.getRecommendedServers(candidates, followRedirects = true)
 		for (server in servers) {
 			buildString {
 				append(server.address)


### PR DESCRIPTION
Optionally add the result of an HTTP redirect to the discovered servers during the remote discovery process, but only if the redirect stays on the same domain.

Resolves #471 

Adds head requests to the ApiClient and loosens the requirement to return OK status by allowing a specified range. The redirect logic is contained in RecommendedServerDiscovery, supported by a new RecommendedServerIssue to slightly prefer non-redirected addresses. If an address was found as the result of following a redirect, its RecommendedServerInfo will include the original address, and a new method isRedirect() returns true.