### PR TITLE
Filter out null query parameters

### DIFF
--- a/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
+++ b/jellyfin-api-ktor/src/jvmMain/kotlin/org/jellyfin/sdk/api/ktor/KtorClient.kt
@@ -59,6 +59,8 @@ public class KtorClient(
 	public override var deviceInfo: DeviceInfo = initialDeviceInfo
 		private set
 
+	private val logger = KotlinLogging.logger {}
+
 	private val client: HttpClient = HttpClient {
 		followRedirects = httpClientOptions.followRedirects
 		expectSuccess = false
@@ -73,6 +75,8 @@ public class KtorClient(
 	private val _webSocket = lazy {
 		DefaultSocketApi(this, httpClientOptions.socketReconnectPolicy, socketConnectionFactory)
 	}
+
+	override val webSocket: SocketApi by _webSocket
 
 	override fun update(baseUrl: String?, accessToken: String?, clientInfo: ClientInfo, deviceInfo: DeviceInfo) {
 		this.baseUrl = baseUrl
@@ -97,7 +101,6 @@ public class KtorClient(
 		val url = createUrl(pathTemplate, pathParameters, queryParameters)
 
 		// Log HTTP call with access token removed
-		val logger = KotlinLogging.logger {}
 		logger.info {
 			val safeUrl = accessToken?.let { url.replace(it, "******") } ?: url
 			"$method $safeUrl"
@@ -180,8 +183,6 @@ public class KtorClient(
 			throw ApiClientException("Unknown IO error occurred!", err)
 		}
 	}
-
-	override val webSocket: SocketApi by _webSocket
 
 	private fun HttpMethod.asKtorHttpMethod(): KtorHttpMethod = when (this) {
 		HttpMethod.GET -> KtorHttpMethod.Get

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
@@ -53,6 +53,8 @@ public class OkHttpClient(
 	public override var deviceInfo: DeviceInfo = initialDeviceInfo
 		private set
 
+	private val logger = KotlinLogging.logger {}
+
 	private val _webSocket = lazy {
 		DefaultSocketApi(this, httpClientOptions.socketReconnectPolicy, socketConnectionFactory)
 	}
@@ -82,7 +84,6 @@ public class OkHttpClient(
 		val url = createUrl(pathTemplate, pathParameters, queryParameters)
 
 		// Log HTTP call with access token removed
-		val logger = KotlinLogging.logger {}
 		logger.info {
 			val safeUrl = accessToken?.let { url.replace(it, "******") } ?: url
 			"$method $safeUrl"
@@ -117,7 +118,10 @@ public class OkHttpClient(
 				accessToken = accessToken
 			)
 			header("Authorization", authorization)
-			header("User-Agent", "${clientInfo.name}/${clientInfo.version} via jellyfin-sdk-kotlin (OkHttp/${OkHttp.VERSION})")
+			header(
+				"User-Agent",
+				"${clientInfo.name}/${clientInfo.version} via jellyfin-sdk-kotlin (OkHttp/${OkHttp.VERSION})"
+			)
 		}.build()
 
 		try {

--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilderTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/client/util/UrlBuilderTests.kt
@@ -18,6 +18,17 @@ class UrlBuilderTests : FunSpec({
 		UrlBuilder.buildPath(path, parameters) shouldBe "test/1/2/three"
 	}
 
+	test("buildPath ignores path parameters") {
+		val path = "/test/{one}/{two}/three"
+		val parameters = mapOf(
+			"one" to "1",
+			"two" to "2",
+			"three" to "3"
+		)
+
+		UrlBuilder.buildPath(path, parameters, true) shouldBe "test/{one}/{two}/three"
+	}
+
 	test("buildPath replaces values not separated by a slash") {
 		val path = "/test/{twe}{lve}/three"
 		val parameters = mapOf(
@@ -87,6 +98,16 @@ class UrlBuilderTests : FunSpec({
 		)
 
 		path.buildPath(parameters) shouldBe "test/foo/baz"
+	}
+
+	test("buildUrl with empty path template uses baseUrl") {
+		val baseUrl = "https://demo.jellyfin.org/stable/"
+		UrlBuilder.buildUrl(baseUrl = baseUrl, pathTemplate = "") shouldBe baseUrl
+	}
+
+	test("buildUrl with slash only path template uses baseUrl") {
+		val baseUrl = "https://demo.jellyfin.org/stable"
+		UrlBuilder.buildUrl(baseUrl = baseUrl, pathTemplate = "/") shouldBe "$baseUrl/"
 	}
 
 	test("buildUrl appends query parameters") {
@@ -218,6 +239,17 @@ class UrlBuilderTests : FunSpec({
 		UrlBuilder.buildUrl(
 			baseUrl = baseUrl,
 			pathTemplate = "{foo}/{foo/{bar",
+			ignorePathParameters = true,
+		) shouldBe "${baseUrl}%7Bfoo%7D/%7Bfoo/%7Bbar"
+	}
+
+	test("buildUrl ignores path parameters when ignorePathParameters is set but has parameters") {
+		val baseUrl = "https://demo.jellyfin.org/stable/"
+
+		UrlBuilder.buildUrl(
+			baseUrl = baseUrl,
+			pathTemplate = "/{foo}/{foo/{bar",
+			pathParameters = mapOf("foo" to "test", "bar" to "test2"),
 			ignorePathParameters = true,
 		) shouldBe "${baseUrl}%7Bfoo%7D/%7Bfoo/%7Bbar"
 	}

--- a/openapi-generator/README.md
+++ b/openapi-generator/README.md
@@ -39,7 +39,7 @@ git push
 ## Hooks
 
 Hooks are classes that will modify the output of the generator. They should be registered in the
-`HookModule.kt` file. The following hooks are available:
+`HooksModule.kt` file. The following hooks are available:
 
   - **TypeBuilderHook**  
     A hook that can intercept the TypeBuilder which converts OpenAPI schemas to Kotlin types. It

--- a/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
+++ b/openapi-generator/src/main/kotlin/org/jellyfin/openapi/builder/api/OperationBuilder.kt
@@ -111,7 +111,13 @@ open class OperationBuilder(
 			val buildMapType = MemberName("kotlin.collections", "buildMap")
 			beginControlFlow("val %N = %M<%T, %T?>(%L)", name, buildMapType, Types.STRING, Types.ANY, parameters.size)
 			parameters.forEach { parameter ->
-				addStatement("put(%S, %N)", parameter.originalName, parameter.name)
+				if (parameter.type.isNullable) {
+					beginControlFlow("if (%N != null)", parameter.name)
+					addStatement("put(%S, %N)", parameter.originalName, parameter.name)
+					endControlFlow()
+				} else {
+					addStatement("put(%S, %N)", parameter.originalName, parameter.name)
+				}
 			}
 			endControlFlow()
 		}.let(::addCode)


### PR DESCRIPTION
Ensure that null query parameters are not included when building the query parameter map in generated API clients.
Null query parameters were being generated, but then filtered out in buildUrl.  This ensures that the query parameters will be non-null, however buildUrl signature has not changed as it is public and there my be usage outside the sdk.

New generated code will look like this when parameters are nullable:
```
		val queryParameters = buildMap<String, Any?>(1) {
			if (imageIndex != null) {
				put("imageIndex", imageIndex)
			}
		}
```
Excluding null query parameters like this matches the behaviour of the default openapi-generator kotlin output.

Instantiate KotlinLogging logger once per Client class

Added tests to cover scenarios where path parameters should be ignored or are empty.

Fixed `HooksModule.kt` typo in the `README.md`