### PR TITLE
Use encodeURLPart in AuthorizationHeaderBuilder

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/AuthorizationHeaderBuilder.kt
@@ -1,14 +1,12 @@
 package org.jellyfin.sdk.api.client.util
 
-import io.ktor.http.encodeURLParameter
-
 public object AuthorizationHeaderBuilder {
 	public const val AUTHORIZATION_SCHEME: String = "MediaBrowser"
 
 	public fun encodeParameterValue(raw: String): String = raw
 		.trim()
 		.replace(Regex("\\n"), " ")
-		.encodeURLParameter(spaceToPlus = true)
+		.encodeURLPart()
 
 	public fun buildParameter(key: String, value: String): String {
 		// Check for bad strings to prevent endless hours debugging why the server throws http 500 errors

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilder.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilder.kt
@@ -121,7 +121,7 @@ public object UrlBuilder {
 
 					// Don't encode null values
 					if (value != null) {
-						append(value.toString().encodeURLPathPart())
+						append(value.toString().encodeURLPart())
 					}
 
 					// Close path variable
@@ -137,25 +137,6 @@ public object UrlBuilder {
 
 		// Append rest of path to result (can be empty)
 		append(template.substring(lastEnd + 1))
-	}
-
-	private fun String.encodeURLPathPart(): String = buildString {
-		this@encodeURLPathPart.forEach { char ->
-			when {
-				char.isUnreserved() -> append(char)
-				char == ' ' -> append('+')
-				else -> append("%${char.code.toString(16).uppercase()}")
-			}
-		}
-	}
-
-	private fun Char.isUnreserved() = isLetterOrDigit() || this in arrayOf('-', '_', '.', '~')
-
-	private fun String.extractQuerystring(): Pair<String, String?> {
-		val path = substringBefore('?')
-		val querystring = if (path.length < length) substring(path.length + 1) else null
-
-		return path to querystring
 	}
 }
 

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/url.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/url.kt
@@ -1,0 +1,28 @@
+package org.jellyfin.sdk.api.client.util
+
+internal fun String.encodeURLPart(): String = buildString {
+	this@encodeURLPart.codePoints().forEach { codePoint ->
+		val char = codePoint.toChar()
+		when {
+			char.isUnreserved() -> append(char)
+			char == ' ' -> append('+')
+			else -> char
+				.toString()
+				.encodeToByteArray()
+				.forEach { byte -> append("%", byte.toUByte().toString(16).uppercase().padStart(2, '0')) }
+		}
+	}
+}
+
+internal fun Char.isUnreserved() =
+	this in 'A'..'Z' ||
+		this in 'a'..'z' ||
+		this in '0'..'9' ||
+		this in arrayOf('-', '_', '.', '~')
+
+internal fun String.extractQuerystring(): Pair<String, String?> {
+	val path = substringBefore('?')
+	val querystring = if (path.length < length) substring(path.length + 1) else null
+
+	return path to querystring
+}


### PR DESCRIPTION
- Extract encodeURLPart, isUnreserved and extractQuerystring to internal functions in org.jellyfin.sdk.api.client.util package.
- Rename encodeURLPathPart to encodeURLPart
- Use encodeURLPart in AuthorizationHeaderBuilder
- Fix encoding of non-ascii characters (thanks for the unit testing with kanji)