### PR TITLE
Fix AddressCandidateHelper returning invalid candidates when input protocol is not lowercase

### DIFF
--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -43,7 +43,7 @@ public actual class AddressCandidateHelper actual constructor(
 
 			// Add the input as initial candidate
 			if (input.isNotBlank()) {
-				if (input.startsWith(PROTOCOL_HTTP) || input.startsWith(PROTOCOL_HTTPS)) {
+				if (input.startsWith(PROTOCOL_HTTP, ignoreCase = true) || input.startsWith(PROTOCOL_HTTPS, ignoreCase = true)) {
 					candidates.add(input.toHttpUrl())
 				} else {
 					candidates.add((PROTOCOL_HTTP + input).toHttpUrl())

--- a/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
+++ b/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
@@ -65,4 +65,17 @@ class DiscoveryServiceTests : FunSpec({
 		instance.getAddressCandidates("localhost:65536").shouldBeEmpty()
 		instance.getAddressCandidates("localhost:999999").shouldBeEmpty()
 	}
+
+	test("getAddressCandidates is case insensitive for protocol") {
+		val instance = getInstance()
+
+		// Lowercase
+		instance.getAddressCandidates("https://localhost") shouldContain "https://localhost"
+
+		// Uppercase
+		instance.getAddressCandidates("HTTPS://localhost") shouldContain "https://localhost"
+
+		// Mixed
+		instance.getAddressCandidates("Https://localhost") shouldContain "https://localhost"
+	}
 })


### PR DESCRIPTION


Fixes https://forum.jellyfin.org/t-andoind-clients-fail-to-connect-when-the-uri-scheme-is-not-lowercase