### PR TITLE
Add LiveTVModelsHook

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -8774,8 +8774,9 @@ public final class org/jellyfin/sdk/model/api/SeriesTimerCreatedMessage$Companio
 
 public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
@@ -8783,20 +8784,20 @@ public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto {
 	public final fun component13 ()Ljava/time/LocalDateTime;
 	public final fun component14 ()Ljava/time/LocalDateTime;
 	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()I
-	public final fun component17 ()I
-	public final fun component18 ()I
-	public final fun component19 ()Z
+	public final fun component16 ()Ljava/lang/Integer;
+	public final fun component17 ()Ljava/lang/Integer;
+	public final fun component18 ()Ljava/lang/Integer;
+	public final fun component19 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/lang/String;
 	public final fun component21 ()Ljava/util/List;
-	public final fun component22 ()Z
+	public final fun component22 ()Ljava/lang/Boolean;
 	public final fun component23 ()Lorg/jellyfin/sdk/model/api/KeepUntil;
-	public final fun component24 ()Z
-	public final fun component25 ()Z
-	public final fun component26 ()Z
-	public final fun component27 ()I
-	public final fun component28 ()Z
+	public final fun component24 ()Ljava/lang/Boolean;
+	public final fun component25 ()Ljava/lang/Boolean;
+	public final fun component26 ()Ljava/lang/Boolean;
+	public final fun component27 ()Ljava/lang/Integer;
+	public final fun component28 ()Ljava/lang/Boolean;
 	public final fun component29 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component30 ()Lorg/jellyfin/sdk/model/api/DayPattern;
@@ -8811,8 +8812,8 @@ public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;ZZZIZLjava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;Lorg/jellyfin/sdk/model/api/DayPattern;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/SeriesTimerInfoDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ljava/util/UUID;
 	public final fun getChannelName ()Ljava/lang/String;
@@ -8826,7 +8827,7 @@ public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto {
 	public final fun getId ()Ljava/lang/String;
 	public final fun getImageTags ()Ljava/util/Map;
 	public final fun getKeepUntil ()Lorg/jellyfin/sdk/model/api/KeepUntil;
-	public final fun getKeepUpTo ()I
+	public final fun getKeepUpTo ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOverview ()Ljava/lang/String;
 	public final fun getParentBackdropImageTags ()Ljava/util/List;
@@ -8835,21 +8836,21 @@ public final class org/jellyfin/sdk/model/api/SeriesTimerInfoDto {
 	public final fun getParentPrimaryImageTag ()Ljava/lang/String;
 	public final fun getParentThumbImageTag ()Ljava/lang/String;
 	public final fun getParentThumbItemId ()Ljava/lang/String;
-	public final fun getPostPaddingSeconds ()I
-	public final fun getPrePaddingSeconds ()I
-	public final fun getPriority ()I
+	public final fun getPostPaddingSeconds ()Ljava/lang/Integer;
+	public final fun getPrePaddingSeconds ()Ljava/lang/Integer;
+	public final fun getPriority ()Ljava/lang/Integer;
 	public final fun getProgramId ()Ljava/lang/String;
-	public final fun getRecordAnyChannel ()Z
-	public final fun getRecordAnyTime ()Z
-	public final fun getRecordNewOnly ()Z
+	public final fun getRecordAnyChannel ()Ljava/lang/Boolean;
+	public final fun getRecordAnyTime ()Ljava/lang/Boolean;
+	public final fun getRecordNewOnly ()Ljava/lang/Boolean;
 	public final fun getServerId ()Ljava/lang/String;
 	public final fun getServiceName ()Ljava/lang/String;
-	public final fun getSkipEpisodesInLibrary ()Z
+	public final fun getSkipEpisodesInLibrary ()Ljava/lang/Boolean;
 	public final fun getStartDate ()Ljava/time/LocalDateTime;
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
-	public final fun isPostPaddingRequired ()Z
-	public final fun isPrePaddingRequired ()Z
+	public final fun isPostPaddingRequired ()Ljava/lang/Boolean;
+	public final fun isPrePaddingRequired ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -10308,8 +10309,9 @@ public final class org/jellyfin/sdk/model/api/TimerEventInfo$Companion {
 
 public final class org/jellyfin/sdk/model/api/TimerInfoDto {
 	public static final field Companion Lorg/jellyfin/sdk/model/api/TimerInfoDto$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
@@ -10317,14 +10319,14 @@ public final class org/jellyfin/sdk/model/api/TimerInfoDto {
 	public final fun component13 ()Ljava/time/LocalDateTime;
 	public final fun component14 ()Ljava/time/LocalDateTime;
 	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()I
-	public final fun component17 ()I
-	public final fun component18 ()I
-	public final fun component19 ()Z
+	public final fun component16 ()Ljava/lang/Integer;
+	public final fun component17 ()Ljava/lang/Integer;
+	public final fun component18 ()Ljava/lang/Integer;
+	public final fun component19 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/lang/String;
 	public final fun component21 ()Ljava/util/List;
-	public final fun component22 ()Z
+	public final fun component22 ()Ljava/lang/Boolean;
 	public final fun component23 ()Lorg/jellyfin/sdk/model/api/KeepUntil;
 	public final fun component24 ()Lorg/jellyfin/sdk/model/api/RecordingStatus;
 	public final fun component25 ()Ljava/lang/String;
@@ -10338,8 +10340,8 @@ public final class org/jellyfin/sdk/model/api/TimerInfoDto {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TimerInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;IIIZLjava/lang/String;Ljava/util/List;ZLorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/api/TimerInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Lorg/jellyfin/sdk/model/api/KeepUntil;Lorg/jellyfin/sdk/model/api/RecordingStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lorg/jellyfin/sdk/model/api/BaseItemDto;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/api/TimerInfoDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ljava/util/UUID;
 	public final fun getChannelName ()Ljava/lang/String;
@@ -10355,9 +10357,9 @@ public final class org/jellyfin/sdk/model/api/TimerInfoDto {
 	public final fun getOverview ()Ljava/lang/String;
 	public final fun getParentBackdropImageTags ()Ljava/util/List;
 	public final fun getParentBackdropItemId ()Ljava/lang/String;
-	public final fun getPostPaddingSeconds ()I
-	public final fun getPrePaddingSeconds ()I
-	public final fun getPriority ()I
+	public final fun getPostPaddingSeconds ()Ljava/lang/Integer;
+	public final fun getPrePaddingSeconds ()Ljava/lang/Integer;
+	public final fun getPriority ()Ljava/lang/Integer;
 	public final fun getProgramId ()Ljava/lang/String;
 	public final fun getProgramInfo ()Lorg/jellyfin/sdk/model/api/BaseItemDto;
 	public final fun getRunTimeTicks ()Ljava/lang/Long;
@@ -10368,8 +10370,8 @@ public final class org/jellyfin/sdk/model/api/TimerInfoDto {
 	public final fun getStatus ()Lorg/jellyfin/sdk/model/api/RecordingStatus;
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
-	public final fun isPostPaddingRequired ()Z
-	public final fun isPrePaddingRequired ()Z
+	public final fun isPostPaddingRequired ()Ljava/lang/Boolean;
+	public final fun isPrePaddingRequired ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesTimerInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/SeriesTimerInfoDto.kt
@@ -49,7 +49,7 @@ public data class SeriesTimerInfoDto(
 	 * The channel id of the recording.
 	 */
 	@SerialName("ChannelId")
-	public val channelId: UUID,
+	public val channelId: UUID? = null,
 	/**
 	 * The external channel identifier.
 	 */
@@ -86,12 +86,12 @@ public data class SeriesTimerInfoDto(
 	 * The start date of the recording, in UTC.
 	 */
 	@SerialName("StartDate")
-	public val startDate: DateTime,
+	public val startDate: DateTime? = null,
 	/**
 	 * The end date of the recording, in UTC.
 	 */
 	@SerialName("EndDate")
-	public val endDate: DateTime,
+	public val endDate: DateTime? = null,
 	/**
 	 * The name of the service.
 	 */
@@ -101,22 +101,22 @@ public data class SeriesTimerInfoDto(
 	 * The priority.
 	 */
 	@SerialName("Priority")
-	public val priority: Int,
+	public val priority: Int? = null,
 	/**
 	 * The pre padding seconds.
 	 */
 	@SerialName("PrePaddingSeconds")
-	public val prePaddingSeconds: Int,
+	public val prePaddingSeconds: Int? = null,
 	/**
 	 * The post padding seconds.
 	 */
 	@SerialName("PostPaddingSeconds")
-	public val postPaddingSeconds: Int,
+	public val postPaddingSeconds: Int? = null,
 	/**
 	 * A value indicating whether this instance is pre padding required.
 	 */
 	@SerialName("IsPrePaddingRequired")
-	public val isPrePaddingRequired: Boolean,
+	public val isPrePaddingRequired: Boolean? = null,
 	/**
 	 * The Id of the Parent that has a backdrop if the item does not have one.
 	 */
@@ -131,28 +131,28 @@ public data class SeriesTimerInfoDto(
 	 * A value indicating whether this instance is post padding required.
 	 */
 	@SerialName("IsPostPaddingRequired")
-	public val isPostPaddingRequired: Boolean,
+	public val isPostPaddingRequired: Boolean? = null,
 	@SerialName("KeepUntil")
-	public val keepUntil: KeepUntil,
+	public val keepUntil: KeepUntil? = null,
 	/**
 	 * A value indicating whether [record any time].
 	 */
 	@SerialName("RecordAnyTime")
-	public val recordAnyTime: Boolean,
+	public val recordAnyTime: Boolean? = null,
 	@SerialName("SkipEpisodesInLibrary")
-	public val skipEpisodesInLibrary: Boolean,
+	public val skipEpisodesInLibrary: Boolean? = null,
 	/**
 	 * A value indicating whether [record any channel].
 	 */
 	@SerialName("RecordAnyChannel")
-	public val recordAnyChannel: Boolean,
+	public val recordAnyChannel: Boolean? = null,
 	@SerialName("KeepUpTo")
-	public val keepUpTo: Int,
+	public val keepUpTo: Int? = null,
 	/**
 	 * A value indicating whether [record new only].
 	 */
 	@SerialName("RecordNewOnly")
-	public val recordNewOnly: Boolean,
+	public val recordNewOnly: Boolean? = null,
 	/**
 	 * The days.
 	 */

--- a/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TimerInfoDto.kt
+++ b/jellyfin-model/src/commonMain/kotlin-generated/org/jellyfin/sdk/model/api/TimerInfoDto.kt
@@ -46,7 +46,7 @@ public data class TimerInfoDto(
 	 * The channel id of the recording.
 	 */
 	@SerialName("ChannelId")
-	public val channelId: UUID,
+	public val channelId: UUID? = null,
 	/**
 	 * The external channel identifier.
 	 */
@@ -83,12 +83,12 @@ public data class TimerInfoDto(
 	 * The start date of the recording, in UTC.
 	 */
 	@SerialName("StartDate")
-	public val startDate: DateTime,
+	public val startDate: DateTime? = null,
 	/**
 	 * The end date of the recording, in UTC.
 	 */
 	@SerialName("EndDate")
-	public val endDate: DateTime,
+	public val endDate: DateTime? = null,
 	/**
 	 * The name of the service.
 	 */
@@ -98,22 +98,22 @@ public data class TimerInfoDto(
 	 * The priority.
 	 */
 	@SerialName("Priority")
-	public val priority: Int,
+	public val priority: Int? = null,
 	/**
 	 * The pre padding seconds.
 	 */
 	@SerialName("PrePaddingSeconds")
-	public val prePaddingSeconds: Int,
+	public val prePaddingSeconds: Int? = null,
 	/**
 	 * The post padding seconds.
 	 */
 	@SerialName("PostPaddingSeconds")
-	public val postPaddingSeconds: Int,
+	public val postPaddingSeconds: Int? = null,
 	/**
 	 * A value indicating whether this instance is pre padding required.
 	 */
 	@SerialName("IsPrePaddingRequired")
-	public val isPrePaddingRequired: Boolean,
+	public val isPrePaddingRequired: Boolean? = null,
 	/**
 	 * The Id of the Parent that has a backdrop if the item does not have one.
 	 */
@@ -128,14 +128,14 @@ public data class TimerInfoDto(
 	 * A value indicating whether this instance is post padding required.
 	 */
 	@SerialName("IsPostPaddingRequired")
-	public val isPostPaddingRequired: Boolean,
+	public val isPostPaddingRequired: Boolean? = null,
 	@SerialName("KeepUntil")
-	public val keepUntil: KeepUntil,
+	public val keepUntil: KeepUntil? = null,
 	/**
 	 * The status.
 	 */
 	@SerialName("Status")
-	public val status: RecordingStatus,
+	public val status: RecordingStatus? = null,
 	/**
 	 * The series timer identifier.
 	 */

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/HooksModule.kt
@@ -6,12 +6,14 @@ import org.jellyfin.openapi.hooks.api.LargeOperationRequestModelHook
 import org.jellyfin.openapi.hooks.api.PlayStateServiceNameHook
 import org.jellyfin.openapi.hooks.model.DotNetDescriptionHook
 import org.jellyfin.openapi.hooks.model.ImageMapsHook
+import org.jellyfin.openapi.hooks.model.LiveTVModelsHook
 import org.jellyfin.openapi.hooks.model.SwashbuckleDescriptionHook
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val hooksModule = module {
 	single { ImageMapsHook() } bind TypeBuilderHook::class
+	single { LiveTVModelsHook() } bind TypeBuilderHook::class
 
 	single { BinaryOperationUrlHook() } bind OperationUrlHook::class
 	single { ClientLogOperationUrlHook() } bind OperationUrlHook::class

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/LiveTVModelsHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/model/LiveTVModelsHook.kt
@@ -1,0 +1,36 @@
+package org.jellyfin.openapi.hooks.model
+
+import com.squareup.kotlinpoet.TypeName
+import io.swagger.v3.oas.models.media.Schema
+import org.jellyfin.openapi.builder.openapi.OpenApiTypeBuilder
+import org.jellyfin.openapi.hooks.ModelTypePath
+import org.jellyfin.openapi.hooks.TypeBuilderHook
+import org.jellyfin.openapi.hooks.TypePath
+import org.jellyfin.openapi.hooks.model.LiveTVModelsHook.Companion.liveTvNullableModels
+
+/**
+ * A hook that modifies all properties of the models stored in [liveTvNullableModels] to be nullable.
+ */
+class LiveTVModelsHook : TypeBuilderHook {
+	companion object {
+		private val liveTvNullableModels = setOf(
+			"SeriesTimerInfoDto",
+			"TimerInfoDto",
+		)
+
+		private val ignoreProperties = setOf(
+			"imageTags",
+		)
+	}
+
+	override fun onBuildType(path: TypePath, schema: Schema<*>, typeBuilder: OpenApiTypeBuilder): TypeName? {
+		return when {
+			path is ModelTypePath && liveTvNullableModels.contains(path.model) && !ignoreProperties.contains(path.property) ->
+				typeBuilder
+					.buildSchema(path, schema)
+					.copy(nullable = true)
+
+			else -> null
+		}
+	}
+}


### PR DESCRIPTION
I found some issues with the OpenAPI specification while migrating the Android TV app to the SDK. More specifically, the Live TV timer types have properties that should be nullable but are not.

The Live TV API uses the timer DTO's for creating, updating and reading. In the old java apiclient we only required the program id. Now the channelId, keepUntil, startDate, endDate, priority and status properties are also expected. My best guess is that swashbuckle is making some mistake because all of those types are not primitives (GUID/DateTime/Enum) so it probably skips checking for nullability?

Either way, this is a quickfix so the SDK is correct. We should fix this properly in 10.10.