### PR TITLE
Populate endpointAddress from UDP packet source in LocalServerDiscovery

### DIFF
--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
@@ -71,7 +71,12 @@ public actual class LocalServerDiscovery actual constructor(jellyfinOptions: Jel
 			// Read as JSON
 			val info = json.decodeFromString(ServerDiscoveryInfo.serializer(), message)
 
-			info
+			// Populate endpointAddress with the actual source IP of the UDP packet.
+			// The server does not set this field; clients are expected to fill it
+			// from the packet origin so consumers can reach the server by its real
+			// network address instead of whatever the server reports in Address
+			// (which is often localhost or 127.0.0.1).
+			info.copy(endpointAddress = packet.address.hostAddress)
 		} catch (err: SocketTimeoutException) {
 			// Unable to receive due too timeout, which is common for non-Jellyfin devices
 			// Just ignore

--- a/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscoveryTests.kt
+++ b/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscoveryTests.kt
@@ -1,0 +1,65 @@
+package org.jellyfin.sdk.discovery
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import org.jellyfin.sdk.createJellyfin
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import kotlin.concurrent.thread
+
+class LocalServerDiscoveryTests : FunSpec({
+	test("discover populates endpointAddress from packet source IP") {
+		// Fake Jellyfin server that responds to discovery on loopback
+		val serverSocket = DatagramSocket(0, InetAddress.getLoopbackAddress())
+		val serverPort = serverSocket.localPort
+
+		thread(isDaemon = true) {
+			val buf = ByteArray(1024)
+			val request = DatagramPacket(buf, buf.size)
+			serverSocket.receive(request)
+
+			// Server reports localhost in Address (common misconfiguration)
+			val response = """
+				{"Address":"http://localhost:8096","Id":"test-id","Name":"Test Server"}
+			""".trimIndent().toByteArray()
+			val reply = DatagramPacket(response, response.size, request.address, request.port)
+			serverSocket.send(reply)
+			serverSocket.close()
+		}
+
+		// Manually replicate what discover() does: send message, receive, check result
+		val clientSocket = DatagramSocket().apply { soTimeout = 2000 }
+		val message = LocalServerDiscovery.DISCOVERY_MESSAGE.toByteArray()
+		clientSocket.send(
+			DatagramPacket(message, message.size, InetAddress.getLoopbackAddress(), serverPort),
+		)
+
+		val recvBuf = ByteArray(1024)
+		val recvPacket = DatagramPacket(recvBuf, recvBuf.size)
+		clientSocket.receive(recvPacket)
+		clientSocket.close()
+
+		// The raw JSON has no endpointAddress
+		val rawJson = String(recvPacket.data, 0, recvPacket.length)
+		rawJson.contains("EndpointAddress") shouldBe false
+
+		// The packet source IP should be loopback
+		val sourceHost = recvPacket.address.hostAddress
+		sourceHost.shouldNotBeNull()
+
+		// Verify that the SDK's receive() logic would set endpointAddress = sourceHost
+		val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+		val info = json.decodeFromString(
+			org.jellyfin.sdk.model.api.ServerDiscoveryInfo.serializer(),
+			rawJson,
+		)
+		val corrected = info.copy(endpointAddress = sourceHost)
+
+		corrected.address shouldBe "http://localhost:8096"
+		corrected.endpointAddress shouldBe sourceHost
+		corrected.name shouldBe "Test Server"
+	}
+})


### PR DESCRIPTION
I was getting localhost from server discovery on my LAN. Turns out the Jellyfin server doesn't populate `EndpointAddress` in its UDP response — it only sends `Address`, `Id`, and `Name`. Other client SDKs (Python, WebOS) fill `endpointAddress` from the UDP packet source IP on the client side, but the Kotlin SDK doesn't.

This is a one-line change: after deserializing the response, set `endpointAddress` to `packet.address.hostAddress`. The `Address` field is left untouched — consumers can check `endpointAddress` when `Address` contains localhost.

I also opened a server-side fix for the root cause: https://github.com/jellyfin/jellyfin/pull/16515

Addresses https://github.com/jellyfin/jellyfin/issues/15898
Addresses https://github.com/jellyfin/jellyfin/issues/11564