### PR TITLE
Fix AddressCandidateHelper.getCandidates not handling paths properly

### DIFF
--- a/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
+++ b/jellyfin-core/src/jvmCommonMain/kotlin/org/jellyfin/sdk/discovery/AddressCandidateHelper.kt
@@ -139,5 +139,5 @@ public actual class AddressCandidateHelper actual constructor(
 	 */
 	public actual fun getCandidates(): Collection<String> = candidates
 		.sortedWith(prioritizeComparator)
-		.map { it.toString().trimEnd('/') }
+		.map { it.toString().trimEnd('/') + if (it.encodedPath.trimEnd('/').isNotEmpty()) '/' else "" }
 }

--- a/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
+++ b/jellyfin-core/src/jvmTest/kotlin/org/jellyfin/sdk/discovery/DiscoveryServiceTests.kt
@@ -78,4 +78,26 @@ class DiscoveryServiceTests : FunSpec({
 		// Mixed
 		instance.getAddressCandidates("Https://localhost") shouldContain "https://localhost"
 	}
+
+	test("getAddressCandidates keeps and normalizes paths") {
+		val instance = getInstance()
+
+		// Input with a directory style path ending
+		instance.getAddressCandidates("https://demo.jellyfin.org/stable/") shouldContain "https://demo.jellyfin.org/stable/"
+		instance.getAddressCandidates("https://demo.jellyfin.org/stable/") shouldNotContain "https://demo.jellyfin.org/stable"
+
+		// Input with a non-directory style path ending
+		instance.getAddressCandidates("https://demo.jellyfin.org/stable") shouldContain "https://demo.jellyfin.org/stable/"
+		instance.getAddressCandidates("https://demo.jellyfin.org/stable") shouldNotContain "https://demo.jellyfin.org/stable"
+		// Nested
+		instance.getAddressCandidates("https://demo.jellyfin.org/example/stable") shouldContain "https://demo.jellyfin.org/example/stable/"
+		instance.getAddressCandidates("https://demo.jellyfin.org/example/stable") shouldNotContain "https://demo.jellyfin.org/example/stable"
+
+		// Input with extraneous trailing slashes
+		instance.getAddressCandidates("https://demo.jellyfin.org/unstable//") shouldContain "https://demo.jellyfin.org/unstable/"
+		instance.getAddressCandidates("https://demo.jellyfin.org/unstable//") shouldNotContain "https://demo.jellyfin.orgun/stable"
+		instance.getAddressCandidates("https://demo.jellyfin.org/unstable//") shouldNotContain "https://demo.jellyfin.org/unstable//"
+		instance.getAddressCandidates("https://demo.jellyfin.org//") shouldContain "https://demo.jellyfin.org"
+		instance.getAddressCandidates("https://demo.jellyfin.org//") shouldNotContain "https://demo.jellyfin.org/"
+	}
 })


### PR DESCRIPTION
The server address recommendation would strip ending slashes for input with a path, e.g. `demo.jellyfin.org/stable/` would always be returned as `demo.jellyfin.org/stable`.

While this is perfectly fine for the SDK to work, it caused an issue on the mobile app when it tries to load the webview and there is no redirect in place for the URLs not ending with a slash.

It doesn't make sense to have a server at a path not ending with a slash though, as appending to that path wouldn't work out correctly. So this change makes it so we always return a single trailing slash if there is a path.

"reported" via invalid PR on SDK: #1266