### PR TITLE
Fix websocket subscription grace period

### DIFF
--- a/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
+++ b/jellyfin-api/src/commonMain/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApi.kt
@@ -220,9 +220,7 @@ public class DefaultSocketApi(
 			_subscriptionCount--
 			logger.info { "Subscription count changed to $_subscriptionCount" }
 
-			// Disconnect when subscription count reaches zero
 			val stopping = _subscriptionCount == 0
-			if (stopping) scope.launch { socketConnection.disconnect() }
 
 			// Send stop messages
 			for (type in subscriptionTypes) {

--- a/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApiTests.kt
+++ b/jellyfin-api/src/commonTest/kotlin/org/jellyfin/sdk/api/sockets/DefaultSocketApiTests.kt
@@ -1,0 +1,114 @@
+package org.jellyfin.sdk.api.sockets
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.HttpClientOptions
+import org.jellyfin.sdk.api.client.HttpMethod
+import org.jellyfin.sdk.api.client.RawResponse
+import org.jellyfin.sdk.model.ClientInfo
+import org.jellyfin.sdk.model.DeviceInfo
+
+class DefaultSocketApiTests : FunSpec({
+	test("WebSocket stays connected when subscriptions resume within grace period") {
+		val connection = TestSocketConnection()
+		val socketApi = DefaultSocketApi(
+			api = TestApiClient(),
+			socketReconnectPolicy = SocketReconnectPolicy.ExponentialDelayReconnect(),
+			socketConnectionFactory = SocketConnectionFactory { _, _ -> connection },
+		)
+
+		coroutineScope {
+			val firstSubscription = launch(start = CoroutineStart.UNDISPATCHED) {
+				socketApi.subscribeAll().collect {}
+			}
+			connection.connected.await()
+
+			firstSubscription.cancelAndJoin()
+
+			val secondSubscription = launch(start = CoroutineStart.UNDISPATCHED) {
+				socketApi.subscribeAll().collect {}
+			}
+
+			withTimeoutOrNull(1_000) {
+				connection.disconnected.await()
+			} shouldBe null
+			connection.connectCount.value shouldBe 1
+
+			secondSubscription.cancelAndJoin()
+		}
+	}
+})
+
+private class TestSocketConnection : SocketConnection {
+	private val _state = MutableStateFlow<SocketConnectionState>(SocketConnectionState.Disconnected())
+
+	override val state: StateFlow<SocketConnectionState> = _state
+
+	val connected = CompletableDeferred<Unit>()
+	val disconnected = CompletableDeferred<Unit>()
+	val connectCount = MutableStateFlow(0)
+
+	override suspend fun connect(
+		url: String,
+		clientName: String,
+		clientVersion: String,
+		deviceId: String,
+		deviceName: String,
+		accessToken: String,
+		languages: List<String>,
+	): Boolean {
+		connectCount.value++
+		_state.value = SocketConnectionState.Connecting
+		connected.complete(Unit)
+		return true
+	}
+
+	override suspend fun send(message: String): Boolean = true
+
+	override suspend fun disconnect() {
+		_state.value = SocketConnectionState.Disconnected()
+		disconnected.complete(Unit)
+	}
+}
+
+private class TestApiClient : ApiClient() {
+	override val baseUrl: String = "http://localhost"
+	override val accessToken: String = "test-token"
+	override val clientInfo: ClientInfo = ClientInfo(
+		name = "Test Client",
+		version = "1.0",
+	)
+	override val deviceInfo: DeviceInfo = DeviceInfo(
+		id = "test-device",
+		name = "Test Device",
+	)
+	override val httpClientOptions: HttpClientOptions = HttpClientOptions()
+
+	override val webSocket: SocketApi
+		get() = error("Not used in this test")
+
+	override fun update(
+		baseUrl: String?,
+		accessToken: String?,
+		clientInfo: ClientInfo,
+		deviceInfo: DeviceInfo,
+	) = Unit
+
+	override suspend fun request(
+		method: HttpMethod,
+		pathTemplate: String,
+		pathParameters: Map<String, Any?>,
+		queryParameters: Map<String, Any?>,
+		requestBody: Any?,
+	): RawResponse = error("Not used in this test")
+}


### PR DESCRIPTION
### Problem

The socket was disconnected immediately when the subscription count reached `0`, even though the shared `messages` flow stays alive for another 5 seconds.

If subscriptions returned during that time, the flow was reused but the socket stayed disconnected.

### Change

Let the existing `WhileSubscribed` grace period handle the socket lifetime instead of disconnecting immediately.

### Testing

Added a regression test for quick re-subscription.

SDK tests, lint, and documentation checks pass.

Also tested the equivalent change with Android TV using 2s, 8s, 30s, and 300s standby periods. All tests passed.

I also verified that Home rows picked up newly added movies and shows again after resume without having to restart the app.

### Related

Addresses the WebSocket lifecycle part of jellyfin/jellyfin-androidtv#1149.

### AI assistance

An LLM was used during analysis and test preparation. I reviewed, understood, and runtime-tested the change myself.