### PR TITLE
Compile with Android SDK 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-gradle = "8.13.0"
-android-sdk = "33"
+android-sdk = "36"
 binarycompatibilityvalidator = "0.18.1"
 clikt = "5.0.3"
 detekt = "1.23.8"


### PR DESCRIPTION
Renovate doesn't bump this one for us so it's easy to get outdated 🙃. This one is needed for #1097.