### PR TITLE
Use OkHTTP in UrlBuilder

### DIFF
--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilderTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilderTests.kt
@@ -219,6 +219,6 @@ class UrlBuilderTests : FunSpec({
 			baseUrl = baseUrl,
 			pathTemplate = "{foo}/{foo/{bar",
 			ignorePathParameters = true,
-		) shouldBe "${baseUrl}{foo}/{foo/{bar"
+		) shouldBe "${baseUrl}%7Bfoo%7D/%7Bfoo/%7Bbar"
 	}
 })


### PR DESCRIPTION
Similar to #1048. Updates the UrlBuilder to use OkHttp's HttpUrl. Unfortunately OkHttp does not expose its escaping functions so I had to implement my own for the path building. Small behavior change here is that we'll now escape slightly more characters by default, for which I had to update one unit test.