### PR TITLE
Update JVM toolchain to 21

### DIFF
--- a/.github/workflows/sdk-docs.yaml
+++ b/.github/workflows/sdk-docs.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run dokkaHtmlMultiModule task

--- a/.github/workflows/sdk-docs.yaml
+++ b/.github/workflows/sdk-docs.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 23
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run dokkaHtmlMultiModule task

--- a/.github/workflows/sdk-lint.yaml
+++ b/.github/workflows/sdk-lint.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run detekt and lint tasks

--- a/.github/workflows/sdk-lint.yaml
+++ b/.github/workflows/sdk-lint.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 23
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run detekt and lint tasks

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 23
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Set JELLYFIN_VERSION

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Set JELLYFIN_VERSION

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 23]
+        java: [17, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run apiCheck task
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run verifySources task

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21]
+        java: [17, 23]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 23
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run apiCheck task
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 23
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run verifySources task

--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run updateApiSpecUnstable task

--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 23
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Run updateApiSpecUnstable task

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 23
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Set STABLE_API_VERSION

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       - name: Set STABLE_API_VERSION

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(23)
+	jvmToolchain(21)
 
 	sourceSets {
 		all {

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(8)
+	jvmToolchain(23)
 
 	sourceSets {
 		all {

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.dokka)
@@ -6,6 +8,11 @@ plugins {
 kotlin {
 	explicitApi()
 
+	jvm{
+		compilerOptions{
+			jvmTarget = JvmTarget.JVM_1_8
+		}
+	}
 	jvm()
 
 	jvmToolchain(21)

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 	explicitApi()
 
 	jvm {
-		compilerOptions{
+		compilerOptions {
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -8,12 +8,11 @@ plugins {
 kotlin {
 	explicitApi()
 
-	jvm{
+	jvm {
 		compilerOptions{
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}
-	jvm()
 
 	jvmToolchain(21)
 

--- a/jellyfin-api-okhttp/build.gradle.kts
+++ b/jellyfin-api-okhttp/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(23)
+	jvmToolchain(21)
 
 	sourceSets {
 		all {

--- a/jellyfin-api-okhttp/build.gradle.kts
+++ b/jellyfin-api-okhttp/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(8)
+	jvmToolchain(23)
 
 	sourceSets {
 		all {

--- a/jellyfin-api-okhttp/build.gradle.kts
+++ b/jellyfin-api-okhttp/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.dokka)
@@ -6,6 +8,11 @@ plugins {
 kotlin {
 	explicitApi()
 
+	jvm{
+		compilerOptions{
+			jvmTarget = JvmTarget.JVM_1_8
+		}
+	}
 	jvm()
 
 	jvmToolchain(21)

--- a/jellyfin-api-okhttp/build.gradle.kts
+++ b/jellyfin-api-okhttp/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 	explicitApi()
 
 	jvm {
-		compilerOptions{
+		compilerOptions {
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}

--- a/jellyfin-api-okhttp/build.gradle.kts
+++ b/jellyfin-api-okhttp/build.gradle.kts
@@ -8,12 +8,11 @@ plugins {
 kotlin {
 	explicitApi()
 
-	jvm{
+	jvm {
 		compilerOptions{
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}
-	jvm()
 
 	jvmToolchain(21)
 

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(23)
+	jvmToolchain(21)
 
 	sourceSets {
 		all {

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(8)
+	jvmToolchain(23)
 
 	sourceSets {
 		all {

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.dokka)
@@ -5,7 +7,11 @@ plugins {
 
 kotlin {
 	explicitApi()
-
+	jvm{
+		compilerOptions{
+			jvmTarget = JvmTarget.JVM_1_8
+		}
+	}
 	jvm()
 
 	jvmToolchain(21)

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -7,12 +7,11 @@ plugins {
 
 kotlin {
 	explicitApi()
-	jvm{
+	jvm {
 		compilerOptions{
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}
-	jvm()
 
 	jvmToolchain(21)
 

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 kotlin {
 	explicitApi()
 	jvm {
-		compilerOptions{
+		compilerOptions {
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -9,12 +9,11 @@ plugins {
 kotlin {
 	explicitApi()
 
-	jvm{
+	jvm {
 		compilerOptions{
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}
-	jvm()
 	androidTarget {
 		publishAllLibraryVariants()
 	}

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 	kotlin("multiplatform")
 	id("com.android.library")
@@ -7,6 +9,11 @@ plugins {
 kotlin {
 	explicitApi()
 
+	jvm{
+		compilerOptions{
+			jvmTarget = JvmTarget.JVM_1_8
+		}
+	}
 	jvm()
 	androidTarget {
 		publishAllLibraryVariants()

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
 		publishAllLibraryVariants()
 	}
 
-	jvmToolchain(23)
+	jvmToolchain(21)
 
 	applyDefaultHierarchyTemplate()
 

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
 		publishAllLibraryVariants()
 	}
 
-	jvmToolchain(8)
+	jvmToolchain(23)
 
 	applyDefaultHierarchyTemplate()
 

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -10,12 +10,15 @@ kotlin {
 	explicitApi()
 
 	jvm {
-		compilerOptions{
+		compilerOptions {
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}
 	androidTarget {
 		publishAllLibraryVariants()
+		compilerOptions {
+			jvmTarget = JvmTarget.JVM_1_8
+		}
 	}
 
 	jvmToolchain(21)

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -9,12 +9,11 @@ plugins {
 kotlin {
 	explicitApi()
 
-	jvm{
+	jvm {
 		compilerOptions{
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}
-	jvm()
 
 	jvmToolchain(21)
 

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(8)
+	jvmToolchain(23)
 
 	sourceSets {
 		all {

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.kotlin.serialization)
@@ -7,6 +9,11 @@ plugins {
 kotlin {
 	explicitApi()
 
+	jvm{
+		compilerOptions{
+			jvmTarget = JvmTarget.JVM_1_8
+		}
+	}
 	jvm()
 
 	jvmToolchain(21)

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
 	explicitApi()
 
 	jvm {
-		compilerOptions{
+		compilerOptions {
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(23)
+	jvmToolchain(21)
 
 	sourceSets {
 		all {

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -7,12 +7,11 @@ plugins {
 kotlin {
 	explicitApi()
 
-	jvm{
+	jvm {
 		compilerOptions{
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}
-	jvm()
 
 	jvmToolchain(21)
 

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 	kotlin("multiplatform")
 }
@@ -5,6 +7,11 @@ plugins {
 kotlin {
 	explicitApi()
 
+	jvm{
+		compilerOptions{
+			jvmTarget = JvmTarget.JVM_1_8
+		}
+	}
 	jvm()
 
 	jvmToolchain(21)

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(23)
+	jvmToolchain(21)
 
 	sourceSets {
 		all {

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
 
 	jvm()
 
-	jvmToolchain(8)
+	jvmToolchain(23)
 
 	sourceSets {
 		all {

--- a/testutils/build.gradle.kts
+++ b/testutils/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 	explicitApi()
 
 	jvm {
-		compilerOptions{
+		compilerOptions {
 			jvmTarget = JvmTarget.JVM_1_8
 		}
 	}


### PR DESCRIPTION
At the moment the build chain uses an ancient version of the JVM Toolchain.
That causes issues for people with JDK versions any higher then 8.

This likely will cause issues with the automated build process on github.

@nielsvanvelzen 🫶 🗿 