### PR TITLE
Assign endpointAddress from LocalServerDiscovery

### DIFF
--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/LocalServerDiscovery.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.sdk.discovery
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -7,7 +8,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.isActive
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jellyfin.sdk.JellyfinOptions
 import org.jellyfin.sdk.model.api.ServerDiscoveryInfo
 import java.io.IOException
@@ -69,9 +69,12 @@ public actual class LocalServerDiscovery actual constructor(jellyfinOptions: Jel
 			logger.debug { """Received message "$message"""" }
 
 			// Read as JSON
-			val info = json.decodeFromString(ServerDiscoveryInfo.serializer(), message)
+			val info = json.decodeFromString<ServerDiscoveryInfo>(message)
 
-			info
+			// Assign the host address we contacted to the discovery info
+			info.copy(
+				endpointAddress = packet.address.hostAddress,
+			)
 		} catch (err: SocketTimeoutException) {
 			// Unable to receive due too timeout, which is common for non-Jellyfin devices
 			// Just ignore

--- a/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
+++ b/samples/kotlin-cli/src/main/kotlin/org/jellyfin/sample/cli/command/Discover.kt
@@ -31,7 +31,7 @@ class Discover(
 		logger.info("Starting local network discovery")
 
 		jellyfin.discovery.discoverLocalServers().onEach {
-			logger.info("Server ${it.name} was found at address ${it.address}:")
+			logger.info("Server ${it.name} was found at address ${it.address} (${it.endpointAddress}):")
 			logger.info("  $it")
 		}.collect()
 	}


### PR DESCRIPTION
The `ServerDiscoveryInfo` model from the server always returns `null` for the `endpointAddress`. Looking through our jellyfin-archive it looks like it is intended to be set by sdks/apiclients/apps when doing discovery, to communicate the address from the client perspective. As the "address" property can be overwritten by the server (e.g. using the published server URL option).

It's up to a client what to do with this value. Our recommendation is to always rely on the `address` field returned by the server first before attempting to use the `endpointAddress`.

Human version of #1209.