### PR TITLE
Revert removal of android.useAndroidX=true Gradle property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx2048m
+android.useAndroidX=true


### PR DESCRIPTION
Removed this earlier in the 1.7.0 development but it looks like this one is still needed for #1097, which reintroduces androidx libraries in the dependency chain.