### PR TITLE
Add formatting of ServerVersion for Jellyfin 12.0

### DIFF
--- a/jellyfin-model/api/jellyfin-model.api
+++ b/jellyfin-model/api/jellyfin-model.api
@@ -58,6 +58,8 @@ public final class org/jellyfin/sdk/model/ServerVersion : java/lang/Comparable {
 	public final fun getPatch ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public final fun toString (I)Ljava/lang/String;
+	public static synthetic fun toString$default (Lorg/jellyfin/sdk/model/ServerVersion;IILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final synthetic class org/jellyfin/sdk/model/ServerVersion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {

--- a/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/ServerVersion.kt
+++ b/jellyfin-model/src/commonMain/kotlin/org/jellyfin/sdk/model/ServerVersion.kt
@@ -16,17 +16,40 @@ public data class ServerVersion(
 ) : Comparable<ServerVersion> {
 	public override operator fun compareTo(other: ServerVersion): Int = comparator.compare(this, other)
 
+	private val stringParts = when {
+		major >= 12 && patch == 0 && build == null -> 2
+		build == null -> 3
+		else -> 4
+	}
+
 	/**
 	 * Convert version to string. Format is "[major].[minor].[patch].[build]".
 	 * [build] is omitted if null.
+	 * [patch] is omitted if [major] is 12 or higher, [patch] is 0 and [build] is null.
 	 * Sample output:
 	 * - 1.0.0
 	 * - 10.6.4
 	 * - 10.7.0.0
+	 * - 12.0
 	 */
-	override fun toString(): String = buildString {
-		append(major, '.', minor, '.', patch)
-		if (build != null) append('.', build)
+	override fun toString(): String = toString(stringParts)
+
+	/**
+	 * Convert version to string. Format is "[major].[minor].[patch].[build]". The amount of parts returned is
+	 * determined by [parts] and should be between 1 and 4 (inclusive). Defaults to 2 parts.
+	 * Sample output:
+	 * - 1.0.0
+	 * - 10.6.4
+	 * - 10.7.0.0
+	 * - 12.0
+	 */
+	public fun toString(parts: Int = 2): String = buildString {
+		require(parts in 1..4) { "parts must be in range 1..4" }
+
+		append(major)
+		if (parts >= 2) append('.', minor)
+		if (parts >= 3) append('.', patch)
+		if (parts >= 4) append('.', build ?: 0)
 	}
 
 	public companion object {

--- a/jellyfin-model/src/commonTest/kotlin/org/jellyfin/sdk/model/discovery/ServerVersionTests.kt
+++ b/jellyfin-model/src/commonTest/kotlin/org/jellyfin/sdk/model/discovery/ServerVersionTests.kt
@@ -40,4 +40,25 @@ class ServerVersionTests : FunSpec({
 		run { ServerVersion.fromString("10.8.0")!! < ServerVersion(10, 8, 0, 0) } shouldBe false
 		run { ServerVersion.fromString("10.8.0")!! < ServerVersion.fromString("10.8.0")!! } shouldBe false
 	}
+
+	test("Converts to string") {
+		ServerVersion(1, 0, 0).toString() shouldBe "1.0.0"
+		ServerVersion(10, 6, 4).toString() shouldBe "10.6.4"
+		ServerVersion(10, 11, 8, 2).toString() shouldBe "10.11.8.2"
+		ServerVersion(10, 11, 8).toString() shouldBe "10.11.8"
+
+		ServerVersion(12, 0, 0).toString() shouldBe "12.0"
+		ServerVersion(12, 0, 0, null).toString() shouldBe "12.0"
+		ServerVersion(12, 0, 0, 0).toString() shouldBe "12.0.0.0"
+	}
+
+	test("Converts to string with parts") {
+		val version = ServerVersion(10, 6, 4, 1)
+		version.toString(1) shouldBe "10"
+		version.toString(2) shouldBe "10.6"
+		version.toString(3) shouldBe "10.6.4"
+		version.toString(4) shouldBe "10.6.4.1"
+
+		ServerVersion(10, 6, 4, null).toString(4) shouldBe "10.6.4.0"
+	}
 })


### PR DESCRIPTION
Add a new `toString(parts: 1..4)` function to the ServerVersion model and change the existing (parameter less) version to determine the parts based on the set version. Extend unit tests to test this behavior.

This will change the behavior to return 2 parts starting with major version 12 (e.g. Jellyfin 12.0).