### PR TITLE
Remove zoneId parameter from DateTimeSerializer

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -19450,8 +19450,6 @@ public final class org/jellyfin/sdk/model/extensions/TicksExtensionsKt {
 
 public final class org/jellyfin/sdk/model/serializer/DateTimeSerializer : kotlinx/serialization/KSerializer {
 	public fun <init> ()V
-	public fun <init> (Ljava/time/ZoneId;)V
-	public synthetic fun <init> (Ljava/time/ZoneId;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/time/LocalDateTime;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;

--- a/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializer.kt
+++ b/jellyfin-model/src/jvmMain/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializer.kt
@@ -12,19 +12,22 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
-public actual class DateTimeSerializer(
-	private val zoneId: ZoneId = ZoneId.systemDefault(),
-) : KSerializer<DateTime> {
-	actual override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("org.jellyfin.LocalDateTime", PrimitiveKind.STRING)
+public actual class DateTimeSerializer : KSerializer<DateTime> {
+	actual override val descriptor: SerialDescriptor =
+		PrimitiveSerialDescriptor("org.jellyfin.LocalDateTime", PrimitiveKind.STRING)
 
-	actual override fun deserialize(decoder: Decoder): DateTime = try {
-		ZonedDateTime.parse(decoder.decodeString()).withZoneSameInstant(zoneId).toLocalDateTime()
+	actual override fun deserialize(
+		decoder: Decoder
+	): DateTime = try {
+		ZonedDateTime.parse(decoder.decodeString()).withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime()
 	} catch (err: DateTimeParseException) {
 		// Server will sometimes return 0001-01-01T00:00:00
 		// but java.time can't parse that
 		DateTime.MIN
 	}
 
-	actual override fun serialize(encoder: Encoder, value: DateTime): Unit =
-		encoder.encodeString(value.atZone(zoneId).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+	actual override fun serialize(
+		encoder: Encoder,
+		value: DateTime
+	): Unit = encoder.encodeString(value.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
 }

--- a/jellyfin-model/src/jvmTest/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializerTests.kt
+++ b/jellyfin-model/src/jvmTest/kotlin/org/jellyfin/sdk/model/serializer/DateTimeSerializerTests.kt
@@ -5,10 +5,12 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.TimeZone
 
 class DateTimeSerializerTests : FunSpec({
 	test("Encodes dates and times (UTC)") {
-		val instance = DateTimeSerializer(ZoneId.of("UTC"))
+		TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("UTC")))
+		val instance = DateTimeSerializer()
 
 		Json.encodeToString(
 			instance,
@@ -17,7 +19,8 @@ class DateTimeSerializerTests : FunSpec({
 	}
 
 	test("Encodes dates and times (Offset)") {
-		val instance = DateTimeSerializer(ZoneId.of("UTC+01:00"))
+		TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("UTC+01:00")))
+		val instance = DateTimeSerializer()
 
 		Json.encodeToString(
 			instance,
@@ -26,13 +29,15 @@ class DateTimeSerializerTests : FunSpec({
 	}
 
 	test("Parses minimum value") {
-		val instance = DateTimeSerializer(ZoneId.of("UTC"))
+		TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("UTC")))
+		val instance = DateTimeSerializer()
 
 		Json.decodeFromString(instance, """"0001-01-01T00:00:00"""") shouldBe LocalDateTime.MIN
 	}
 
 	test("Parses dates and times (UTC)") {
-		val instance = DateTimeSerializer(ZoneId.of("UTC"))
+		TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("UTC")))
+		val instance = DateTimeSerializer()
 
 		Json.decodeFromString(
 			instance,
@@ -46,7 +51,8 @@ class DateTimeSerializerTests : FunSpec({
 	}
 
 	test("Parses dates and times (Offset)") {
-		val instance = DateTimeSerializer(ZoneId.of("UTC+01:00"))
+		TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("UTC+01:00")))
+		val instance = DateTimeSerializer()
 
 		Json.decodeFromString(
 			instance,


### PR DESCRIPTION
This change is needed to unblock Kotlin updates. Parameters are **not** supported on KSerializer implementations and this behavior just happened to work for many releases.
We only really use it for our unit tests so I changes those to use a different method of setting the timezone.