### PR TITLE
Fix timezone offset in DateTimeSerializer deserialization

### DIFF
--- a/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializer.kt
+++ b/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializer.kt
@@ -18,7 +18,7 @@ public actual class DateTimeSerializer(
 	actual override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 
 	actual override fun deserialize(decoder: Decoder): DateTime = try {
-		ZonedDateTime.parse(decoder.decodeString()).toLocalDateTime()
+		ZonedDateTime.parse(decoder.decodeString()).withZoneSameInstant(zoneId).toLocalDateTime()
 	} catch (err: DateTimeParseException) {
 		// Server will sometimes return 0001-01-01T00:00:00
 		// but java.time can't parse that

--- a/jellyfin-model/src/jvmTest/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializerTests.kt
+++ b/jellyfin-model/src/jvmTest/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializerTests.kt
@@ -57,5 +57,10 @@ class DateTimeSerializerTests : FunSpec({
 			instance,
 			""""2021-06-30T01:33:07.420+01:00""""
 		) shouldBe LocalDateTime.of(2021, 6, 30, 1, 33, 7, 420000000)
+
+		Json.decodeFromString(
+			instance,
+			""""2024-07-23T20:25:24.420Z""""
+		) shouldBe LocalDateTime.of(2024, 7, 23, 21, 25, 24, 420000000)
 	}
 })


### PR DESCRIPTION
The `ZonedDateTime.parse().toLocalDateTime()` approach would ignore timezone information from the timestamp and consider it local time. So if the server answers with UTC+2 and you are in UTC+5 the timestamp would be off by 3 hours.

Using `ZonedDateTime.parse().withZoneSameInstant().toLocalDateTime()` fixes this behavior.

Ideally we'd stop using LocalDateTime in the SDK and use ZonedDateTime but that's too big of a change to backport to the 1.5.z branch. I'll likely migrate to kotlinx-datetime later.