### PR TITLE
Fix race condition in DefaultSocketApi causing disconnection loop when changing credentials

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
@@ -144,7 +144,7 @@ public class DefaultSocketApi(
 		.state
 		.onEach { connectionState ->
 			// Automatically reconnect when the socket is closed while subscriptions are active
-			if (_subscriptionCount > 0 && _currentCredentials != null && connectionState is SocketConnectionState.Disconnected) {
+			if (_subscriptionCount > 0 && _currentCredentials != null && connectionState is SocketConnectionState.Disconnected && !reconnectMutex.isLocked) {
 				socketReconnectPolicy.notifyDisconnected()
 
 				val reconnectDelay = socketReconnectPolicy.getReconnectDelay()


### PR DESCRIPTION
Whenever the socket connection is disconnected we automatically reconnect when there's still active subscriptions.
The reconnect function will always disconnect any existing connection before opening a new one.

Now guess what can go wrong: whenever you reconnect, it will trigger the automatic reconnect. This will cause a reconnection loop. This issue could be triggered in the ATV app by changing users, where it updates the credentials and a reconnect is attempted.

The fix was easy, never initiate the automatic reconnect when an reconnect is already happening.

Fixes jellyfin/jellyfin-androidtv#4225