### PR TITLE
Prefix descriptor names of custom serializers

### DIFF
--- a/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializer.kt
+++ b/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializer.kt
@@ -15,7 +15,7 @@ import java.time.format.DateTimeParseException
 public actual class DateTimeSerializer(
 	private val zoneId: ZoneId = ZoneId.systemDefault(),
 ) : KSerializer<DateTime> {
-	actual override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
+	actual override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("org.jellyfin.LocalDateTime", PrimitiveKind.STRING)
 
 	actual override fun deserialize(decoder: Decoder): DateTime = try {
 		ZonedDateTime.parse(decoder.decodeString()).withZoneSameInstant(zoneId).toLocalDateTime()

--- a/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/UUIDSerializer.kt
+++ b/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/UUIDSerializer.kt
@@ -20,7 +20,7 @@ public actual fun String.toUUIDOrNull(): UUID? = try {
 }
 
 public actual class UUIDSerializer : KSerializer<UUID> {
-	actual override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+	actual override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("org.jellyfin.UUID", PrimitiveKind.STRING)
 
 	actual override fun deserialize(decoder: Decoder): UUID {
 		return decoder.decodeString().toUUID()


### PR DESCRIPTION
The kotlinx.serialization library added a new UUID serializer in 1.7.2 for the (experimental) UUID type in the Kotlin stdlib. Unfortunately this causes an issue, their serializer uses the same (simple-)name as ours, causing an exception when trying to encode/decode JSON.

The fix is two-sides, they'll fix their side to use more strict name validation. And we'll fix it to use a more unique name. On the upside, this will also improve the experience for users of the SDK, as they will also be less likely to have a serializer with a name we also use.
