### PR TITLE
Update URL for OpenAPI source

### DIFF
--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -69,7 +69,7 @@ arrayOf(
 	"unstable" to "Unstable",
 ).forEach { (flavor, flavorPascalCase) ->
 	tasks.register("downloadApiSpec${flavorPascalCase}", de.undercouch.gradle.tasks.download.Download::class) {
-		src("https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-${flavor}.json")
+		src("https://api.jellyfin.org/openapi/jellyfin-openapi-${flavor}.json")
 		dest(defaultConfig["openApiFile"])
 		outputs.file(defaultConfig["openApiFile"]!!)
 	}

--- a/openapi-generator/build.gradle.kts
+++ b/openapi-generator/build.gradle.kts
@@ -65,7 +65,6 @@ tasks.register("verifySources", JavaExec::class) {
 
 arrayOf(
 	"stable" to "Stable",
-	"stable-pre" to "Prerelease",
 	"unstable" to "Unstable",
 ).forEach { (flavor, flavorPascalCase) ->
 	tasks.register("downloadApiSpec${flavorPascalCase}", de.undercouch.gradle.tasks.download.Download::class) {


### PR DESCRIPTION
We recently changes all the paths in repo.jellyfin.org but the old ones kept working for a bit. Now that those are removed the OpenAPI updating no longer works because I forgot to update it here.

- Update URL for OpenAPI sources
- Remove support for "stable-pre" flavor as we no longer have pre-releases