### PR TITLE
Set User-Agent for HTTP requests

### DIFF
--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -123,6 +123,11 @@ public class KtorClient(
 					)
 				)
 
+				header(
+					key = HttpHeaders.UserAgent,
+					value = "${clientInfo.name}/${clientInfo.version} via jellyfin-sdk-kotlin (Ktor)"
+				)
+
 				when (requestBody) {
 					// String content
 					is String -> setBody(TextContent(requestBody, ContentType.Text.Plain))

--- a/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
+++ b/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
@@ -22,7 +22,7 @@ public final class org/jellyfin/sdk/api/okhttp/OkHttpFactory : org/jellyfin/sdk/
 
 public final class org/jellyfin/sdk/api/okhttp/OkHttpSocketConnection : org/jellyfin/sdk/api/sockets/SocketConnection {
 	public fun <init> (Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;)V
-	public fun connect (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
@@ -6,6 +6,7 @@ import mu.KotlinLogging
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttp
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -116,6 +117,7 @@ public class OkHttpClient(
 				accessToken = accessToken
 			)
 			header("Authorization", authorization)
+			header("User-Agent", "${clientInfo.name}/${clientInfo.version} via jellyfin-sdk-kotlin (OkHttp/${OkHttp.VERSION})")
 		}.build()
 
 		try {

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1317,7 +1317,7 @@ public final class org/jellyfin/sdk/api/sockets/SocketApiState$Disconnected : or
 }
 
 public abstract interface class org/jellyfin/sdk/api/sockets/SocketConnection {
-	public abstract fun connect (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
@@ -275,7 +275,14 @@ public class DefaultSocketApi(
 			keepAliveTicker?.cancel()
 		} else {
 			// Attempt connection
-			val connected = socketConnection.connect(newCredentials.url, newCredentials.authorizationHeader)
+			val connected = socketConnection.connect(
+				url = newCredentials.url,
+				clientName = newCredentials.clientName,
+				clientVersion = newCredentials.clientVersion,
+				deviceId = newCredentials.deviceId,
+				deviceName = newCredentials.deviceName,
+				accessToken = newCredentials.accessToken,
+			)
 
 			if (connected) {
 				socketReconnectPolicy.notifyConnected()

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketConnection.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketConnection.kt
@@ -20,7 +20,14 @@ public interface SocketConnection {
 	 *
 	 * @see disconnect
 	 */
-	public suspend fun connect(url: String, authorization: String): Boolean
+	public suspend fun connect(
+		url: String,
+		clientName: String,
+		clientVersion: String,
+		deviceId: String,
+		deviceName: String,
+		accessToken: String,
+	): Boolean
 
 	/**
 	 * Send a message to this connection. Messages may be added to an internal queue and be slightly delayed.


### PR DESCRIPTION
This change was requested a few times in various places and will make it easier to debug requests from a specific (Kotlin SDK based) client in reverse proxy logs.

Looks like this:

```
User-Agent: Jellyfin Android TV/0.0.0-dev.1 via jellyfin-sdk-kotlin (OkHttp/4.12.0)
```