### PR TITLE
Publish to Maven Central via Sonatype Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,8 @@ buildscript {
 
 // Add Sonatype publishing repository
 nexusPublishing.repositories.sonatype {
-	nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-	snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+	nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+	snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
 
 	username.set(getProperty("ossrh.username"))
 	password.set(getProperty("ossrh.password"))


### PR DESCRIPTION
The Sonatype repositories have been deprecated for a while which I was not aware of, then suddenly our snapshot publishing started failing and I found this page: https://central.sonatype.org/news/20250326_ossrh_sunset/.

This PR updates the publishing URLs. Credentials have already been updated in the repository settings.