### PR TITLE
Support API language via DeviceInfo

### DIFF
--- a/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
+++ b/jellyfin-api-okhttp/api/jellyfin-api-okhttp.api
@@ -22,7 +22,7 @@ public final class org/jellyfin/sdk/api/okhttp/OkHttpFactory : org/jellyfin/sdk/
 
 public final class org/jellyfin/sdk/api/okhttp/OkHttpSocketConnection : org/jellyfin/sdk/api/sockets/SocketConnection {
 	public fun <init> (Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;)V
-	public fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpClient.kt
@@ -1,8 +1,8 @@
 package org.jellyfin.sdk.api.okhttp
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.SerializationException
-import io.github.oshai.kotlinlogging.KotlinLogging
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
@@ -118,6 +118,7 @@ public class OkHttpClient(
 			)
 			header("Authorization", authorization)
 			header("User-Agent", "${clientInfo.name}/${clientInfo.version} via jellyfin-sdk-kotlin (OkHttp/${OkHttp.VERSION})")
+			if (deviceInfo.languages.isNotEmpty()) header("Accept-Language", deviceInfo.languages.joinToString(","))
 		}.build()
 
 		try {

--- a/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpSocketConnection.kt
+++ b/jellyfin-api-okhttp/src/jvmMain/kotlin/org/jellyfin/sdk/api/okhttp/OkHttpSocketConnection.kt
@@ -1,12 +1,12 @@
 package org.jellyfin.sdk.api.okhttp
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import io.github.oshai.kotlinlogging.KotlinLogging
 import okhttp3.OkHttp
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -72,6 +72,7 @@ public class OkHttpSocketConnection(
 		deviceId: String,
 		deviceName: String,
 		accessToken: String,
+		languages: List<String>,
 	): Boolean {
 		if (webSocket != null) disconnect()
 
@@ -86,6 +87,7 @@ public class OkHttpSocketConnection(
 			)
 			header("Authorization", authorization)
 			header("User-Agent", "${clientName}/${clientVersion} via jellyfin-sdk-kotlin (OkHttp/${OkHttp.VERSION})")
+			if (languages.isNotEmpty()) header("Accept-Language", languages.joinToString(","))
 		}.build()
 
 		_state.value = SocketConnectionState.Connecting

--- a/jellyfin-api/api/jellyfin-api.api
+++ b/jellyfin-api/api/jellyfin-api.api
@@ -1313,7 +1313,7 @@ public final class org/jellyfin/sdk/api/sockets/SocketApiState$Disconnected : or
 }
 
 public abstract interface class org/jellyfin/sdk/api/sockets/SocketConnection {
-	public abstract fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
@@ -74,6 +74,7 @@ public class DefaultSocketApi(
 		val clientVersion: String,
 		val deviceId: String,
 		val deviceName: String,
+		val languages: List<String>,
 		val accessToken: String,
 	) {
 		val authorizationHeader = AuthorizationHeaderBuilder.buildHeader(
@@ -261,6 +262,7 @@ public class DefaultSocketApi(
 			clientVersion = api.clientInfo.version,
 			deviceId = api.deviceInfo.id,
 			deviceName = api.deviceInfo.name,
+			languages = api.deviceInfo.languages,
 			accessToken = accessToken,
 		)
 	}
@@ -285,6 +287,7 @@ public class DefaultSocketApi(
 				deviceId = newCredentials.deviceId,
 				deviceName = newCredentials.deviceName,
 				accessToken = newCredentials.accessToken,
+				languages = newCredentials.languages,
 			)
 
 			if (connected) {

--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketConnection.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/SocketConnection.kt
@@ -27,6 +27,7 @@ public interface SocketConnection {
 		deviceId: String,
 		deviceName: String,
 		accessToken: String,
+		languages: List<String>,
 	): Boolean
 
 	/**

--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -12,13 +12,16 @@ public final class org/jellyfin/sdk/model/ClientInfo {
 }
 
 public final class org/jellyfin/sdk/model/DeviceInfo {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jellyfin/sdk/model/DeviceInfo;
-	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/DeviceInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/DeviceInfo;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lorg/jellyfin/sdk/model/DeviceInfo;
+	public static synthetic fun copy$default (Lorg/jellyfin/sdk/model/DeviceInfo;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jellyfin/sdk/model/DeviceInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getId ()Ljava/lang/String;
+	public final fun getLanguages ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/DeviceInfo.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/DeviceInfo.kt
@@ -13,5 +13,11 @@ public data class DeviceInfo(
 	/**
 	 * Name of the device.
 	 */
-	val name: String
+	val name: String,
+
+	/**
+	 * List of BCP-47 formatted languages this device prefers to be used in order of most to least preferred. This is
+	 * used to request the language used in API responses. Use an empty list for server default.
+	 */
+	val languages: List<String> = emptyList(),
 )

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Main.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Main.kt
@@ -8,6 +8,7 @@ import org.jellyfin.sample.cli.command.Libraries
 import org.jellyfin.sample.cli.command.Login
 import org.jellyfin.sample.cli.command.Observe
 import org.jellyfin.sample.cli.command.Ping
+import org.jellyfin.sample.cli.command.Tasks
 import org.jellyfin.sample.cli.command.Users
 import org.jellyfin.sdk.createJellyfin
 import org.jellyfin.sdk.model.ClientInfo
@@ -25,6 +26,7 @@ fun main(args: Array<String>) {
 		subcommands(Login(jellyfin))
 		subcommands(Observe(jellyfin))
 		subcommands(Ping(jellyfin))
+		subcommands(Tasks(jellyfin))
 		subcommands(Users(jellyfin))
 	}
 

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Options.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/Options.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.sample.cli
 
 import com.github.ajalt.clikt.core.ParameterHolder
+import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import kotlinx.coroutines.runBlocking
@@ -34,10 +35,21 @@ fun ParameterHolder.apiInstanceHolder(jellyfin: Jellyfin): Lazy<ApiClient> {
 		help = "Password"
 	).also(::registerOption)
 
+	val languages = option(
+		"--language",
+		help = "Language"
+	).multiple().also(::registerOption)
+
 	return lazy {
 		runBlocking {
 			// Create instance
-			val api = jellyfin.createApi(baseUrl = server.value, accessToken = token.value)
+			val api = jellyfin.createApi(
+				baseUrl = server.value,
+				accessToken = token.value,
+				deviceInfo = requireNotNull(jellyfin.deviceInfo).copy(
+					languages = languages.value,
+				),
+			)
 
 			// Authenticate manually if access token is not provided
 			if (api.accessToken == null && username.value != null) {

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Tasks.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Tasks.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.sample.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import kotlinx.coroutines.runBlocking
+import org.jellyfin.sample.cli.apiInstanceHolder
+import org.jellyfin.sample.cli.logger
+import org.jellyfin.sdk.Jellyfin
+import org.jellyfin.sdk.api.client.extensions.scheduledTasksApi
+
+class Tasks(
+	jellyfin: Jellyfin,
+) : CliktCommand(name = "tasks") {
+	private val logger by logger()
+	private val api by apiInstanceHolder(jellyfin)
+
+	override fun help(context: Context): String = "List scheduled tasks"
+
+	override fun run(): Unit = runBlocking {
+		val tasks by api.scheduledTasksApi.getTasks()
+
+		for (task in tasks) {
+			logger.info("${task.name}: ${task.description}")
+		}
+	}
+}


### PR DESCRIPTION
Implement support for jellyfin/jellyfin-meta#107 / jellyfin/jellyfin#16488 by adding a new "languages" list to the DeviceInfo. The OkHttpClient uses this information to set the `Accept-Language` header for API requests.

Additionally add a new subcommand to the kotlin-cli sample to list scheduled tasks and a new `--language` command line flag (can be specified multiple times) to test the i18n support.

Example u
`gradlew :samples:kotlin-cli:run --args="tasks --server http://localhost:8096 -u demo -p demo --language nl-NL --language de"`