### PR TITLE
Fix discovery skipping trailing-slash server URLs

### DIFF
--- a/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/commonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -40,6 +40,10 @@ public expect class AddressCandidateHelper(
 	 * The priority is based on a few rules:
 	 * - HTTPS before HTTP
 	 * - Jellyfin ports before protocol default ports
+	 * - Trailing-slash form matching the user input when a subpath was supplied
+	 *
+	 * Non-root paths are returned both with and without a trailing slash so reverse
+	 * proxies that treat the two forms differently can still be discovered.
 	 */
 	public fun getCandidates(): Collection<String>
 }

--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -37,6 +37,13 @@ public actual class AddressCandidateHelper actual constructor(
 	private val candidates = mutableSetOf<HttpUrl>()
 	private val prioritizeComparator = Comparator<HttpUrl> { a, b -> b.score() - a.score() }
 
+	/**
+	 * Whether the user-supplied input ended with a trailing slash on a non-root path.
+	 * Used to prioritize that variant for reverse proxies that treat `/path` and `/path/` differently.
+	 */
+	private val preferTrailingSlash: Boolean =
+		input.isNotBlank() && input.trimEnd().endsWith('/') && !isRootOrEmptyPath(input)
+
 	init {
 		try {
 			logger.debug { "Input is $input" }
@@ -53,6 +60,18 @@ public actual class AddressCandidateHelper actual constructor(
 			// Input can't be parsed
 			logger.error(error) { "Input $input could not be parsed" }
 		}
+	}
+
+	private fun isRootOrEmptyPath(value: String): Boolean {
+		val withoutProtocol = when {
+			value.startsWith(PROTOCOL_HTTP, ignoreCase = true) -> value.substring(PROTOCOL_HTTP.length)
+			value.startsWith(PROTOCOL_HTTPS, ignoreCase = true) -> value.substring(PROTOCOL_HTTPS.length)
+			else -> value
+		}
+		val slashIndex = withoutProtocol.indexOf('/')
+		if (slashIndex < 0) return true
+		val path = withoutProtocol.substring(slashIndex).trimEnd('/')
+		return path.isEmpty()
 	}
 
 	/**
@@ -127,7 +146,33 @@ public actual class AddressCandidateHelper actual constructor(
 		if (isHttps && port == 443) score += 3
 		if (!isHttps && port == 80) score += 3
 
+		// Prefer trailing-slash form when the user supplied one (subpath reverse proxies)
+		val hasTrailingSlash = encodedPath.length > 1 && encodedPath.endsWith('/')
+		if (preferTrailingSlash == hasTrailingSlash) score += 1
+
 		return score
+	}
+
+	/**
+	 * Some reverse proxies treat `/jellyfin` and `/jellyfin/` differently.
+	 * Emit both forms for non-root paths so discovery can try either.
+	 */
+	private fun HttpUrl.trailingSlashVariants(): Collection<HttpUrl> {
+		val path = encodedPath
+		if (path == "/" || path.isEmpty()) return listOf(this)
+
+		val withoutSlash = if (path.endsWith('/')) {
+			newBuilder().encodedPath(path.trimEnd('/')).build()
+		} else {
+			this
+		}
+		val withSlash = if (path.endsWith('/')) {
+			this
+		} else {
+			newBuilder().encodedPath("$path/").build()
+		}
+
+		return listOf(withoutSlash, withSlash)
 	}
 
 	/**
@@ -136,8 +181,17 @@ public actual class AddressCandidateHelper actual constructor(
 	 * The priority is based on a few rules:
 	 * - HTTPS before HTTP
 	 * - Jellyfin ports before protocol default ports
+	 * - Trailing-slash form matching the user input when a subpath was supplied
+	 *
+	 * Non-root paths are returned both with and without a trailing slash.
 	 */
 	public actual fun getCandidates(): Collection<String> = candidates
+		.flatMap { it.trailingSlashVariants() }
 		.sortedWith(prioritizeComparator)
-		.map { it.toString().trimEnd('/') }
+		.map { url ->
+			// Normalize root URLs (`https://host/` -> `https://host`) but keep subpath slashes
+			if (url.encodedPath == "/") url.toString().trimEnd('/')
+			else url.toString()
+		}
+		.distinct()
 }

--- a/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
+++ b/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
@@ -78,4 +78,25 @@ class DiscoveryServiceTests : FunSpec({
 		// Mixed
 		instance.getAddressCandidates("Https://localhost") shouldContain "https://localhost"
 	}
+
+	test("getAddressCandidates keeps both trailing slash variants for subpaths") {
+		val instance = getInstance()
+
+		val withSlash = instance.getAddressCandidates("https://nas.example.com/jellyfin/")
+		withSlash shouldContain "https://nas.example.com/jellyfin/"
+		withSlash shouldContain "https://nas.example.com/jellyfin"
+		withSlash.first() shouldBe "https://nas.example.com/jellyfin/"
+
+		val withoutSlash = instance.getAddressCandidates("https://nas.example.com/jellyfin")
+		withoutSlash shouldContain "https://nas.example.com/jellyfin"
+		withoutSlash shouldContain "https://nas.example.com/jellyfin/"
+		withoutSlash.first() shouldBe "https://nas.example.com/jellyfin"
+	}
+
+	test("getAddressCandidates does not keep trailing slash on root urls") {
+		val instance = getInstance()
+
+		instance.getAddressCandidates("https://localhost/") shouldContain "https://localhost"
+		instance.getAddressCandidates("https://localhost/") shouldNotContain "https://localhost/"
+	}
 })


### PR DESCRIPTION
## Summary
- Keep both trailing-slash and non-trailing-slash variants when generating address candidates for non-root paths
- Prefer the form that matches the user input, so reverse proxies that treat `/path` and `/path/` differently can still be discovered
- Leave root URLs normalized without a trailing slash (`https://host/` → `https://host`)

## Motivation
Some reverse-proxy setups (especially Jellyfin under a subpath like `/jellyfin/`) behave differently with and without a trailing slash. Discovery previously always stripped the final `/`, so an address such as `https://example.com/jellyfin/` was only tried as `https://example.com/jellyfin` (plus alternate ports), which could time out or fail.

## Test plan
- [ ] Unit tests in `DiscoveryServiceTests` pass for trailing-slash variants and root URL normalization
- [ ] Manual: enter `https://<host>/<subpath>/` and confirm discovery tries the trailing-slash URL first and can connect
- [ ] Manual: enter `https://<host>/<subpath>` and confirm both variants are still tried, with the non-slash form preferred
- [ ] Manual: enter a root URL like `https://localhost/` and confirm candidates do not keep a trailing slash