### PR TITLE
Add OkHttpClient

### DIFF
--- a/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
+++ b/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
@@ -20,3 +20,11 @@ public final class org/jellyfin/sdk/api/okhttp/OkHttpFactory : org/jellyfin/sdk/
 	public final fun getBase ()Lokhttp3/OkHttpClient;
 }
 
+public final class org/jellyfin/sdk/api/okhttp/OkHttpSocketConnection : org/jellyfin/sdk/api/sockets/SocketConnection {
+	public fun <init> (Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;)V
+	public fun connect (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getState ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
+++ b/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
@@ -1,0 +1,12 @@
+public final class org/jellyfin/sdk/api/okhttp/OkHttpClient : org/jellyfin/sdk/api/client/ApiClient {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
+	public fun getAccessToken ()Ljava/lang/String;
+	public fun getBaseUrl ()Ljava/lang/String;
+	public fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
+	public fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
+	public fun getHttpClientOptions ()Lorg/jellyfin/sdk/api/client/HttpClientOptions;
+	public fun getWebSocket ()Lorg/jellyfin/sdk/api/sockets/SocketApi;
+	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun update (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)V
+}
+

--- a/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
+++ b/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
@@ -1,5 +1,5 @@
 public final class org/jellyfin/sdk/api/okhttp/OkHttpClient : org/jellyfin/sdk/api/client/ApiClient {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
+	public fun <init> (Lokhttp3/OkHttpClient;Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)V
 	public fun getAccessToken ()Ljava/lang/String;
 	public fun getBaseUrl ()Ljava/lang/String;
 	public fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
@@ -8,5 +8,15 @@ public final class org/jellyfin/sdk/api/okhttp/OkHttpClient : org/jellyfin/sdk/a
 	public fun getWebSocket ()Lorg/jellyfin/sdk/api/sockets/SocketApi;
 	public fun request (Lorg/jellyfin/sdk/api/client/HttpMethod;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun update (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;)V
+}
+
+public final class org/jellyfin/sdk/api/okhttp/OkHttpFactory : org/jellyfin/sdk/api/client/ApiClientFactory, org/jellyfin/sdk/api/sockets/SocketConnectionFactory {
+	public fun <init> ()V
+	public fun <init> (Lokhttp3/OkHttpClient;)V
+	public synthetic fun <init> (Lokhttp3/OkHttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun create (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
+	public fun create (Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lkotlinx/coroutines/CoroutineScope;)Lorg/jellyfin/sdk/api/sockets/SocketConnection;
+	public final fun createClient (Lorg/jellyfin/sdk/api/client/HttpClientOptions;)Lokhttp3/OkHttpClient;
+	public final fun getBase ()Lokhttp3/OkHttpClient;
 }
 

--- a/jellyfin-api-okhttp/build.gradle.kts
+++ b/jellyfin-api-okhttp/build.gradle.kts
@@ -1,0 +1,51 @@
+plugins {
+	kotlin("multiplatform")
+	alias(libs.plugins.dokka)
+}
+
+kotlin {
+	explicitApi()
+
+	jvm()
+
+	jvmToolchain(8)
+
+	sourceSets {
+		all {
+			languageSettings {
+				progressiveMode = true
+			}
+		}
+
+		val commonMain by getting {
+			dependencies {
+				implementation(projects.jellyfinApi)
+				implementation(projects.jellyfinModel)
+
+				implementation(libs.kotlinx.coroutines)
+				implementation(libs.kotlinx.serialization.core)
+				implementation(libs.okhttp)
+
+				implementation(libs.kotlin.logging)
+			}
+		}
+
+		val commonTest by getting {
+			dependencies {
+				implementation(projects.testutils)
+			}
+		}
+	}
+}
+
+enablePublishing {
+	val javadocJar by tasks.registering(Jar::class) {
+		dependsOn(tasks.dokkaHtml)
+		from(tasks.dokkaHtml.flatMap { it.outputDirectory })
+		archiveClassifier.set("javadoc")
+	}
+
+	publications.withType<MavenPublication> {
+		artifact(javadocJar)
+	}
+}

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
@@ -1,0 +1,177 @@
+package org.jellyfin.sdk.api.okhttp
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.serialization.SerializationException
+import mu.KotlinLogging
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.client.HttpMethod
+import org.jellyfin.sdk.api.client.RawResponse
+import org.jellyfin.sdk.api.client.exception.ApiClientException
+import org.jellyfin.sdk.api.client.exception.InvalidContentException
+import org.jellyfin.sdk.api.client.exception.InvalidStatusException
+import org.jellyfin.sdk.api.client.exception.SecureConnectionException
+import org.jellyfin.sdk.api.client.exception.TimeoutException
+import org.jellyfin.sdk.api.client.util.ApiSerializer
+import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
+import org.jellyfin.sdk.api.sockets.DefaultSocketApi
+import org.jellyfin.sdk.api.sockets.SocketApi
+import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+import org.jellyfin.sdk.model.FileInfo
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.time.toJavaDuration
+
+@Suppress("LongParameterList")
+public class OkHttpClient(
+	initialBaseUrl: String?,
+	initialAccessToken: String?,
+	initialClientInfo: ClientInfo,
+	initialDeviceInfo: DeviceInfo,
+	override val httpClientOptions: HttpClientOptions,
+	private val socketConnectionFactory: SocketConnectionFactory,
+) : ApiClient() {
+	public override var baseUrl: String? = initialBaseUrl
+		private set
+	public override var accessToken: String? = initialAccessToken
+		private set
+	public override var clientInfo: ClientInfo = initialClientInfo
+		private set
+	public override var deviceInfo: DeviceInfo = initialDeviceInfo
+		private set
+
+	private val client by lazy {
+		OkHttpClient.Builder()
+			.followRedirects(httpClientOptions.followRedirects)
+			.connectTimeout(httpClientOptions.connectTimeout.toJavaDuration())
+			.callTimeout(httpClientOptions.requestTimeout.toJavaDuration())
+			.readTimeout(httpClientOptions.socketTimeout.toJavaDuration())
+			.writeTimeout(httpClientOptions.socketTimeout.toJavaDuration())
+			.build()
+	}
+
+	private val _webSocket = lazy {
+		DefaultSocketApi(this, httpClientOptions.socketReconnectPolicy, socketConnectionFactory)
+	}
+
+	override val webSocket: SocketApi by _webSocket
+
+	override fun update(baseUrl: String?, accessToken: String?, clientInfo: ClientInfo, deviceInfo: DeviceInfo) {
+		this.baseUrl = baseUrl
+		this.accessToken = accessToken
+		this.clientInfo = clientInfo
+		this.deviceInfo = deviceInfo
+
+		// Notify websocket only if initialized
+		if (_webSocket.isInitialized()) {
+			_webSocket.value.notifyApiClientUpdate()
+		}
+	}
+
+	@Suppress("ThrowsCount")
+	override suspend fun request(
+		method: HttpMethod,
+		pathTemplate: String,
+		pathParameters: Map<String, Any?>,
+		queryParameters: Map<String, Any?>,
+		requestBody: Any?,
+	): RawResponse {
+		val url = createUrl(pathTemplate, pathParameters, queryParameters)
+
+		// Log HTTP call with access token removed
+		val logger = KotlinLogging.logger {}
+		logger.info {
+			val safeUrl = accessToken?.let { url.replace(it, "******") } ?: url
+			"$method $safeUrl"
+		}
+
+		val request = Request.Builder().apply {
+			val body = when (method) {
+				HttpMethod.POST -> when (requestBody) {
+					// String content
+					is String -> requestBody.toRequestBody("text/plain".toMediaType())
+					// File content
+					is FileInfo -> requestBody.content.toRequestBody(requestBody.mediaType.toMediaType())
+					// Binary content
+					is ByteArray -> requestBody.toRequestBody("application/octet-stream".toMediaType())
+					// Json content
+					else -> ApiSerializer.encodeRequestBody(requestBody)
+						?.toRequestBody("application/json".toMediaType())
+				} ?: ByteArray(0).toRequestBody(null, 0, 0)
+
+				else -> null
+			}
+			method(method.name, body)
+			url(url)
+
+			header("Accept", HEADER_ACCEPT)
+
+			val authorization = AuthorizationHeaderBuilder.buildHeader(
+				clientName = clientInfo.name,
+				clientVersion = clientInfo.version,
+				deviceId = deviceInfo.id,
+				deviceName = deviceInfo.name,
+				accessToken = accessToken
+			)
+			header("Authorization", authorization)
+		}.build()
+
+		try {
+			val response = client.newCall(request).await()
+			if (!response.isSuccessful) throw InvalidStatusException(response.code)
+			return RawResponse(response.body!!.bytes(), response.code, response.headers.toMultimap())
+		} catch (err: UnknownHostException) {
+			logger.debug(err) { "HTTP host unreachable" }
+			throw TimeoutException("HTTP host unreachable", err)
+		} catch (err: SocketTimeoutException) {
+			logger.debug(err) { "Socket timed out" }
+			throw TimeoutException("Socket timed out", err)
+		} catch (err: ConnectException) {
+			logger.debug(err) { "Connection failed" }
+			throw TimeoutException("Connection failed", err)
+		} catch (err: SerializationException) {
+			logger.error(err) { "Serialization failed" }
+			throw InvalidContentException("Serialization failed", err)
+		} catch (err: SSLException) {
+			logger.error(err) { "Unknown SSL error occurred" }
+			throw SecureConnectionException("Unknown SSL error occurred", err)
+		} catch (err: IOException) {
+			logger.error(err) { "Unknown IO error occurred!" }
+			throw ApiClientException("Unknown IO error occurred!", err)
+		}
+	}
+
+	private suspend fun Call.await(): Response = suspendCancellableCoroutine { continuation ->
+		enqueue(object : Callback {
+			override fun onResponse(call: Call, response: Response) {
+				continuation.resume(response)
+			}
+
+			override fun onFailure(call: Call, e: IOException) {
+				if (!call.isCanceled()) {
+					continuation.resumeWithException(e)
+				}
+			}
+		})
+
+		continuation.invokeOnCancellation {
+			runCatching {
+				cancel()
+			}
+		}
+	}
+}

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
@@ -6,7 +6,6 @@ import mu.KotlinLogging
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -34,10 +33,10 @@ import java.net.UnknownHostException
 import javax.net.ssl.SSLException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.time.toJavaDuration
 
 @Suppress("LongParameterList")
 public class OkHttpClient(
+	private val client: okhttp3.OkHttpClient,
 	initialBaseUrl: String?,
 	initialAccessToken: String?,
 	initialClientInfo: ClientInfo,
@@ -53,16 +52,6 @@ public class OkHttpClient(
 		private set
 	public override var deviceInfo: DeviceInfo = initialDeviceInfo
 		private set
-
-	private val client by lazy {
-		OkHttpClient.Builder()
-			.followRedirects(httpClientOptions.followRedirects)
-			.connectTimeout(httpClientOptions.connectTimeout.toJavaDuration())
-			.callTimeout(httpClientOptions.requestTimeout.toJavaDuration())
-			.readTimeout(httpClientOptions.socketTimeout.toJavaDuration())
-			.writeTimeout(httpClientOptions.socketTimeout.toJavaDuration())
-			.build()
-	}
 
 	private val _webSocket = lazy {
 		DefaultSocketApi(this, httpClientOptions.socketReconnectPolicy, socketConnectionFactory)

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpFactory.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpFactory.kt
@@ -1,0 +1,56 @@
+package org.jellyfin.sdk.api.okhttp
+
+import kotlinx.coroutines.CoroutineScope
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.ApiClientFactory
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.sockets.OkHttpSocketConnection
+import org.jellyfin.sdk.api.sockets.SocketConnection
+import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+import kotlin.time.toJavaDuration
+
+/**
+ * Create a new factory that creates OkHttp ApiClient instances and SocketConnections on a shared connection pool. All
+ * instances will be built on top of the [base] okHttpClient.
+ */
+public class OkHttpFactory(
+	public val base: okhttp3.OkHttpClient = okhttp3.OkHttpClient.Builder().build(),
+) : ApiClientFactory, SocketConnectionFactory {
+	override fun create(
+		baseUrl: String?,
+		accessToken: String?,
+		clientInfo: ClientInfo,
+		deviceInfo: DeviceInfo,
+		httpClientOptions: HttpClientOptions,
+		socketConnectionFactory: SocketConnectionFactory
+	): ApiClient = OkHttpClient(
+		client = createClient(httpClientOptions),
+		initialBaseUrl = baseUrl,
+		initialAccessToken = accessToken,
+		initialClientInfo = clientInfo,
+		initialDeviceInfo = deviceInfo,
+		httpClientOptions = httpClientOptions,
+		socketConnectionFactory = socketConnectionFactory,
+	)
+
+	override fun create(
+		clientOptions: HttpClientOptions,
+		scope: CoroutineScope
+	): SocketConnection = OkHttpSocketConnection(
+		client = createClient(clientOptions),
+		scope = scope,
+	)
+
+	/**
+	 * Create a new [okhttp3.OkHttpClient] instance with the [HttpClientOptions] applied to it.
+	 */
+	public fun createClient(httpClientOptions: HttpClientOptions): okhttp3.OkHttpClient = base.newBuilder()
+		.followRedirects(httpClientOptions.followRedirects)
+		.connectTimeout(httpClientOptions.connectTimeout.toJavaDuration())
+		.callTimeout(httpClientOptions.requestTimeout.toJavaDuration())
+		.readTimeout(httpClientOptions.socketTimeout.toJavaDuration())
+		.writeTimeout(httpClientOptions.socketTimeout.toJavaDuration())
+		.build()
+}

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpFactory.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpFactory.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.CoroutineScope
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.ApiClientFactory
 import org.jellyfin.sdk.api.client.HttpClientOptions
-import org.jellyfin.sdk.api.sockets.OkHttpSocketConnection
 import org.jellyfin.sdk.api.sockets.SocketConnection
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpSocketConnection.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpSocketConnection.kt
@@ -1,4 +1,4 @@
-package org.jellyfin.sdk.api.sockets
+package org.jellyfin.sdk.api.okhttp
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,6 +12,8 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
+import org.jellyfin.sdk.api.sockets.SocketConnection
+import org.jellyfin.sdk.api.sockets.SocketConnectionState
 
 private val logger = KotlinLogging.logger {}
 

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -21,6 +21,10 @@ public abstract class org/jellyfin/sdk/api/client/ApiClient {
 public final class org/jellyfin/sdk/api/client/ApiClient$Companion {
 }
 
+public abstract interface class org/jellyfin/sdk/api/client/ApiClientFactory {
+	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
+}
+
 public final class org/jellyfin/sdk/api/client/HttpClientOptions {
 	public synthetic fun <init> (ZJJJLorg/jellyfin/sdk/api/sockets/SocketReconnectPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (ZJJJLorg/jellyfin/sdk/api/sockets/SocketReconnectPolicy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1261,7 +1265,7 @@ public final class org/jellyfin/sdk/api/sockets/DefaultSocketApi : org/jellyfin/
 }
 
 public final class org/jellyfin/sdk/api/sockets/OkHttpSocketConnection : org/jellyfin/sdk/api/sockets/SocketConnection {
-	public fun <init> (Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lkotlinx/coroutines/CoroutineScope;)V
+	public fun <init> (Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;)V
 	public fun connect (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getState ()Lkotlinx/coroutines/flow/StateFlow;

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1264,14 +1264,6 @@ public final class org/jellyfin/sdk/api/sockets/DefaultSocketApi : org/jellyfin/
 	public fun subscribeAll ()Lkotlinx/coroutines/flow/Flow;
 }
 
-public final class org/jellyfin/sdk/api/sockets/OkHttpSocketConnection : org/jellyfin/sdk/api/sockets/SocketConnection {
-	public fun <init> (Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;)V
-	public fun connect (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getState ()Lkotlinx/coroutines/flow/StateFlow;
-	public fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public abstract interface class org/jellyfin/sdk/api/sockets/SocketApi {
 	public abstract fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun subscribe (Lkotlin/reflect/KClass;)Lkotlinx/coroutines/flow/Flow;

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClientFactory.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/ApiClientFactory.kt
@@ -1,7 +1,5 @@
-package org.jellyfin.sdk.util
+package org.jellyfin.sdk.api.client
 
-import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.HttpClientOptions
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo

--- a/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/OkHttpSocketConnection.kt
+++ b/jellyfin-api/src/jvmMain/kotlin/org/jellyfin/sdk/api/sockets/OkHttpSocketConnection.kt
@@ -12,13 +12,11 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
-import org.jellyfin.sdk.api.client.HttpClientOptions
-import java.util.concurrent.TimeUnit
 
 private val logger = KotlinLogging.logger {}
 
 public class OkHttpSocketConnection(
-	clientOptions: HttpClientOptions,
+	private val client: OkHttpClient,
 	scope: CoroutineScope,
 ) : SocketConnection {
 	private companion object {
@@ -26,13 +24,6 @@ public class OkHttpSocketConnection(
 		private const val CLOSE_REASON_NORMAL = 1000
 	}
 
-	private val client = OkHttpClient.Builder().apply {
-		followRedirects(clientOptions.followRedirects)
-
-		connectTimeout(clientOptions.connectTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-		readTimeout(clientOptions.socketTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-		writeTimeout(clientOptions.socketTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-	}.build()
 	private var webSocket: WebSocket? = null
 	private val _state = MutableStateFlow<SocketConnectionState>(SocketConnectionState.Disconnected())
 	public override val state: StateFlow<SocketConnectionState> = _state.asStateFlow()

--- a/jellyfin-core/api/android/jellyfin-core.api
+++ b/jellyfin-core/api/android/jellyfin-core.api
@@ -21,17 +21,17 @@ public final class org/jellyfin/sdk/JellyfinKt {
 
 public final class org/jellyfin/sdk/JellyfinOptions {
 	public static final field Companion Lorg/jellyfin/sdk/JellyfinOptions$Companion;
-	public fun <init> (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)V
+	public fun <init> (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)V
 	public final fun component1 ()Landroid/content/Context;
 	public final fun component2 ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun component3 ()Lorg/jellyfin/sdk/model/DeviceInfo;
-	public final fun component4 ()Lorg/jellyfin/sdk/util/ApiClientFactory;
+	public final fun component4 ()Lorg/jellyfin/sdk/api/client/ApiClientFactory;
 	public final fun component5 ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
 	public final fun component6 ()Lorg/jellyfin/sdk/model/ServerVersion;
-	public final fun copy (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/JellyfinOptions;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public final fun copy (Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Landroid/content/Context;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
+	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/api/client/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
@@ -44,13 +44,13 @@ public final class org/jellyfin/sdk/JellyfinOptions {
 public final class org/jellyfin/sdk/JellyfinOptions$Builder {
 	public fun <init> ()V
 	public final fun build ()Lorg/jellyfin/sdk/JellyfinOptions;
-	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
+	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/api/client/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun getMinimumServerVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public final fun getSocketConnectionFactory ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
-	public final fun setApiClientFactory (Lorg/jellyfin/sdk/util/ApiClientFactory;)V
+	public final fun setApiClientFactory (Lorg/jellyfin/sdk/api/client/ApiClientFactory;)V
 	public final fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public final fun setContext (Landroid/content/Context;)V
 	public final fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
@@ -229,9 +229,5 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$Unsupported
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class org/jellyfin/sdk/util/ApiClientFactory {
-	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
 }
 

--- a/jellyfin-core/api/jvm/jellyfin-core.api
+++ b/jellyfin-core/api/jvm/jellyfin-core.api
@@ -21,16 +21,16 @@ public final class org/jellyfin/sdk/JellyfinKt {
 
 public final class org/jellyfin/sdk/JellyfinOptions {
 	public static final field Companion Lorg/jellyfin/sdk/JellyfinOptions$Companion;
-	public fun <init> (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)V
+	public fun <init> (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)V
 	public final fun component1 ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun component2 ()Lorg/jellyfin/sdk/model/DeviceInfo;
-	public final fun component3 ()Lorg/jellyfin/sdk/util/ApiClientFactory;
+	public final fun component3 ()Lorg/jellyfin/sdk/api/client/ApiClientFactory;
 	public final fun component4 ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
 	public final fun component5 ()Lorg/jellyfin/sdk/model/ServerVersion;
-	public final fun copy (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/JellyfinOptions;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/util/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public final fun copy (Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;)Lorg/jellyfin/sdk/JellyfinOptions;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/JellyfinOptions;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/ApiClientFactory;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;Lorg/jellyfin/sdk/model/ServerVersion;ILjava/lang/Object;)Lorg/jellyfin/sdk/JellyfinOptions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
+	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/api/client/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun getMinimumServerVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
@@ -42,12 +42,12 @@ public final class org/jellyfin/sdk/JellyfinOptions {
 public final class org/jellyfin/sdk/JellyfinOptions$Builder {
 	public fun <init> ()V
 	public final fun build ()Lorg/jellyfin/sdk/JellyfinOptions;
-	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/util/ApiClientFactory;
+	public final fun getApiClientFactory ()Lorg/jellyfin/sdk/api/client/ApiClientFactory;
 	public final fun getClientInfo ()Lorg/jellyfin/sdk/model/ClientInfo;
 	public final fun getDeviceInfo ()Lorg/jellyfin/sdk/model/DeviceInfo;
 	public final fun getMinimumServerVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public final fun getSocketConnectionFactory ()Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;
-	public final fun setApiClientFactory (Lorg/jellyfin/sdk/util/ApiClientFactory;)V
+	public final fun setApiClientFactory (Lorg/jellyfin/sdk/api/client/ApiClientFactory;)V
 	public final fun setClientInfo (Lorg/jellyfin/sdk/model/ClientInfo;)V
 	public final fun setDeviceInfo (Lorg/jellyfin/sdk/model/DeviceInfo;)V
 	public final fun setMinimumServerVersion (Lorg/jellyfin/sdk/model/ServerVersion;)V
@@ -221,9 +221,5 @@ public final class org/jellyfin/sdk/discovery/RecommendedServerIssue$Unsupported
 	public final fun getVersion ()Lorg/jellyfin/sdk/model/ServerVersion;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class org/jellyfin/sdk/util/ApiClientFactory {
-	public abstract fun create (Ljava/lang/String;Ljava/lang/String;Lorg/jellyfin/sdk/model/ClientInfo;Lorg/jellyfin/sdk/model/DeviceInfo;Lorg/jellyfin/sdk/api/client/HttpClientOptions;Lorg/jellyfin/sdk/api/sockets/SocketConnectionFactory;)Lorg/jellyfin/sdk/api/client/ApiClient;
 }
 

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
 		val commonMain by getting {
 			dependencies {
 				api(projects.jellyfinApi)
-				api(projects.jellyfinApiKtor)
+				api(projects.jellyfinApiOkhttp)
 				api(projects.jellyfinModel)
 
 				implementation(libs.kotlinx.coroutines)

--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -2,7 +2,7 @@ package org.jellyfin.sdk
 
 import android.content.Context
 import org.jellyfin.sdk.android.androidDevice
-import org.jellyfin.sdk.api.ktor.KtorClient
+import org.jellyfin.sdk.api.okhttp.OkHttpClient
 import org.jellyfin.sdk.api.sockets.OkHttpSocketConnection
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
@@ -22,7 +22,7 @@ public actual data class JellyfinOptions(
 		public var context: Context? = null
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
-		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
+		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::OkHttpClient)
 		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpSocketConnection)
 		public var minimumServerVersion: ServerVersion = Jellyfin.minimumVersion
 

--- a/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/androidMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -2,13 +2,12 @@ package org.jellyfin.sdk
 
 import android.content.Context
 import org.jellyfin.sdk.android.androidDevice
-import org.jellyfin.sdk.api.okhttp.OkHttpClient
-import org.jellyfin.sdk.api.sockets.OkHttpSocketConnection
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.ServerVersion
-import org.jellyfin.sdk.util.ApiClientFactory
+import org.jellyfin.sdk.api.client.ApiClientFactory
+import org.jellyfin.sdk.api.okhttp.OkHttpFactory
 
 public actual data class JellyfinOptions(
 	public val context: Context,
@@ -22,9 +21,11 @@ public actual data class JellyfinOptions(
 		public var context: Context? = null
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
-		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::OkHttpClient)
-		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpSocketConnection)
+		public var apiClientFactory: ApiClientFactory? = null
+		public var socketConnectionFactory: SocketConnectionFactory? = null
 		public var minimumServerVersion: ServerVersion = Jellyfin.minimumVersion
+
+		private val defaultClientFactory by lazy { OkHttpFactory() }
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
 			context = requireNotNull(context) {
@@ -32,8 +33,8 @@ public actual data class JellyfinOptions(
 			},
 			clientInfo = clientInfo,
 			deviceInfo = deviceInfo ?: androidDevice(context!!),
-			apiClientFactory = apiClientFactory,
-			socketConnectionFactory = socketConnectionFactory,
+			apiClientFactory = apiClientFactory ?: defaultClientFactory,
+			socketConnectionFactory = socketConnectionFactory ?: defaultClientFactory,
 			minimumServerVersion = minimumServerVersion,
 		)
 	}

--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -1,10 +1,10 @@
 package org.jellyfin.sdk
 
+import org.jellyfin.sdk.api.client.ApiClientFactory
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.ServerVersion
-import org.jellyfin.sdk.util.ApiClientFactory
 
 public expect class JellyfinOptions {
 	public val clientInfo: ClientInfo?

--- a/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -1,6 +1,6 @@
 package org.jellyfin.sdk
 
-import org.jellyfin.sdk.api.ktor.KtorClient
+import org.jellyfin.sdk.api.okhttp.OkHttpClient
 import org.jellyfin.sdk.api.sockets.OkHttpSocketConnection
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
@@ -18,7 +18,7 @@ public actual data class JellyfinOptions(
 	public actual class Builder {
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
-		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::KtorClient)
+		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::OkHttpClient)
 		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpSocketConnection)
 		public var minimumServerVersion: ServerVersion = Jellyfin.minimumVersion
 

--- a/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
+++ b/jellyfin-core/src/jvmMain/kotlin/org/jellyfin/sdk/JellyfinOptions.kt
@@ -1,12 +1,11 @@
 package org.jellyfin.sdk
 
-import org.jellyfin.sdk.api.okhttp.OkHttpClient
-import org.jellyfin.sdk.api.sockets.OkHttpSocketConnection
+import org.jellyfin.sdk.api.client.ApiClientFactory
+import org.jellyfin.sdk.api.okhttp.OkHttpFactory
 import org.jellyfin.sdk.api.sockets.SocketConnectionFactory
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.ServerVersion
-import org.jellyfin.sdk.util.ApiClientFactory
 
 public actual data class JellyfinOptions(
 	public actual val clientInfo: ClientInfo?,
@@ -18,15 +17,17 @@ public actual data class JellyfinOptions(
 	public actual class Builder {
 		public var clientInfo: ClientInfo? = null
 		public var deviceInfo: DeviceInfo? = null
-		public var apiClientFactory: ApiClientFactory = ApiClientFactory(::OkHttpClient)
-		public var socketConnectionFactory: SocketConnectionFactory = SocketConnectionFactory(::OkHttpSocketConnection)
+		public var apiClientFactory: ApiClientFactory? = null
+		public var socketConnectionFactory: SocketConnectionFactory? = null
 		public var minimumServerVersion: ServerVersion = Jellyfin.minimumVersion
+
+		private val defaultClientFactory by lazy { OkHttpFactory() }
 
 		public actual fun build(): JellyfinOptions = JellyfinOptions(
 			clientInfo = clientInfo,
 			deviceInfo = deviceInfo,
-			apiClientFactory = apiClientFactory,
-			socketConnectionFactory = socketConnectionFactory,
+			apiClientFactory = apiClientFactory ?: defaultClientFactory,
+			socketConnectionFactory = socketConnectionFactory ?: defaultClientFactory,
 			minimumServerVersion = minimumServerVersion,
 		)
 	}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ include(":jellyfin-core")
 include(":jellyfin-model")
 include(":jellyfin-api")
 include(":jellyfin-api-ktor")
+include(":jellyfin-api-okhttp")
 
 // Code generation
 include(":openapi-generator")


### PR DESCRIPTION
When the initial code for our Kotlin SDK was made I opted to use Ktor as this made it easy to get started. From the start we've used the OkHttp implementation and barely used Ktor functionality. Our WebSocket implementation already uses OkHttp and recent pull requests changed our URL building code to also use OkHttp.

With this change our default HTTP API networking implementation will also be OkHttp, Ktor will no longer be shipped by default. The Ktor module will be removed in a future release.

The implementation uses a single OkHttpFactory by default. This makes sure that all instances created share a connection pool and dispatcher, which is a best practice for performance according to OkHttp developers.

**Changes**

- Add new jellyfin-api-okhttp module
- Add OkHttpClient implementation of ApiClient
- Add OkHttpFactory to create OkHttpClient and OkHttpSocketConnection instances with a shared connection pool
- Move OkHttpSocketConnection from jellyfin-api to jellyfin-api-okhttp
- Use OkHttp by default in jellyfin-core
- Move ApiClientFactory from jellyfin-core to jellyfin-api. This is also where the SocketConnectionFactory currently lives

**Known behavior changes**

- The OkHttp implementation will not switch coroutine contexts by itself. In our Android TV app this brought up some "networking on main thread" issues.