### PR TITLE
Use ByteArray instead of ByteReadChannel in API responses

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }

--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -15,6 +15,7 @@ import io.ktor.content.TextContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
+import io.ktor.util.toByteArray
 import io.ktor.util.toMap
 import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
@@ -145,7 +146,7 @@ public class KtorClient(
 			// Check HTTP status
 			if (!response.status.isSuccess()) throw InvalidStatusException(response.status.value)
 			// Return custom response instance
-			return RawResponse(response.bodyAsChannel(), response.status.value, response.headers.toMap())
+			return RawResponse(response.bodyAsChannel().toByteArray(), response.status.value, response.headers.toMap())
 		} catch (err: UnknownHostException) {
 			logger.debug(err) { "HTTP host unreachable" }
 			throw TimeoutException("HTTP host unreachable", err)

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -51,8 +51,8 @@ public final class org/jellyfin/sdk/api/client/HttpMethod : java/lang/Enum {
 }
 
 public final class org/jellyfin/sdk/api/client/RawResponse {
-	public fun <init> (Lio/ktor/utils/io/ByteReadChannel;ILjava/util/Map;)V
-	public final fun getBody ()Lio/ktor/utils/io/ByteReadChannel;
+	public fun <init> ([BILjava/util/Map;)V
+	public final fun getBody ()[B
 	public final fun getHeaders ()Ljava/util/Map;
 	public final fun getStatus ()I
 }

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -25,7 +25,6 @@ kotlin {
 
 				implementation(libs.kotlinx.coroutines)
 				implementation(libs.kotlinx.serialization.json)
-				implementation(libs.ktor.http)
 
 				implementation(libs.kotlin.logging)
 			}

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/AudioApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.Float
 import kotlin.Int
@@ -135,7 +135,7 @@ public class AudioApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -195,7 +195,7 @@ public class AudioApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/stream", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/stream", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -204,7 +204,7 @@ public class AudioApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getAudioStream(request: GetAudioStreamRequest): Response<ByteReadChannel> = getAudioStream(
+	public suspend fun getAudioStream(request: GetAudioStreamRequest): Response<ByteArray> = getAudioStream(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,
@@ -524,7 +524,7 @@ public class AudioApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("container", container)
@@ -583,7 +583,7 @@ public class AudioApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -592,7 +592,7 @@ public class AudioApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getAudioStreamByContainer(request: GetAudioStreamByContainerRequest): Response<ByteReadChannel> = getAudioStreamByContainer(
+	public suspend fun getAudioStreamByContainer(request: GetAudioStreamByContainerRequest): Response<ByteArray> = getAudioStreamByContainer(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,
@@ -914,7 +914,7 @@ public class AudioApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("container", container)
@@ -974,7 +974,7 @@ public class AudioApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/stream.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -984,7 +984,7 @@ public class AudioApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getAudioStreamByContainerDeprecated(request: GetAudioStreamByContainerDeprecatedRequest): Response<ByteReadChannel> = getAudioStreamByContainerDeprecated(
+	public suspend fun getAudioStreamByContainerDeprecated(request: GetAudioStreamByContainerDeprecatedRequest): Response<ByteArray> = getAudioStreamByContainerDeprecated(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,
@@ -1311,7 +1311,7 @@ public class AudioApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -1372,7 +1372,7 @@ public class AudioApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/stream", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/stream", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1382,7 +1382,7 @@ public class AudioApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getAudioStreamDeprecated(request: GetAudioStreamDeprecatedRequest): Response<ByteReadChannel> = getAudioStreamDeprecated(
+	public suspend fun getAudioStreamDeprecated(request: GetAudioStreamDeprecatedRequest): Response<ByteArray> = getAudioStreamDeprecated(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ConfigurationApi.kt
@@ -5,8 +5,8 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.ByteArray
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.buildMap
@@ -49,13 +49,13 @@ public class ConfigurationApi(
 	 *
 	 * @param key Configuration key.
 	 */
-	public suspend fun getNamedConfiguration(key: String): Response<ByteReadChannel> {
+	public suspend fun getNamedConfiguration(key: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("key", key)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/System/Configuration/{key}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/System/Configuration/{key}", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/DynamicHlsApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.Float
 import kotlin.Int
@@ -155,7 +155,7 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(4) {
 			put("itemId", itemId)
 			put("playlistId", playlistId)
@@ -219,7 +219,7 @@ public class DynamicHlsApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -228,7 +228,7 @@ public class DynamicHlsApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getHlsAudioSegment(request: GetHlsAudioSegmentRequest): Response<ByteReadChannel> = getHlsAudioSegment(
+	public suspend fun getHlsAudioSegment(request: GetHlsAudioSegmentRequest): Response<ByteArray> = getHlsAudioSegment(
 		itemId = request.itemId,
 		playlistId = request.playlistId,
 		segmentId = request.segmentId,
@@ -580,7 +580,7 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(4) {
 			put("itemId", itemId)
 			put("playlistId", playlistId)
@@ -645,7 +645,7 @@ public class DynamicHlsApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -655,7 +655,7 @@ public class DynamicHlsApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getHlsAudioSegmentDeprecated(request: GetHlsAudioSegmentDeprecatedRequest): Response<ByteReadChannel> = getHlsAudioSegmentDeprecated(
+	public suspend fun getHlsAudioSegmentDeprecated(request: GetHlsAudioSegmentDeprecatedRequest): Response<ByteArray> = getHlsAudioSegmentDeprecated(
 		itemId = request.itemId,
 		playlistId = request.playlistId,
 		segmentId = request.segmentId,
@@ -1013,7 +1013,7 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(4) {
 			put("itemId", itemId)
 			put("playlistId", playlistId)
@@ -1079,7 +1079,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1088,7 +1088,7 @@ public class DynamicHlsApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getHlsVideoSegment(request: GetHlsVideoSegmentRequest): Response<ByteReadChannel> = getHlsVideoSegment(
+	public suspend fun getHlsVideoSegment(request: GetHlsVideoSegmentRequest): Response<ByteArray> = getHlsVideoSegment(
 		itemId = request.itemId,
 		playlistId = request.playlistId,
 		segmentId = request.segmentId,
@@ -1452,7 +1452,7 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(4) {
 			put("itemId", itemId)
 			put("playlistId", playlistId)
@@ -1519,7 +1519,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/hls1/{playlistId}/{segmentId}.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1529,7 +1529,7 @@ public class DynamicHlsApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getHlsVideoSegmentDeprecated(request: GetHlsVideoSegmentDeprecatedRequest): Response<ByteReadChannel> = getHlsVideoSegmentDeprecated(
+	public suspend fun getHlsVideoSegmentDeprecated(request: GetHlsVideoSegmentDeprecatedRequest): Response<ByteArray> = getHlsVideoSegmentDeprecated(
 		itemId = request.itemId,
 		playlistId = request.playlistId,
 		segmentId = request.segmentId,
@@ -1889,7 +1889,7 @@ public class DynamicHlsApi(
 		enableSubtitlesInManifest: Boolean? = null,
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -1953,7 +1953,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1962,7 +1962,7 @@ public class DynamicHlsApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getLiveHlsStream(request: GetLiveHlsStreamRequest): Response<ByteReadChannel> = getLiveHlsStream(
+	public suspend fun getLiveHlsStream(request: GetLiveHlsStreamRequest): Response<ByteArray> = getLiveHlsStream(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,
@@ -2309,7 +2309,7 @@ public class DynamicHlsApi(
 		enableSubtitlesInManifest: Boolean? = null,
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -2374,7 +2374,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/live.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -2384,7 +2384,7 @@ public class DynamicHlsApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getLiveHlsStreamDeprecated(request: GetLiveHlsStreamDeprecatedRequest): Response<ByteReadChannel> = getLiveHlsStreamDeprecated(
+	public suspend fun getLiveHlsStreamDeprecated(request: GetLiveHlsStreamDeprecatedRequest): Response<ByteArray> = getLiveHlsStreamDeprecated(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,
@@ -2727,7 +2727,7 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAdaptiveBitrateStreaming: Boolean? = true,
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -2787,7 +2787,7 @@ public class DynamicHlsApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -2796,7 +2796,7 @@ public class DynamicHlsApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getMasterHlsAudioPlaylist(request: GetMasterHlsAudioPlaylistRequest): Response<ByteReadChannel> = getMasterHlsAudioPlaylist(
+	public suspend fun getMasterHlsAudioPlaylist(request: GetMasterHlsAudioPlaylistRequest): Response<ByteArray> = getMasterHlsAudioPlaylist(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,
@@ -3124,7 +3124,7 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAdaptiveBitrateStreaming: Boolean? = true,
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -3185,7 +3185,7 @@ public class DynamicHlsApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/master.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -3195,7 +3195,7 @@ public class DynamicHlsApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getMasterHlsAudioPlaylistDeprecated(request: GetMasterHlsAudioPlaylistDeprecatedRequest): Response<ByteReadChannel> = getMasterHlsAudioPlaylistDeprecated(
+	public suspend fun getMasterHlsAudioPlaylistDeprecated(request: GetMasterHlsAudioPlaylistDeprecatedRequest): Response<ByteArray> = getMasterHlsAudioPlaylistDeprecated(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,
@@ -3531,7 +3531,7 @@ public class DynamicHlsApi(
 		enableTrickplay: Boolean? = true,
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -3594,7 +3594,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -3603,7 +3603,7 @@ public class DynamicHlsApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getMasterHlsVideoPlaylist(request: GetMasterHlsVideoPlaylistRequest): Response<ByteReadChannel> = getMasterHlsVideoPlaylist(
+	public suspend fun getMasterHlsVideoPlaylist(request: GetMasterHlsVideoPlaylistRequest): Response<ByteArray> = getMasterHlsVideoPlaylist(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,
@@ -3949,7 +3949,7 @@ public class DynamicHlsApi(
 		enableTrickplay: Boolean? = true,
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -4013,7 +4013,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/master.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -4023,7 +4023,7 @@ public class DynamicHlsApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getMasterHlsVideoPlaylistDeprecated(request: GetMasterHlsVideoPlaylistDeprecatedRequest): Response<ByteReadChannel> = getMasterHlsVideoPlaylistDeprecated(
+	public suspend fun getMasterHlsVideoPlaylistDeprecated(request: GetMasterHlsVideoPlaylistDeprecatedRequest): Response<ByteArray> = getMasterHlsVideoPlaylistDeprecated(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,
@@ -4363,7 +4363,7 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -4422,7 +4422,7 @@ public class DynamicHlsApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -4431,7 +4431,7 @@ public class DynamicHlsApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getVariantHlsAudioPlaylist(request: GetVariantHlsAudioPlaylistRequest): Response<ByteReadChannel> = getVariantHlsAudioPlaylist(
+	public suspend fun getVariantHlsAudioPlaylist(request: GetVariantHlsAudioPlaylistRequest): Response<ByteArray> = getVariantHlsAudioPlaylist(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,
@@ -4753,7 +4753,7 @@ public class DynamicHlsApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -4813,7 +4813,7 @@ public class DynamicHlsApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/main.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -4823,7 +4823,7 @@ public class DynamicHlsApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getVariantHlsAudioPlaylistDeprecated(request: GetVariantHlsAudioPlaylistDeprecatedRequest): Response<ByteReadChannel> = getVariantHlsAudioPlaylistDeprecated(
+	public suspend fun getVariantHlsAudioPlaylistDeprecated(request: GetVariantHlsAudioPlaylistDeprecatedRequest): Response<ByteArray> = getVariantHlsAudioPlaylistDeprecated(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,
@@ -5151,7 +5151,7 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -5212,7 +5212,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -5221,7 +5221,7 @@ public class DynamicHlsApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getVariantHlsVideoPlaylist(request: GetVariantHlsVideoPlaylistRequest): Response<ByteReadChannel> = getVariantHlsVideoPlaylist(
+	public suspend fun getVariantHlsVideoPlaylist(request: GetVariantHlsVideoPlaylistRequest): Response<ByteArray> = getVariantHlsVideoPlaylist(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,
@@ -5555,7 +5555,7 @@ public class DynamicHlsApi(
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
 		alwaysBurnInSubtitleWhenTranscoding: Boolean? = false,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -5617,7 +5617,7 @@ public class DynamicHlsApi(
 			put("alwaysBurnInSubtitleWhenTranscoding", alwaysBurnInSubtitleWhenTranscoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/main.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -5627,7 +5627,7 @@ public class DynamicHlsApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getVariantHlsVideoPlaylistDeprecated(request: GetVariantHlsVideoPlaylistDeprecatedRequest): Response<ByteReadChannel> = getVariantHlsVideoPlaylistDeprecated(
+	public suspend fun getVariantHlsVideoPlaylistDeprecated(request: GetVariantHlsVideoPlaylistDeprecatedRequest): Response<ByteArray> = getVariantHlsVideoPlaylistDeprecated(
 		itemId = request.itemId,
 		static = request.static,
 		params = request.params,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/HlsSegmentApi.kt
@@ -5,8 +5,8 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.ByteArray
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.buildMap
@@ -25,14 +25,14 @@ public class HlsSegmentApi(
 	 * @param itemId The item id.
 	 * @param segmentId The segment id.
 	 */
-	public suspend fun getHlsAudioSegmentLegacyAac(itemId: String, segmentId: String): Response<ByteReadChannel> {
+	public suspend fun getHlsAudioSegmentLegacyAac(itemId: String, segmentId: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("segmentId", segmentId)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/hls/{segmentId}/stream.aac", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/hls/{segmentId}/stream.aac", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -57,14 +57,14 @@ public class HlsSegmentApi(
 	 * @param itemId The item id.
 	 * @param segmentId The segment id.
 	 */
-	public suspend fun getHlsAudioSegmentLegacyMp3(itemId: String, segmentId: String): Response<ByteReadChannel> {
+	public suspend fun getHlsAudioSegmentLegacyMp3(itemId: String, segmentId: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("segmentId", segmentId)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/hls/{segmentId}/stream.mp3", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/hls/{segmentId}/stream.mp3", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -89,14 +89,14 @@ public class HlsSegmentApi(
 	 * @param itemId The video id.
 	 * @param playlistId The playlist id.
 	 */
-	public suspend fun getHlsPlaylistLegacy(itemId: String, playlistId: String): Response<ByteReadChannel> {
+	public suspend fun getHlsPlaylistLegacy(itemId: String, playlistId: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("playlistId", playlistId)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/hls/{playlistId}/stream.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/hls/{playlistId}/stream.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -128,7 +128,7 @@ public class HlsSegmentApi(
 		playlistId: String,
 		segmentId: String,
 		segmentContainer: String,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(4) {
 			put("itemId", itemId)
 			put("playlistId", playlistId)
@@ -137,7 +137,7 @@ public class HlsSegmentApi(
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/hls/{playlistId}/{segmentId}.{segmentContainer}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/hls/{playlistId}/{segmentId}.{segmentContainer}", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ImageApi.kt
@@ -5,8 +5,8 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.ByteArray
 import kotlin.Double
 import kotlin.Int
 import kotlin.String
@@ -155,7 +155,7 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("name", name)
 			put("imageType", imageType)
@@ -178,7 +178,7 @@ public class ImageApi(
 			put("foregroundLayer", foregroundLayer)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Artists/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Artists/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -187,7 +187,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getArtistImage(request: GetArtistImageRequest): Response<ByteReadChannel> = getArtistImage(
+	public suspend fun getArtistImage(request: GetArtistImageRequest): Response<ByteArray> = getArtistImage(
 		name = request.name,
 		imageType = request.imageType,
 		imageIndex = request.imageIndex,
@@ -310,7 +310,7 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("name", name)
 			put("imageType", imageType)
@@ -333,7 +333,7 @@ public class ImageApi(
 			put("imageIndex", imageIndex)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Genres/{name}/Images/{imageType}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Genres/{name}/Images/{imageType}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -342,7 +342,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getGenreImage(request: GetGenreImageRequest): Response<ByteReadChannel> = getGenreImage(
+	public suspend fun getGenreImage(request: GetGenreImageRequest): Response<ByteArray> = getGenreImage(
 		name = request.name,
 		imageType = request.imageType,
 		tag = request.tag,
@@ -465,7 +465,7 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("name", name)
 			put("imageType", imageType)
@@ -488,7 +488,7 @@ public class ImageApi(
 			put("foregroundLayer", foregroundLayer)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Genres/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Genres/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -497,7 +497,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getGenreImageByIndex(request: GetGenreImageByIndexRequest): Response<ByteReadChannel> = getGenreImageByIndex(
+	public suspend fun getGenreImageByIndex(request: GetGenreImageByIndexRequest): Response<ByteArray> = getGenreImageByIndex(
 		name = request.name,
 		imageType = request.imageType,
 		imageIndex = request.imageIndex,
@@ -620,7 +620,7 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("imageType", imageType)
@@ -643,7 +643,7 @@ public class ImageApi(
 			put("imageIndex", imageIndex)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Items/{itemId}/Images/{imageType}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -652,7 +652,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getItemImage(request: GetItemImageRequest): Response<ByteReadChannel> = getItemImage(
+	public suspend fun getItemImage(request: GetItemImageRequest): Response<ByteArray> = getItemImage(
 		itemId = request.itemId,
 		imageType = request.imageType,
 		maxWidth = request.maxWidth,
@@ -775,7 +775,7 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(9) {
 			put("itemId", itemId)
 			put("imageType", imageType)
@@ -798,7 +798,7 @@ public class ImageApi(
 			put("foregroundLayer", foregroundLayer)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Items/{itemId}/Images/{imageType}/{imageIndex}/{tag}/{format}/{maxWidth}/{maxHeight}/{percentPlayed}/{unplayedCount}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -807,7 +807,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getItemImage2(request: GetItemImage2Request): Response<ByteReadChannel> = getItemImage2(
+	public suspend fun getItemImage2(request: GetItemImage2Request): Response<ByteArray> = getItemImage2(
 		itemId = request.itemId,
 		imageType = request.imageType,
 		maxWidth = request.maxWidth,
@@ -930,7 +930,7 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("itemId", itemId)
 			put("imageType", imageType)
@@ -953,7 +953,7 @@ public class ImageApi(
 			put("foregroundLayer", foregroundLayer)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Items/{itemId}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -962,7 +962,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getItemImageByIndex(request: GetItemImageByIndexRequest): Response<ByteReadChannel> = getItemImageByIndex(
+	public suspend fun getItemImageByIndex(request: GetItemImageByIndexRequest): Response<ByteArray> = getItemImageByIndex(
 		itemId = request.itemId,
 		imageType = request.imageType,
 		imageIndex = request.imageIndex,
@@ -1100,7 +1100,7 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("name", name)
 			put("imageType", imageType)
@@ -1123,7 +1123,7 @@ public class ImageApi(
 			put("imageIndex", imageIndex)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/MusicGenres/{name}/Images/{imageType}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/MusicGenres/{name}/Images/{imageType}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1132,7 +1132,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getMusicGenreImage(request: GetMusicGenreImageRequest): Response<ByteReadChannel> = getMusicGenreImage(
+	public suspend fun getMusicGenreImage(request: GetMusicGenreImageRequest): Response<ByteArray> = getMusicGenreImage(
 		name = request.name,
 		imageType = request.imageType,
 		tag = request.tag,
@@ -1255,7 +1255,7 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("name", name)
 			put("imageType", imageType)
@@ -1278,7 +1278,7 @@ public class ImageApi(
 			put("foregroundLayer", foregroundLayer)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/MusicGenres/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/MusicGenres/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1287,7 +1287,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getMusicGenreImageByIndex(request: GetMusicGenreImageByIndexRequest): Response<ByteReadChannel> = getMusicGenreImageByIndex(
+	public suspend fun getMusicGenreImageByIndex(request: GetMusicGenreImageByIndexRequest): Response<ByteArray> = getMusicGenreImageByIndex(
 		name = request.name,
 		imageType = request.imageType,
 		imageIndex = request.imageIndex,
@@ -1410,7 +1410,7 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("name", name)
 			put("imageType", imageType)
@@ -1433,7 +1433,7 @@ public class ImageApi(
 			put("imageIndex", imageIndex)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Persons/{name}/Images/{imageType}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Persons/{name}/Images/{imageType}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1442,7 +1442,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getPersonImage(request: GetPersonImageRequest): Response<ByteReadChannel> = getPersonImage(
+	public suspend fun getPersonImage(request: GetPersonImageRequest): Response<ByteArray> = getPersonImage(
 		name = request.name,
 		imageType = request.imageType,
 		tag = request.tag,
@@ -1565,7 +1565,7 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("name", name)
 			put("imageType", imageType)
@@ -1588,7 +1588,7 @@ public class ImageApi(
 			put("foregroundLayer", foregroundLayer)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Persons/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Persons/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1597,7 +1597,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getPersonImageByIndex(request: GetPersonImageByIndexRequest): Response<ByteReadChannel> = getPersonImageByIndex(
+	public suspend fun getPersonImageByIndex(request: GetPersonImageByIndexRequest): Response<ByteArray> = getPersonImageByIndex(
 		name = request.name,
 		imageType = request.imageType,
 		imageIndex = request.imageIndex,
@@ -1710,7 +1710,7 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 		quality: Int? = 90,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = emptyMap<String, Any?>()
 		require(quality in 0..100) { "Parameter \"quality\" must be in range 0..100 (inclusive)." }
 		val queryParameters = buildMap<String, Any?>(12) {
@@ -1728,7 +1728,7 @@ public class ImageApi(
 			put("quality", quality)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Branding/Splashscreen", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Branding/Splashscreen", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1737,7 +1737,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getSplashscreen(request: GetSplashscreenRequest = GetSplashscreenRequest()): Response<ByteReadChannel> = getSplashscreen(
+	public suspend fun getSplashscreen(request: GetSplashscreenRequest = GetSplashscreenRequest()): Response<ByteArray> = getSplashscreen(
 		tag = request.tag,
 		format = request.format,
 		maxWidth = request.maxWidth,
@@ -1840,7 +1840,7 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("name", name)
 			put("imageType", imageType)
@@ -1863,7 +1863,7 @@ public class ImageApi(
 			put("imageIndex", imageIndex)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Studios/{name}/Images/{imageType}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Studios/{name}/Images/{imageType}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1872,7 +1872,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getStudioImage(request: GetStudioImageRequest): Response<ByteReadChannel> = getStudioImage(
+	public suspend fun getStudioImage(request: GetStudioImageRequest): Response<ByteArray> = getStudioImage(
 		name = request.name,
 		imageType = request.imageType,
 		tag = request.tag,
@@ -1995,7 +1995,7 @@ public class ImageApi(
 		blur: Int? = null,
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("name", name)
 			put("imageType", imageType)
@@ -2018,7 +2018,7 @@ public class ImageApi(
 			put("foregroundLayer", foregroundLayer)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Studios/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Studios/{name}/Images/{imageType}/{imageIndex}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -2027,7 +2027,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getStudioImageByIndex(request: GetStudioImageByIndexRequest): Response<ByteReadChannel> = getStudioImageByIndex(
+	public suspend fun getStudioImageByIndex(request: GetStudioImageByIndexRequest): Response<ByteArray> = getStudioImageByIndex(
 		name = request.name,
 		imageType = request.imageType,
 		imageIndex = request.imageIndex,
@@ -2148,7 +2148,7 @@ public class ImageApi(
 		backgroundColor: String? = null,
 		foregroundLayer: String? = null,
 		imageIndex: Int? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = buildMap<String, Any?>(16) {
 			put("userId", userId)
@@ -2169,7 +2169,7 @@ public class ImageApi(
 			put("imageIndex", imageIndex)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/UserImage", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/UserImage", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -2178,7 +2178,7 @@ public class ImageApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getUserImage(request: GetUserImageRequest = GetUserImageRequest()): Response<ByteReadChannel> = getUserImage(
+	public suspend fun getUserImage(request: GetUserImageRequest = GetUserImageRequest()): Response<ByteArray> = getUserImage(
 		userId = request.userId,
 		tag = request.tag,
 		format = request.format,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LibraryApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
@@ -114,13 +114,13 @@ public class LibraryApi(
 	 *
 	 * @param itemId The item id.
 	 */
-	public suspend fun getDownload(itemId: UUID): Response<ByteReadChannel> {
+	public suspend fun getDownload(itemId: UUID): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/Download", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Items/{itemId}/Download", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -142,13 +142,13 @@ public class LibraryApi(
 	 *
 	 * @param itemId The item id.
 	 */
-	public suspend fun getFile(itemId: UUID): Response<ByteReadChannel> {
+	public suspend fun getFile(itemId: UUID): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Items/{itemId}/File", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Items/{itemId}/File", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/LiveTvApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
@@ -313,13 +313,13 @@ public class LiveTvApi(
 	 *
 	 * @param recordingId Recording id.
 	 */
-	public suspend fun getLiveRecordingFile(recordingId: String): Response<ByteReadChannel> {
+	public suspend fun getLiveRecordingFile(recordingId: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("recordingId", recordingId)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/LiveTv/LiveRecordings/{recordingId}/stream", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/LiveTv/LiveRecordings/{recordingId}/stream", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -342,14 +342,14 @@ public class LiveTvApi(
 	 * @param streamId Stream id.
 	 * @param container Container type.
 	 */
-	public suspend fun getLiveStreamFile(streamId: String, container: String): Response<ByteReadChannel> {
+	public suspend fun getLiveStreamFile(streamId: String, container: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("streamId", streamId)
 			put("container", container)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/LiveTv/LiveStreamFiles/{streamId}/stream.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/LiveTv/LiveStreamFiles/{streamId}/stream.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -975,11 +975,11 @@ public class LiveTvApi(
 	/**
 	 * Gets available countries.
 	 */
-	public suspend fun getSchedulesDirectCountries(): Response<ByteReadChannel> {
+	public suspend fun getSchedulesDirectCountries(): Response<ByteArray> {
 		val pathParameters = emptyMap<String, Any?>()
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/LiveTv/ListingProviders/SchedulesDirect/Countries", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/LiveTv/ListingProviders/SchedulesDirect/Countries", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/MediaInfoApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
@@ -51,14 +51,14 @@ public class MediaInfoApi(
 	 *
 	 * @param size The bitrate. Defaults to 102400.
 	 */
-	public suspend fun getBitrateTestBytes(size: Int? = 102_400): Response<ByteReadChannel> {
+	public suspend fun getBitrateTestBytes(size: Int? = 102_400): Response<ByteArray> {
 		val pathParameters = emptyMap<String, Any?>()
 		require(size in 1..100_000_000) { "Parameter \"size\" must be in range 1..100000000 (inclusive)." }
 		val queryParameters = buildMap<String, Any?>(1) {
 			put("size", size)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Playback/BitrateTest", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Playback/BitrateTest", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/PluginsApi.kt
@@ -5,8 +5,8 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.String
 import kotlin.Unit
@@ -80,14 +80,14 @@ public class PluginsApi(
 	 * @param pluginId Plugin id.
 	 * @param version Plugin version.
 	 */
-	public suspend fun getPluginImage(pluginId: UUID, version: String): Response<ByteReadChannel> {
+	public suspend fun getPluginImage(pluginId: UUID, version: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("pluginId", pluginId)
 			put("version", version)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Plugins/{pluginId}/{version}/Image", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Plugins/{pluginId}/{version}/Image", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/SubtitleApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
@@ -72,13 +72,13 @@ public class SubtitleApi(
 	 *
 	 * @param name The name of the fallback font file to get.
 	 */
-	public suspend fun getFallbackFont(name: String): Response<ByteReadChannel> {
+	public suspend fun getFallbackFont(name: String): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("name", name)
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/FallbackFont/Fonts/{name}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/FallbackFont/Fonts/{name}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -349,7 +349,7 @@ public class SubtitleApi(
 		index: Int,
 		mediaSourceId: String,
 		segmentLength: Int,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("itemId", itemId)
 			put("index", index)
@@ -359,7 +359,7 @@ public class SubtitleApi(
 			put("segmentLength", segmentLength)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/{mediaSourceId}/Subtitles/{index}/subtitles.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/{mediaSourceId}/Subtitles/{index}/subtitles.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TrickplayApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/TrickplayApi.kt
@@ -5,8 +5,8 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.ByteArray
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.buildMap
@@ -29,7 +29,7 @@ public class TrickplayApi(
 		itemId: UUID,
 		width: Int,
 		mediaSourceId: UUID? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("width", width)
@@ -38,7 +38,7 @@ public class TrickplayApi(
 			put("mediaSourceId", mediaSourceId)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/Trickplay/{width}/tiles.m3u8", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/Trickplay/{width}/tiles.m3u8", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -77,7 +77,7 @@ public class TrickplayApi(
 		width: Int,
 		index: Int,
 		mediaSourceId: UUID? = null,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("itemId", itemId)
 			put("width", width)
@@ -87,7 +87,7 @@ public class TrickplayApi(
 			put("mediaSourceId", mediaSourceId)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/Trickplay/{width}/{index}.jpg", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/Trickplay/{width}/{index}.jpg", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/UniversalAudioApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Int
 import kotlin.Long
 import kotlin.String
@@ -69,7 +69,7 @@ public class UniversalAudioApi(
 		enableAudioVbrEncoding: Boolean? = true,
 		breakOnNonKeyFrames: Boolean? = false,
 		enableRedirection: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -96,7 +96,7 @@ public class UniversalAudioApi(
 			put("enableRedirection", enableRedirection)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Audio/{itemId}/universal", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Audio/{itemId}/universal", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -105,7 +105,7 @@ public class UniversalAudioApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getUniversalAudioStream(request: GetUniversalAudioStreamRequest): Response<ByteReadChannel> = getUniversalAudioStream(
+	public suspend fun getUniversalAudioStream(request: GetUniversalAudioStreamRequest): Response<ByteArray> = getUniversalAudioStream(
 		itemId = request.itemId,
 		container = request.container,
 		mediaSourceId = request.mediaSourceId,

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideoAttachmentsApi.kt
@@ -5,8 +5,8 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
+import kotlin.ByteArray
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.buildMap
@@ -30,7 +30,7 @@ public class VideoAttachmentsApi(
 		videoId: UUID,
 		mediaSourceId: String,
 		index: Int,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(3) {
 			put("videoId", videoId)
 			put("mediaSourceId", mediaSourceId)
@@ -38,7 +38,7 @@ public class VideoAttachmentsApi(
 		}
 		val queryParameters = emptyMap<String, Any?>()
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{videoId}/{mediaSourceId}/Attachments/{index}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{videoId}/{mediaSourceId}/Attachments/{index}", pathParameters, queryParameters, data)
 		return response
 	}
 

--- a/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/VideosApi.kt
@@ -5,9 +5,9 @@
 // Please read the README.md file in the openapi-generator module for additional information.
 package org.jellyfin.sdk.api.operations
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.ByteArray
 import kotlin.Deprecated
 import kotlin.Float
 import kotlin.Int
@@ -177,7 +177,7 @@ public class VideosApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -239,7 +239,7 @@ public class VideosApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/stream", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/stream", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -248,7 +248,7 @@ public class VideosApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getVideoStream(request: GetVideoStreamRequest): Response<ByteReadChannel> = getVideoStream(
+	public suspend fun getVideoStream(request: GetVideoStreamRequest): Response<ByteArray> = getVideoStream(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,
@@ -582,7 +582,7 @@ public class VideosApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(2) {
 			put("itemId", itemId)
 			put("container", container)
@@ -644,7 +644,7 @@ public class VideosApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/stream.{container}", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/stream.{container}", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -653,7 +653,7 @@ public class VideosApi(
 	 *
 	 * @param request The request parameters
 	 */
-	public suspend fun getVideoStreamByContainer(request: GetVideoStreamByContainerRequest): Response<ByteReadChannel> = getVideoStreamByContainer(
+	public suspend fun getVideoStreamByContainer(request: GetVideoStreamByContainerRequest): Response<ByteArray> = getVideoStreamByContainer(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,
@@ -991,7 +991,7 @@ public class VideosApi(
 		context: EncodingContext? = null,
 		streamOptions: Map<String, String?>? = emptyMap(),
 		enableAudioVbrEncoding: Boolean? = true,
-	): Response<ByteReadChannel> {
+	): Response<ByteArray> {
 		val pathParameters = buildMap<String, Any?>(1) {
 			put("itemId", itemId)
 		}
@@ -1054,7 +1054,7 @@ public class VideosApi(
 			put("enableAudioVbrEncoding", enableAudioVbrEncoding)
 		}
 		val data = null
-		val response = api.`get`<ByteReadChannel>("/Videos/{itemId}/stream", pathParameters, queryParameters, data)
+		val response = api.`get`<ByteArray>("/Videos/{itemId}/stream", pathParameters, queryParameters, data)
 		return response
 	}
 
@@ -1064,7 +1064,7 @@ public class VideosApi(
 	 * @param request The request parameters
 	 */
 	@Deprecated("This member is deprecated and may be removed in the future")
-	public suspend fun getVideoStreamDeprecated(request: GetVideoStreamDeprecatedRequest): Response<ByteReadChannel> = getVideoStreamDeprecated(
+	public suspend fun getVideoStreamDeprecated(request: GetVideoStreamDeprecatedRequest): Response<ByteArray> = getVideoStreamDeprecated(
 		itemId = request.itemId,
 		container = request.container,
 		static = request.static,

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/RawResponse.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.sdk.api.client
 
-import io.ktor.utils.io.ByteReadChannel
 import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
 import org.jellyfin.sdk.api.client.exception.InvalidContentException
@@ -18,7 +17,6 @@ public class RawResponse(
 			when {
 				T::class == Unit::class -> Unit as T
 				T::class == ByteArray::class -> body as T
-				T::class == ByteReadChannel::class -> ByteReadChannel(body) as T
 				else -> ApiSerializer.decodeResponseBody(body.decodeToString())
 			}
 		} catch (err: SerializationException) {

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializer.kt
@@ -1,7 +1,5 @@
 package org.jellyfin.sdk.api.client.util
 
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.readRemaining
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -30,11 +28,8 @@ public object ApiSerializer {
 		return json.encodeToString(requestBody::class.serializer() as KSerializer<Any>, requestBody)
 	}
 
-	public suspend inline fun <reified T : Any> decodeResponseBody(responseBody: ByteReadChannel): T = when {
-		T::class == Unit::class -> Unit as T
-		T::class == ByteReadChannel::class -> responseBody as T
-		else -> json.decodeFromString(responseBody.readRemaining().readText())
-	}
+	public inline fun <reified T : Any> decodeResponseBody(string: String): T =
+		json.decodeFromString(string) as T
 
 	public fun encodeSocketMessage(message: InboundWebSocketMessage): String =
 		json.encodeToString(InboundWebSocketMessage.serializer(), message)

--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializerTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/ApiSerializerTests.kt
@@ -1,37 +1,19 @@
 package org.jellyfin.sdk.api.client.util
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeTypeOf
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.charsets.Charsets
-import kotlinx.coroutines.test.runTest
 
 class ApiSerializerTests : FunSpec({
-	test("ApiSerializer can decode Unit") {
-		val result = ApiSerializer.decodeResponseBody<Unit>(ByteReadChannel("", Charsets.UTF_8))
-
-		result.shouldBeTypeOf<Unit>()
-	}
-
-	test("ApiSerializer can decode ByteReadChannel") {
-		val channel = ByteReadChannel(byteArrayOf(0x1, 0x0, 0x1))
-		val result = ApiSerializer.decodeResponseBody<ByteReadChannel>(channel)
-
-		result shouldBe channel
-	}
-
 	test("ApiSerializer can decode JSON") {
-		val channel = ByteReadChannel("""{"test": true}""")
-		val result = ApiSerializer.decodeResponseBody<Map<String, Boolean>>(channel)
+		val content = """{"test": true}"""
+		val result = ApiSerializer.decodeResponseBody<Map<String, Boolean>>(content)
 
 		result["test"] shouldBe true
 	}
 
 	test("ApiSerializer can decode primitive") {
-		val channel = ByteReadChannel("""42""")
-		val result = ApiSerializer.decodeResponseBody<Int>(channel)
+		val content = """42"""
+		val result = ApiSerializer.decodeResponseBody<Int>(content)
 
 		result shouldBe 42
 	}

--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/RawResponseTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/RawResponseTests.kt
@@ -1,0 +1,37 @@
+package org.jellyfin.sdk.api.client.util
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import org.jellyfin.sdk.api.client.RawResponse
+
+private fun createResponse(content: ByteArray) = RawResponse(content, 200, emptyMap())
+
+class RawResponseTests : FunSpec({
+	test("ApiSerializer can decode Unit") {
+		val result = createResponse(ByteArray(0)).createContent<Unit>()
+
+		result.shouldBeTypeOf<Unit>()
+	}
+
+	test("ApiSerializer can decode ByteReadChannel") {
+		val content = byteArrayOf(0x1, 0x0, 0x1)
+		val result = createResponse(content).createContent<ByteArray>()
+
+		result shouldBe content
+	}
+
+	test("ApiSerializer can decode JSON") {
+		val content = """{"test": true}""".toByteArray()
+		val result = createResponse(content).createContent<Map<String, Boolean>>()
+
+		result["test"] shouldBe true
+	}
+
+	test("ApiSerializer can decode primitive") {
+		val content = """42""".toByteArray()
+		val result = createResponse(content).createContent<Int>()
+
+		result shouldBe 42
+	}
+})

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiReturnTypeBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiReturnTypeBuilder.kt
@@ -29,7 +29,7 @@ class OpenApiReturnTypeBuilder(
 			MimeType.FONT_ALL in supportedReturnMimeTypes ||
 			MimeType.APPLICATION_X_MPEG_URL in supportedReturnMimeTypes ||
 			MimeType.APPLICATION_OCTET_STREAM in supportedReturnMimeTypes ->
-				Types.BINARY
+				Types.BYTE_ARRAY
 			// JSON (restful) types
 			MimeType.APPLICATION_JSON in supportedReturnMimeTypes -> {
 				val schema = response!!.content[MimeType.APPLICATION_JSON]!!.schema

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiTypeBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/openapi/OpenApiTypeBuilder.kt
@@ -57,7 +57,7 @@ class OpenApiTypeBuilder(
 			// UUID
 			is UUIDSchema -> buildUUIDType()
 			// Binary
-			is BinarySchema -> buildBinary(path)
+			is BinarySchema -> buildBinary()
 			// Collections
 			is ArraySchema -> buildArrayType(path, schema)
 			is MapSchema -> buildMapType(path, schema)
@@ -116,10 +116,7 @@ class OpenApiTypeBuilder(
 			.toPascalCase(from = CaseFormat.CAPITALIZED_CAMEL)
 	)
 
-	fun buildBinary(path: TypePath) = when {
-		path is ApiTypePath && path.isReturnType() -> Types.BINARY
-		else -> Types.BYTE_ARRAY
-	}
+	fun buildBinary() = Types.BYTE_ARRAY
 
 	fun buildJsonElement() = Types.JSON_ELEMENT
 

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Types.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/constants/Types.kt
@@ -5,7 +5,6 @@ import com.squareup.kotlinpoet.asTypeName
 
 object Types {
 	// Custom
-	val BINARY = ClassName("io.ktor.utils.io", "ByteReadChannel")
 	val BYTE_ARRAY = ByteArray::class.asTypeName()
 	val UUID = ClassName(Packages.MODEL_TYPES, Classes.Types.UUID)
 	val DATETIME = ClassName(Packages.MODEL_TYPES, Classes.Types.DATETIME)

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/api/BinaryOperationUrlHook.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/hooks/api/BinaryOperationUrlHook.kt
@@ -8,5 +8,5 @@ import org.jellyfin.openapi.model.HttpMethod
 
 class BinaryOperationUrlHook : OperationUrlHook {
 	override fun shouldOperationBuildUrlFun(api: ApiService, operation: ApiServiceOperation) =
-		operation.method == HttpMethod.GET && operation.returnType == Types.BINARY
+		operation.method == HttpMethod.GET && operation.returnType == Types.BYTE_ARRAY
 }


### PR DESCRIPTION
- Use ByteArray instead of ByteReadChannel in RawResponse
- Move non-json decoding from ApiSerializer to RawResponse
- Update ApiSerializer.decodeResponseBody to receive string input
- Update api generator to use ByteArray instead of ByteReadChannel for binary responses
- Remove ktor dependency on jellyfin:api module

(ByteReadChannel is a Ktor type)