### PR TITLE
Mark kotlinx.serialization.json as implementation

### DIFF
--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
 			kotlin.srcDir("src/commonMain/kotlin-generated")
 
 			dependencies {
-				compileOnly(libs.kotlinx.serialization.json)
+				implementation(libs.kotlinx.serialization.json)
 			}
 		}
 


### PR DESCRIPTION
This fixes jellyfin/jellyfin-androidtv#4827