### PR TITLE
Update minimum Android SDK to 21 and compile with SDK 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 android-gradle = "9.3.1"
-android-sdk = "36"
+android-sdk-min = "21"
+android-sdk-compile = "37"
 animalsniffer = "2.0.1"
 binarycompatibilityvalidator = "0.18.1"
 clikt = "5.1.0"

--- a/jellyfin-core/build.gradle.kts
+++ b/jellyfin-core/build.gradle.kts
@@ -17,10 +17,10 @@ kotlin {
 		}
 	}
 
-	androidLibrary {
+	android {
 		namespace = "org.jellyfin.sdk"
-		compileSdk = libs.versions.android.sdk.get().toInt()
-		minSdk = 19
+		compileSdk = libs.versions.android.sdk.compile.get().toInt()
+		minSdk = libs.versions.android.sdk.min.get().toInt()
 
 		compilerOptions {
 			jvmTarget = JvmTarget.JVM_1_8
@@ -41,7 +41,6 @@ kotlin {
 		lint {
 			lintConfig = file("$rootDir/android-lint.xml")
 			abortOnError = false
-			sarifReport = true
 		}
 	}
 


### PR DESCRIPTION
Bump the compile SDK to 37 (Android 17) and the minimum SDK to 21 (Android 5). Our apps mirror androidx and use a minimum SDK of 23 (soon to be bumped to 24).

Needed to unblock new ~~androidx~~okttp updates.

Additionally adds slight changes in Gradle usage to reflect changes in newer AGP releases.