### PR TITLE
Avoid using String.codePoints in encodeURLParts

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/url.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/client/util/url.kt
@@ -1,8 +1,7 @@
 package org.jellyfin.sdk.api.client.util
 
 internal fun String.encodeURLPart(): String = buildString {
-	this@encodeURLPart.codePoints().forEach { codePoint ->
-		val char = codePoint.toChar()
+	this@encodeURLPart.forEach { char ->
 		when {
 			char.isUnreserved() -> append(char)
 			char == ' ' -> append('+')


### PR DESCRIPTION
The hunt is over - I fixed Android 6 support again 🙃 

Fixes jellyfin/jellyfin-androidtv#4951