### PR TITLE
Remove old gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,1 @@
-android.useAndroidX=true
-kotlin.mpp.androidSourceSetLayoutVersion=2
-kotlin.incremental=true
-kotlin.mpp.stability.nowarn=true
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
- useAndroidX: default since AGP7
- kmpp android sourceset layout: defaults to 2 since Kotlin 1.9
- kotlin incremental: default since (idk)
- kotlin mpp warning: gone since (idk)