### PR TITLE
Use OkHTTP in AddressCandidateHelper

### DIFF
--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -73,8 +73,6 @@ public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
 	public static final field Companion Lorg/jellyfin/sdk/discovery/AddressCandidateHelper$Companion;
 	public static final field JF_HTTPS_PORT I
 	public static final field JF_HTTP_PORT I
-	public static final field PROTOCOL_HTTP Ljava/lang/String;
-	public static final field PROTOCOL_HTTPS Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun addCommonCandidates ()V
 	public final fun addPortCandidates ()V

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -65,8 +65,6 @@ public final class org/jellyfin/sdk/discovery/AddressCandidateHelper {
 	public static final field Companion Lorg/jellyfin/sdk/discovery/AddressCandidateHelper$Companion;
 	public static final field JF_HTTPS_PORT I
 	public static final field JF_HTTP_PORT I
-	public static final field PROTOCOL_HTTP Ljava/lang/String;
-	public static final field PROTOCOL_HTTPS Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun addCommonCandidates ()V
 	public final fun addPortCandidates ()V

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
 				implementation(libs.kotlinx.coroutines)
 				implementation(libs.kotlinx.serialization.json)
 
-				api(libs.ktor.http)
+				implementation(libs.okhttp)
 
 				// Logging
 				implementation(libs.kotlin.logging)

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -1,143 +1,38 @@
 package org.jellyfin.sdk.discovery
 
-import io.ktor.http.URLBuilder
-import io.ktor.http.URLParserException
-import io.ktor.http.URLProtocol
-import io.ktor.http.Url
-import io.ktor.http.takeFrom
-import mu.KotlinLogging
-
-private val logger = KotlinLogging.logger {}
-
 /**
  * Parses the given [input] and allows to fix common mistakes.
  */
-public class AddressCandidateHelper(
-	private val input: String,
+public expect class AddressCandidateHelper(
+	input: String,
 ) {
 	public companion object {
 		/**
 		 * Default HTTP port for Jellyfin
 		 */
-		public const val JF_HTTP_PORT: Int = 8096
+		public val JF_HTTP_PORT: Int
 
 		/**
 		 * Default HTTPS port for Jellyfin
 		 */
-		public const val JF_HTTPS_PORT: Int = 8920
-
-		/**
-		 * HTTP protocol prefix: http://
-		 */
-		public const val PROTOCOL_HTTP: String = "http://"
-
-		/**
-		 * HTTPS protocol prefix: https://
-		 */
-		public const val PROTOCOL_HTTPS: String = "https://"
-	}
-
-	private val candidates = mutableSetOf<Url>()
-	private val prioritizeComparator = Comparator<Url> { a, b -> b.score() - a.score() }
-
-	init {
-		try {
-			logger.debug { "Input is $input" }
-
-			// Add the input as initial candidate
-			if (input.isNotBlank()) {
-				candidates.add(URLBuilder().apply {
-					// Ktor doesn't like urls not starting with a protocol
-					// so we default to a http prefix
-					if (!input.startsWith(PROTOCOL_HTTP) && !input.startsWith(PROTOCOL_HTTPS))
-						takeFrom(PROTOCOL_HTTP + input)
-					else
-						takeFrom(input)
-				}.build())
-			}
-		} catch (error: URLParserException) {
-			// Input can't be parsed
-			logger.error(error) { "Input $input could not be parsed" }
-		} catch (error: IllegalArgumentException) {
-			// Input can't be parsed
-			logger.error(error) { "Input $input could not be parsed" }
-		}
+		public val JF_HTTPS_PORT: Int
 	}
 
 	/**
-	 * Add a HTTPS candidate for each HTTP candidate
+	 * Add an HTTPS candidate for each HTTP candidate
 	 */
-	public fun addProtocolCandidates() {
-		logger.debug { "Adding protocol candidates" }
-
-		// Add HTTPS candidate for each HTTP candidate
-		candidates
-			.filter { it.protocol == URLProtocol.HTTP }
-			.forEach {
-				candidates.add(URLBuilder(it).apply {
-					protocol = URLProtocol.HTTPS
-					if (port == URLProtocol.HTTP.defaultPort) port = URLProtocol.HTTPS.defaultPort
-				}.build())
-			}
-	}
+	public fun addProtocolCandidates()
 
 	/**
 	 * Add a candidate using Jellyfin ports for each candidate without a specified port or
 	 * protocol-default port.
 	 */
-	public fun addPortCandidates() {
-		logger.debug { "Adding port candidates" }
-
-		// Add HTTPS candidate for each HTTP candidate
-		candidates
-			.filter { it.port == it.protocol.defaultPort }
-			.forEach {
-				when (it.protocol) {
-					URLProtocol.HTTP -> {
-						candidates.add(URLBuilder(it).apply { port = JF_HTTP_PORT }.build())
-					}
-
-					URLProtocol.HTTPS -> {
-						candidates.add(URLBuilder(it).apply { port = JF_HTTP_PORT }.build())
-						candidates.add(URLBuilder(it).apply { port = JF_HTTPS_PORT }.build())
-					}
-				}
-			}
-	}
+	public fun addPortCandidates()
 
 	/**
 	 * Applies all fixes to the [input].
 	 */
-	public fun addCommonCandidates() {
-		logger.debug { "Adding common candidates" }
-
-		addProtocolCandidates()
-		addPortCandidates()
-	}
-
-	@Suppress("MagicNumber")
-	private fun Url.score(): Int {
-		// Start out with a score of 0
-		var score = 0
-
-		// Score based on protocol
-		when (protocol) {
-			URLProtocol.HTTPS -> score += 5
-			else -> score -= 5 // HTTP is less secure, try a secure option first
-		}
-
-		// Score based on port
-		when (port) {
-			JF_HTTP_PORT -> score += 2
-			JF_HTTPS_PORT -> score -= 1 // Using the Jellyfin HTTPS port is not common
-		}
-
-		// Prefer default port for used protocol
-		if (protocol == URLProtocol.HTTPS && port == 443) score += 3
-		if (protocol == URLProtocol.HTTP && port == 80) score += 3
-
-		return score
-	}
+	public fun addCommonCandidates()
 
 	/**
 	 * Returns all unique candidates sorted by priority.
@@ -146,7 +41,5 @@ public class AddressCandidateHelper(
 	 * - HTTPS before HTTP
 	 * - Jellyfin ports before protocol default ports
 	 */
-	public fun getCandidates(): Collection<String> = candidates
-		.sortedWith(prioritizeComparator)
-		.map { it.toString() }
+	public fun getCandidates(): Collection<String>
 }

--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -1,0 +1,152 @@
+package org.jellyfin.sdk.discovery
+
+import io.ktor.http.URLBuilder
+import io.ktor.http.URLParserException
+import io.ktor.http.URLProtocol
+import io.ktor.http.Url
+import io.ktor.http.takeFrom
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Parses the given [input] and allows to fix common mistakes.
+ */
+public actual class AddressCandidateHelper actual constructor(
+	private val input: String,
+) {
+	public actual companion object {
+		/**
+		 * Default HTTP port for Jellyfin
+		 */
+		public const actual val JF_HTTP_PORT: Int = 8096
+
+		/**
+		 * Default HTTPS port for Jellyfin
+		 */
+		public const actual val JF_HTTPS_PORT: Int = 8920
+
+		/**
+		 * HTTP protocol prefix: http://
+		 */
+		private const val PROTOCOL_HTTP: String = "http://"
+
+		/**
+		 * HTTPS protocol prefix: https://
+		 */
+		private const val PROTOCOL_HTTPS: String = "https://"
+	}
+
+	private val candidates = mutableSetOf<Url>()
+	private val prioritizeComparator = Comparator<Url> { a, b -> b.score() - a.score() }
+
+	init {
+		try {
+			logger.debug { "Input is $input" }
+
+			// Add the input as initial candidate
+			if (input.isNotBlank()) {
+				candidates.add(URLBuilder().apply {
+					// Ktor doesn't like urls not starting with a protocol
+					// so we default to a http prefix
+					if (!input.startsWith(PROTOCOL_HTTP) && !input.startsWith(PROTOCOL_HTTPS))
+						takeFrom(PROTOCOL_HTTP + input)
+					else
+						takeFrom(input)
+				}.build())
+			}
+		} catch (error: URLParserException) {
+			// Input can't be parsed
+			logger.error(error) { "Input $input could not be parsed" }
+		} catch (error: IllegalArgumentException) {
+			// Input can't be parsed
+			logger.error(error) { "Input $input could not be parsed" }
+		}
+	}
+
+	/**
+	 * Add an HTTPS candidate for each HTTP candidate
+	 */
+	public actual fun addProtocolCandidates() {
+		logger.debug { "Adding protocol candidates" }
+
+		// Add HTTPS candidate for each HTTP candidate
+		candidates
+			.filter { it.protocol == URLProtocol.Companion.HTTP }
+			.forEach {
+				candidates.add(URLBuilder(it).apply {
+					protocol = URLProtocol.Companion.HTTPS
+					if (port == URLProtocol.Companion.HTTP.defaultPort) port = URLProtocol.Companion.HTTPS.defaultPort
+				}.build())
+			}
+	}
+
+	/**
+	 * Add a candidate using Jellyfin ports for each candidate without a specified port or
+	 * protocol-default port.
+	 */
+	public actual fun addPortCandidates() {
+		logger.debug { "Adding port candidates" }
+
+		// Add HTTPS candidate for each HTTP candidate
+		candidates
+			.filter { it.port == it.protocol.defaultPort }
+			.forEach {
+				when (it.protocol) {
+					URLProtocol.Companion.HTTP -> {
+						candidates.add(URLBuilder(it).apply { port = JF_HTTP_PORT }.build())
+					}
+
+					URLProtocol.Companion.HTTPS -> {
+						candidates.add(URLBuilder(it).apply { port = JF_HTTP_PORT }.build())
+						candidates.add(URLBuilder(it).apply { port = JF_HTTPS_PORT }.build())
+					}
+				}
+			}
+	}
+
+	/**
+	 * Applies all fixes to the [input].
+	 */
+	public actual fun addCommonCandidates() {
+		logger.debug { "Adding common candidates" }
+
+		addProtocolCandidates()
+		addPortCandidates()
+	}
+
+	@Suppress("MagicNumber")
+	private fun Url.score(): Int {
+		// Start out with a score of 0
+		var score = 0
+
+		// Score based on protocol
+		when (protocol) {
+			URLProtocol.Companion.HTTPS -> score += 5
+			else -> score -= 5 // HTTP is less secure, try a secure option first
+		}
+
+		// Score based on port
+		when (port) {
+			JF_HTTP_PORT -> score += 2
+			JF_HTTPS_PORT -> score -= 1 // Using the Jellyfin HTTPS port is not common
+		}
+
+		// Prefer default port for used protocol
+		if (protocol == URLProtocol.Companion.HTTPS && port == 443) score += 3
+		if (protocol == URLProtocol.Companion.HTTP && port == 80) score += 3
+
+		return score
+	}
+
+	/**
+	 * Returns all unique candidates sorted by priority.
+	 *
+	 * The priority is based on a few rules:
+	 * - HTTPS before HTTP
+	 * - Jellyfin ports before protocol default ports
+	 */
+	public actual fun getCandidates(): Collection<String> = candidates
+		.sortedWith(prioritizeComparator)
+		.map { it.toString() }
+}

--- a/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
+++ b/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
@@ -3,6 +3,7 @@ package org.jellyfin.sdk.discovery
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import org.jellyfin.sdk.createJellyfin
 
@@ -45,9 +46,10 @@ class DiscoveryServiceTests : FunSpec({
 		val instance = getInstance()
 
 		instance.getAddressCandidates("[::1]") shouldContain "http://[::1]"
-		instance.getAddressCandidates("[0:0:0:0:0:0:0:1]") shouldContain "http://[0:0:0:0:0:0:0:1]"
+		instance.getAddressCandidates("[0:0:0:0:0:0:0:1]") shouldNotContain "http://[0:0:0:0:0:0:0:1]"
+		instance.getAddressCandidates("[0:0:0:0:0:0:0:1]") shouldContain "http://[::1]"
 		instance.getAddressCandidates("[::1]:8096") shouldContain "http://[::1]:8096"
-		instance.getAddressCandidates("[0:0:0:0:0:0:0:1]:8096") shouldContain "http://[0:0:0:0:0:0:0:1]:8096"
+		instance.getAddressCandidates("[0:0:0:0:0:0:0:1]:8096") shouldContain "http://[::1]:8096"
 	}
 
 	test("getAddressCandidates returns empty on bad input") {


### PR DESCRIPTION
- Split AddressCandidateHelper into expect & actual
- Drop the public PROTOCOL_HTTP and PROTOCOL_HTTPS constants as they're not meant for library users
- Move from Ktor URL to OkHTTP HttpUrl class
- Drop direct ktor dependency from core module

The only behavior change that came up is that inputted IPv6 addresses are not shortened, which IMO is a good thing.