### PR TITLE
Check API compatibility using Animal Sniffer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+	alias(libs.plugins.animalsniffer)
 	alias(libs.plugins.binarycompatibilityvalidator)
 	alias(libs.plugins.detekt)
 	alias(libs.plugins.dokka)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,13 @@
 [versions]
 android-gradle = "8.13.0"
 android-sdk = "36"
+animalsniffer = "2.0.1"
 binarycompatibilityvalidator = "0.18.1"
 clikt = "5.0.3"
 detekt = "1.23.8"
 dokka = "2.0.0"
 download = "5.6.0"
+gummybears = "0.12.0"
 kasechange = "1.4.1"
 koin = "4.1.1"
 kotest = "5.9.1"
@@ -21,6 +23,7 @@ slf4j = "2.0.17"
 swagger-parser = "2.1.34"
 
 [plugins]
+animalsniffer = { id = "ru.vyarus.animalsniffer", version.ref = "animalsniffer" }
 binarycompatibilityvalidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binarycompatibilityvalidator" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
@@ -32,6 +35,7 @@ nexuspublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "ne
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
+gummybears-api19 = { module = "com.toasttab.android:gummy-bears-api-19", version.ref = "gummybears" }
 kasechange = { module = "net.pearx.kasechange:kasechange", version.ref = "kasechange" }
 koin = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/jellyfin-api-ktor/build.gradle.kts
+++ b/jellyfin-api-ktor/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.dokka)
+	alias(libs.plugins.animalsniffer)
 }
 
 kotlin {
@@ -70,3 +71,11 @@ enablePublishing {
 		artifact(javadocJar)
 	}
 }
+
+dependencies.signature(libs.gummybears.api19) {
+	artifact {
+		classifier = "coreLib2"
+		type = "signature"
+	}
+}
+

--- a/jellyfin-api-okhttp/build.gradle.kts
+++ b/jellyfin-api-okhttp/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.dokka)
+	alias(libs.plugins.animalsniffer)
 }
 
 kotlin {
@@ -65,3 +66,11 @@ enablePublishing {
 		artifact(javadocJar)
 	}
 }
+
+dependencies.signature(libs.gummybears.api19) {
+	artifact {
+		classifier = "coreLib2"
+		type = "signature"
+	}
+}
+

--- a/jellyfin-api/build.gradle.kts
+++ b/jellyfin-api/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.dokka)
+	alias(libs.plugins.animalsniffer)
 }
 
 kotlin {
@@ -70,3 +71,11 @@ enablePublishing {
 		artifact(javadocJar)
 	}
 }
+
+dependencies.signature(libs.gummybears.api19) {
+	artifact {
+		classifier = "coreLib2"
+		type = "signature"
+	}
+}
+

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("multiplatform")
 	id("com.android.library")
 	alias(libs.plugins.dokka)
+	alias(libs.plugins.animalsniffer)
 }
 
 kotlin {
@@ -126,5 +127,12 @@ enablePublishing {
 
 	publications.withType<MavenPublication> {
 		artifact(javadocJar)
+	}
+}
+
+dependencies.signature(libs.gummybears.api19) {
+	artifact {
+		classifier = "coreLib2"
+		type = "signature"
 	}
 }

--- a/jellyfin-model/build.gradle.kts
+++ b/jellyfin-model/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("multiplatform")
 	alias(libs.plugins.kotlin.serialization)
 	alias(libs.plugins.dokka)
+	alias(libs.plugins.animalsniffer)
 }
 
 kotlin {
@@ -62,3 +63,11 @@ enablePublishing {
 		artifact(javadocJar)
 	}
 }
+
+dependencies.signature(libs.gummybears.api19) {
+	artifact {
+		classifier = "coreLib2"
+		type = "signature"
+	}
+}
+


### PR DESCRIPTION
Use the [Gradle plugin](https://github.com/xvik/gradle-animalsniffer-plugin) for [Animal Sniffer](https://github.com/mojohaus/animal-sniffer) with [Gummy Bears](https://github.com/open-toast/gummy-bears) to verify the SDK is compatible with Android apps using library desugaring and use API level 19 or newer.