### PR TITLE
Support media type for image uploads

### DIFF
--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -34,6 +34,7 @@ import org.jellyfin.sdk.api.sockets.SocketApi
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.FileInfo
 import java.io.IOException
 import java.net.ConnectException
 import java.net.UnknownHostException
@@ -116,6 +117,8 @@ public actual open class KtorClient actual constructor(
 				when (requestBody) {
 					// String content
 					is String -> setBody(TextContent(requestBody, ContentType.Text.Plain))
+					// File content
+					is FileInfo -> setBody(ByteArrayContent(requestBody.content, ContentType.parse(requestBody.mediaType)))
 					// Binary content
 					is ByteArray -> setBody(ByteArrayContent(requestBody, ContentType.Application.OctetStream))
 					// Json content

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -553,12 +553,12 @@ public final class org/jellyfin/sdk/api/operations/ImageApi : org/jellyfin/sdk/a
 	public static synthetic fun getUserImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Lorg/jellyfin/sdk/model/api/request/GetUserImageRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getUserImageUrl (Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/String;
 	public static synthetic fun getUserImageUrl$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Ljava/lang/String;Lorg/jellyfin/sdk/model/api/ImageFormat;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
-	public final fun postUserImage (Ljava/util/UUID;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun postUserImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;[BLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun setItemImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun setItemImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;I[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun postUserImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/FileInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun postUserImage$default (Lorg/jellyfin/sdk/api/operations/ImageApi;Ljava/util/UUID;Lorg/jellyfin/sdk/model/FileInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setItemImage (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;Lorg/jellyfin/sdk/model/FileInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setItemImageByIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;ILorg/jellyfin/sdk/model/FileInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun updateItemImageIndex (Ljava/util/UUID;Lorg/jellyfin/sdk/model/api/ImageType;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun uploadCustomSplashscreen ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun uploadCustomSplashscreen (Lorg/jellyfin/sdk/model/FileInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jellyfin/sdk/api/operations/InstantMixApi : org/jellyfin/sdk/api/operations/Api {

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
@@ -7,7 +7,6 @@ package org.jellyfin.sdk.api.operations
 
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
-import kotlin.ByteArray
 import kotlin.Double
 import kotlin.Int
 import kotlin.String
@@ -21,6 +20,7 @@ import org.jellyfin.sdk.api.client.Response
 import org.jellyfin.sdk.api.client.extensions.`get`
 import org.jellyfin.sdk.api.client.extensions.delete
 import org.jellyfin.sdk.api.client.extensions.post
+import org.jellyfin.sdk.model.FileInfo
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageInfo
@@ -2352,7 +2352,7 @@ public class ImageApi(
 	 *
 	 * @param userId User Id.
 	 */
-	public suspend fun postUserImage(userId: UUID? = null, `data`: ByteArray): Response<Unit> {
+	public suspend fun postUserImage(userId: UUID? = null, `data`: FileInfo): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = buildMap<String, Any?>(1) {
 			put("userId", userId)
@@ -2370,7 +2370,7 @@ public class ImageApi(
 	public suspend fun setItemImage(
 		itemId: UUID,
 		imageType: ImageType,
-		`data`: ByteArray,
+		`data`: FileInfo,
 	): Response<Unit> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
@@ -2393,7 +2393,7 @@ public class ImageApi(
 		itemId: UUID,
 		imageType: ImageType,
 		imageIndex: Int,
-		`data`: ByteArray,
+		`data`: FileInfo,
 	): Response<Unit> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("itemId", itemId)
@@ -2438,7 +2438,7 @@ public class ImageApi(
 	 * Uploads a custom splashscreen.
 	 * The body is expected to the image contents base64 encoded.
 	 */
-	public suspend fun uploadCustomSplashscreen(`data`: ByteArray): Response<Unit> {
+	public suspend fun uploadCustomSplashscreen(`data`: FileInfo): Response<Unit> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = emptyMap<String, Any?>()
 		val response = api.post<Unit>("/Branding/Splashscreen", pathParameters, queryParameters, data)

--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -24,6 +24,18 @@ public final class org/jellyfin/sdk/model/DeviceInfo {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/jellyfin/sdk/model/FileInfo {
+	public fun <init> ([BLjava/lang/String;)V
+	public synthetic fun <init> ([BLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getContent ()[B
+	public final fun getMediaType ()Ljava/lang/String;
+}
+
+public final class org/jellyfin/sdk/model/FileInfoKt {
+	public static final fun toFileInfo ([BLjava/lang/String;)Lorg/jellyfin/sdk/model/FileInfo;
+	public static synthetic fun toFileInfo$default ([BLjava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/FileInfo;
+}
+
 public final class org/jellyfin/sdk/model/ServerVersion : java/lang/Comparable {
 	public static final field Companion Lorg/jellyfin/sdk/model/ServerVersion$Companion;
 	public fun <init> (IIILjava/lang/Integer;)V

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/FileInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/FileInfo.kt
@@ -1,0 +1,23 @@
+package org.jellyfin.sdk.model
+
+/**
+ * Information about a file used to for uploading.
+ */
+public class FileInfo(
+	/**
+	 * The binary content of the file.
+	 */
+	public val content: ByteArray,
+
+	/**
+	 * The media type of the file. Defaults to "
+	 */
+	public val mediaType: String = "application/octet-stream",
+)
+
+/**
+ * Create a [FileInfo] from this byte array.
+ */
+public fun ByteArray.toFileInfo(
+	mediaType: String = "application/octet-stream",
+): FileInfo = FileInfo(this, mediaType)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiApiServicesBuilder.kt
@@ -128,9 +128,9 @@ class OpenApiApiServicesBuilder(
 			// JSON model body
 			MimeType.APPLICATION_JSON -> ApiServiceOperationRequestBody.Json(model)
 			// Image body
-			MimeType.IMAGE_ALL -> ApiServiceOperationRequestBody.Binary
+			MimeType.IMAGE_ALL -> ApiServiceOperationRequestBody.Binary(requestBodyType)
 			// String body
-			MimeType.TEXT_PLAIN -> ApiServiceOperationRequestBody.String
+			MimeType.TEXT_PLAIN -> ApiServiceOperationRequestBody.Text
 			// Unknown type
 			else -> throw OpenApiGeneratorError("""Unsupported request body type "$requestBodyType".""")
 		}

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Classes.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Classes.kt
@@ -14,6 +14,7 @@ object Classes {
 	object Types {
 		const val UUID = "UUID"
 		const val DATETIME = "DateTime"
+		const val FILE_INFO = "FileInfo"
 	}
 
 	const val CONSTANTS_OBJECT = "ApiConstants"

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Types.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Types.kt
@@ -9,6 +9,7 @@ object Types {
 	val BYTE_ARRAY = ByteArray::class.asTypeName()
 	val UUID = ClassName(Packages.MODEL_TYPES, Classes.Types.UUID)
 	val DATETIME = ClassName(Packages.MODEL_TYPES, Classes.Types.DATETIME)
+	val FILE_INFO = ClassName(Packages.MODEL_TYPES, Classes.Types.FILE_INFO)
 	val JSON_ELEMENT = ClassName("kotlinx.serialization.json", "JsonElement")
 
 	// Special

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationRequestBody.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/model/ApiServiceOperationRequestBody.kt
@@ -10,12 +10,12 @@ sealed interface ApiServiceOperationRequestBody {
 		override val type: TypeName
 	) : ApiServiceOperationRequestBody
 
-	data object String : ApiServiceOperationRequestBody {
+	data object Text : ApiServiceOperationRequestBody {
 		override val type: TypeName = Types.STRING
 	}
 
-	data object Binary : ApiServiceOperationRequestBody {
-		override val type: TypeName = Types.BYTE_ARRAY
+	data class Binary(val mediaType: String) : ApiServiceOperationRequestBody {
+		override val type: TypeName = Types.FILE_INFO
 	}
 
 	data object None : ApiServiceOperationRequestBody {


### PR DESCRIPTION
Starting with Jellyfin 10.9 the server does some additional validation on image uploads. It now requires a `Content-Type` header in the request that contains the media type for one of the supported image formats.

The SDK never bothered with that and always told the server it was uploading binary data (`application/octet-stream`). While this is technically correct, the server does not like it anymore. Causing the API to reject all image uploads made using the SDK.

To fix this issue I've added a new model type called `FileInfo`. This model contains the bytes and an media type. The media type defaults to `application/octet-stream`, which obviously does not work for images.

To upload an image you'll need to convert the ByteArray to a FileInfo object. There are two ways to do this:

1. Construct it manually: `val fileInfo = FileInfo(content, "image/png")`
2. Convert it with an extension function: `val fileInfo = content.toFileInfo("image/png")`


An example of uploading a profile image:

```kotlin
val data = ByteArray() // Somehow loaded from file system or whatever

// Old
api.imageApi.postUserImage(data = data)

// New
api.imageApi.postUserImage(data = data.toFileInfo("image/png"))
```

If you don't know the media type of the image you're uploading or just don't care, no worries. The server never validates the actual file you upload, so you can just always set it to `image/png`. Although I don't recommend this as it may eventually be improved for security purposes.

Fixes #945