### PR TITLE
Increase minimum supported server version to 12.0

### DIFF
--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/Jellyfin.kt
@@ -67,7 +67,7 @@ public class Jellyfin(
 		/**
 		 * The minimum server version expected to work. Lower versions may work but are not supported.
 		 */
-		public val minimumVersion: ServerVersion = ServerVersion(10, 11, 0, 0)
+		public val minimumVersion: ServerVersion = ServerVersion(12, 0, 0, 0)
 
 		/**
 		 * The exact server version used to generate the API. Should be equal or higher than [minimumVersion].


### PR DESCRIPTION
It's virtually impossible to do a proper API review between 10.11 and 12.0 due to the many renames/moving around of operations. But from what I could see there are definitely some breaking changes making the 12.0 API specification incompatible with older Jellyfin servers (e.g. can cause SDK exceptions).

This PR increases the minimum server version to be 12.0