### PR TITLE
Check if Android device name is not blank

### DIFF
--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/android/AndroidDevice.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/android/AndroidDevice.kt
@@ -10,7 +10,7 @@ private fun Context.getDeviceName(): String {
 	// Use name from device settings
 	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
 		val name = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
-		if (name?.isNotBlank() == true) return name
+		if (!name.isNullOrBlank()) return name
 	}
 
 	// Concatenate the name based on manufacturer and model

--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/android/AndroidDevice.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/android/AndroidDevice.kt
@@ -10,7 +10,7 @@ private fun Context.getDeviceName(): String {
 	// Use name from device settings
 	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
 		val name = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
-		if (name != null) return name
+		if (name?.isNotBlank() == true) return name
 	}
 
 	// Concatenate the name based on manufacturer and model


### PR DESCRIPTION
We should also check if the string returned from `Settings.Global.DEVICE_NAME` is not blank.
The Jellyfin server requires a non-empty device name: 
```
System.ArgumentException: The value cannot be an empty string. (Parameter 'request.DeviceName')
```

This seems like a rare issue but I have at least one report in Findroid.

Downstream issue: https://github.com/jarnedemeulemeester/findroid/issues/846